### PR TITLE
Fix Material scheme.

### DIFF
--- a/schemes/Material.itermcolors
+++ b/schemes/Material.itermcolors
@@ -4,12 +4,8 @@
 <dict>
 	<key>Ansi 0 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12941177189350128</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.12941177189350128</real>
 		<key>Red Component</key>
@@ -17,12 +13,8 @@
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12038997560739517</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.078879080712795258</real>
 		<key>Red Component</key>
@@ -30,12 +22,8 @@
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.22740326821804047</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.73019099235534668</real>
 		<key>Red Component</key>
@@ -43,25 +31,17 @@
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.033654335886240005</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
+		<real>0.18199658393859863</real>
 		<key>Green Component</key>
-		<real>0.55859357118606567</real>
+		<real>0.91622048616409302</real>
 		<key>Red Component</key>
-		<real>0.99133074283599854</real>
+		<real>0.99857872724533081</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.95445334911346436</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.64410710334777832</real>
 		<key>Red Component</key>
@@ -69,12 +49,8 @@
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.73656630516052246</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.30266252160072327</real>
 		<key>Red Component</key>
@@ -82,12 +58,8 @@
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.82006889581680298</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.73243516683578491</real>
 		<key>Red Component</key>
@@ -95,12 +67,8 @@
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.84938156604766846</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.84936714172363281</real>
 		<key>Red Component</key>
@@ -108,12 +76,8 @@
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.13958784937858582</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.4825465977191925</real>
 		<key>Red Component</key>
@@ -121,25 +85,17 @@
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.032639358192682266</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
+		<real>0.11582206189632416</real>
 		<key>Green Component</key>
-		<real>0.48271051049232483</real>
+		<real>0.59536725282669067</real>
 		<key>Red Component</key>
-		<real>0.99015593528747559</real>
+		<real>0.96285504102706909</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.69954341650009155</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.3064875602722168</real>
 		<key>Red Component</key>
@@ -147,12 +103,8 @@
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.53314954042434692</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.0</real>
 		<key>Red Component</key>
@@ -160,12 +112,8 @@
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.48725795745849609</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.44183778762817383</real>
 		<key>Red Component</key>
@@ -173,12 +121,8 @@
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.93608629703521729</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.93607044219970703</real>
 		<key>Red Component</key>
@@ -186,12 +130,8 @@
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.25882354378700256</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.25882354378700256</real>
 		<key>Red Component</key>
@@ -199,12 +139,8 @@
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.24844314157962799</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.23034398257732391</real>
 		<key>Red Component</key>
@@ -212,77 +148,35 @@
 	</dict>
 	<key>Background Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.91764706373214722</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.91764706373214722</real>
 		<key>Red Component</key>
 		<real>0.91764706373214722</real>
-	</dict>
-	<key>Badge Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.5</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>1</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.24254441261291504</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
+		<real>0.12038997560739517</real>
 		<key>Green Component</key>
-		<real>0.21523168683052063</real>
+		<real>0.078879080712795258</real>
 		<key>Red Component</key>
-		<real>0.16443461179733276</real>
+		<real>0.718147873878479</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.79186719655990601</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.6861264705657959</real>
 		<key>Red Component</key>
 		<real>0.086931481957435608</real>
 	</dict>
-	<key>Cursor Guide Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.25</real>
-		<key>Blue Component</key>
-		<real>1</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.9100000262260437</real>
-		<key>Red Component</key>
-		<real>0.64999997615814209</real>
-	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.17576293647289276</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.17907498776912689</real>
 		<key>Red Component</key>
@@ -290,38 +184,17 @@
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.17576293647289276</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
+		<real>0.13233847916126251</real>
 		<key>Green Component</key>
-		<real>0.17907498776912689</real>
+		<real>0.13542565703392029</real>
 		<key>Red Component</key>
-		<real>0.17897795140743256</real>
-	</dict>
-	<key>Link Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.69954341650009155</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.3064875602722168</real>
-		<key>Red Component</key>
-		<real>0.07626015692949295</real>
+		<real>0.13533444702625275</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.30725601315498352</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.30725079774856567</real>
 		<key>Red Component</key>
