### PR TITLE
Add preview.rb script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [Extra](#extra)
   - [X11 Installation](#x11-installation)
   - [Terminator color schemes](#terminator-color-schemes)
+  - [Previewing color schemes](#previewing-color-schemes)
 
 ##Intro##
 This is a set of color schemes for iTerm (aka iTerm2). Screenshots below and in the [screenshots](screenshots/) directory.
@@ -715,6 +716,24 @@ An example config file that includes the code snippet for the Symfonic theme wou
           parent = ""
     [plugins]
 ```
+
+###Previewing color schemes###
+
+[preview.rb](tools/preview.rb) is a simple script that allows you to preview
+the color schemes without having to import them. It parses .itermcolors files
+and applies the colors to the current session using [iTerm's proprietary
+escape codes](https://iterm2.com/documentation-escape-codes.html). As noted in
+the linked page, it doesn't run on tmux or screen.
+
+```sh
+# Apply AdventureTime scheme to the current session
+tools/preview.rb schemes/AdventureTime.itermcolors
+
+# Apply the schemes in turn.
+# - Press any key to advance; hit CTRL-C or ESC to stop
+tools/preview.rb schemes/*
+```
+
 
 ----
 

--- a/tools/preview.rb
+++ b/tools/preview.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/ruby
+#
+# Applies the colors defined in .itermcolors file to the current session using
+# proprietary escape codes of iTerm2
+#
+# Author: Junegunn Choi <https://github.com/junegunn> Reference:
+# https://iterm2.com/documentation-escape-codes.html
+
+require 'rexml/document'
+require 'io/console'
+
+files = ARGV.select { |f| File.exists? f }
+if files.empty?
+  puts "usage: #$0 <itermcolors files...>"
+  exit 1
+end
+
+if ENV.has_key? 'TMUX'
+  puts 'Does not work on tmux'
+  exit 1
+end
+
+preview = files.length > 1
+until files.empty?
+  file = files.shift
+  print "[#{File.basename file, '.*'}] " if preview
+  begin
+    colors = {}
+    root = REXML::Document.new(File.read file).root
+    root.elements['dict'].select { |e| e.is_a? REXML::Element }.each do |dict|
+      if dict.previous_element && !dict.previous_element.text.strip.empty?
+        type = dict.previous_element.text.downcase.gsub(/^ansi\s+|\s+color$/, '')
+        colors[type] = {}
+      end
+      next unless type
+
+      dict.elements.each_slice(2) do |elems|
+        key = val = nil
+        elems.each do |elem|
+          case elem.name.downcase
+          when 'key'  then key = elem.text
+          when 'real' then val = elem.text
+          end
+        end
+        colors[type][key.sub(/\s.+/, '').downcase.to_sym] =
+          '%02x' % [255, val.to_f.*(256).to_i].min if key && val
+      end
+      colors[type] &&= colors[type].values_at(:red, :green, :blue).join
+    end
+
+    colors.each do |type, rgb|
+      print "\e]P" << {
+        'foreground'    => 'g',
+        'background'    => 'h',
+        'bold'          => 'i',
+        'selection'     => 'j',
+        'selected text' => 'k',
+        'cursor'        => 'l',
+        'cursor text'   => 'm',
+      }.fetch(type, '%x' % type.to_i) << rgb << "\e\\"
+    end
+    break if files.empty? || [3.chr, "\e"].include?(IO.console.getch)
+  rescue Exception
+    print '(X) '
+  end
+end
+puts if preview
+


### PR DESCRIPTION
preview.rb is a simple script that parses .itermcolors files and applies the colors to the current session using [iTerm's proprietary escape codes](https://iterm2.com/documentation-escape-codes.html). It runs with the default system Ruby on OSX (/usr/bin/ruby) so you don't have to install anything. But as noted in the page, it doesn't run on tmux or screen.

I find it very useful when I want to test many number of schemes

```
tools/screenshotTable.sh

# Applies the schemes in turn as you press any key until you hit CTRL-C or ESC
tools/preview.rb schemes/*
```