@@ -329,29 +202,12 @@
 	</dict>
 	<key>Selection Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.76020538806915283</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.76019245386123657</real>
 		<key>Red Component</key>
 		<real>0.76021528244018555</real>
-	</dict>
-	<key>Tab Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>0.0</real>
 	</dict>
 </dict>
 </plist>

--- a/schemes/MaterialDark.itermcolors
+++ b/schemes/MaterialDark.itermcolors
@@ -4,12 +4,8 @@
 <dict>
 	<key>Ansi 0 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12941177189350128</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.12941177189350128</real>
 		<key>Red Component</key>
@@ -17,12 +13,8 @@
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12038997560739517</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.078879080712795258</real>
 		<key>Red Component</key>
@@ -30,12 +22,8 @@
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.22740326821804047</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.73019099235534668</real>
 		<key>Red Component</key>
@@ -43,12 +31,8 @@
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.18199658393859863</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.91622048616409302</real>
 		<key>Red Component</key>
@@ -56,12 +40,8 @@
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.95445334911346436</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.64410710334777832</real>
 		<key>Red Component</key>
@@ -69,12 +49,8 @@
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.73656630516052246</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.30266252160072327</real>
 		<key>Red Component</key>
@@ -82,12 +58,8 @@
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.82006889581680298</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.73243516683578491</real>
 		<key>Red Component</key>
@@ -95,12 +67,8 @@
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.84938156604766846</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.84936714172363281</real>
 		<key>Red Component</key>
@@ -108,12 +76,8 @@
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.13958784937858582</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.4825465977191925</real>
 		<key>Red Component</key>
@@ -121,12 +85,8 @@
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.11582206189632416</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.59536725282669067</real>
 		<key>Red Component</key>
@@ -134,12 +94,8 @@
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.69954341650009155</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.3064875602722168</real>
 		<key>Red Component</key>
@@ -147,12 +103,8 @@
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.53314954042434692</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.0</real>
 		<key>Red Component</key>
@@ -160,12 +112,8 @@
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.48725795745849609</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.44183778762817383</real>
 		<key>Red Component</key>
@@ -173,12 +121,8 @@
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.93608629703521729</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.93607044219970703</real>
 		<key>Red Component</key>
@@ -186,12 +130,8 @@
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.25882354378700256</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.25882354378700256</real>
 		<key>Red Component</key>
@@ -199,12 +139,8 @@
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.24844314157962799</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.23034398257732391</real>
 		<key>Red Component</key>
@@ -212,38 +148,17 @@
 	</dict>
 	<key>Background Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.13233847916126251</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.13542565703392029</real>
 		<key>Red Component</key>
 		<real>0.13533444702625275</real>
 	</dict>
-	<key>Badge Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.5</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
 	<key>Bold Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12038997560739517</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.078879080712795258</real>
 		<key>Red Component</key>
@@ -251,38 +166,17 @@
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.79186719655990601</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.6861264705657959</real>
 		<key>Red Component</key>
 		<real>0.086931481957435608</real>
 	</dict>
-	<key>Cursor Guide Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.25</real>
-		<key>Blue Component</key>
-		<real>1</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.9100000262260437</real>
-		<key>Red Component</key>
-		<real>0.64999997615814209</real>
-	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.87325412034988403</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.87323933839797974</real>
 		<key>Red Component</key>
@@ -290,38 +184,17 @@
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89729100465774536</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.89727580547332764</real>
 		<key>Red Component</key>
 		<real>0.89730262756347656</real>
 	</dict>
-	<key>Link Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.69954341650009155</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.3064875602722168</real>
-		<key>Red Component</key>
-		<real>0.07626015692949295</real>
-	</dict>
 	<key>Selected Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.23922896385192871</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.23922491073608398</real>
 		<key>Red Component</key>
@@ -329,29 +202,12 @@
 	</dict>
 	<key>Selection Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.87325412034988403</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.87323933839797974</real>
 		<key>Red Component</key>
 		<real>0.87326544523239136</real>
-	</dict>
-	<key>Tab Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>0.0</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
I had an issue with Material schemes (light and dark), which were silently failing during preset load. This fix replaces files with their "stable" versions, as they are named by stoeffel, theme author. [Source]  (https://github.com/stoeffel/material-iterm) remains the same as in project credits.