### PR TITLE
fix brogrammer by updating from source

### DIFF
--- a/schemes/Brogrammer.itermcolors
+++ b/schemes/Brogrammer.itermcolors
@@ -4,12 +4,8 @@
 <dict>
 	<key>Ansi 0 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.12343787401914597</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.12343578040599823</real>
 		<key>Red Component</key>
@@ -17,12 +13,8 @@
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.095619738101959229</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.067135065793991089</real>
 		<key>Red Component</key>
@@ -30,12 +22,8 @@
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.379891037940979</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.82695949077606201</real>
 		<key>Red Component</key>
@@ -43,12 +31,8 @@
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.035377603024244308</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.74144089221954346</real>
 		<key>Red Component</key>
@@ -56,12 +40,8 @@
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.838664710521698</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.50448882579803467</real>
 		<key>Red Component</key>
@@ -69,12 +49,8 @@
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.72698760032653809</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.3135044276714325</real>
 		<key>Red Component</key>
@@ -82,12 +58,8 @@
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.85764402151107788</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.4900696873664856</real>
 		<key>Red Component</key>
@@ -95,12 +67,8 @@
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>1</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>1</real>
 		<key>Red Component</key>
@@ -108,12 +76,8 @@
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.36823004484176636</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.77383565902709961</real>
 		<key>Red Component</key>
@@ -121,12 +85,8 @@
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.060177117586135864</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.72761225700378418</real>
 		<key>Red Component</key>
@@ -134,12 +94,8 @@
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.82454067468643188</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.51804500818252563</real>
 		<key>Red Component</key>
@@ -147,12 +103,8 @@
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.71787959337234497</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.35215187072753906</real>
 		<key>Red Component</key>
@@ -160,12 +112,8 @@
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.838664710521698</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.50448882579803467</real>
 		<key>Red Component</key>
@@ -173,12 +121,8 @@
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89713811874389648</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.8579363226890564</real>
 		<key>Red Component</key>
@@ -186,12 +130,8 @@
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89713811874389648</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.8579363226890564</real>
 		<key>Red Component</key>
@@ -199,12 +139,8 @@
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.1818375289440155</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.20686990022659302</real>
 		<key>Red Component</key>
@@ -212,38 +148,17 @@
 	</dict>
 	<key>Background Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.076218985021114349</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.076217696070671082</real>
 		<key>Red Component</key>
 		<real>0.07621997594833374</real>
 	</dict>
-	<key>Badge Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.5</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>1</real>
-	</dict>
 	<key>Bold Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89713811874389648</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.8579363226890564</real>
 		<key>Red Component</key>
@@ -251,38 +166,17 @@
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.72549021244049072</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.72549021244049072</real>
 		<key>Red Component</key>
 		<real>0.72549021244049072</real>
-	</dict>
-	<key>Cursor Guide Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>0.25</real>
-		<key>Blue Component</key>
-		<real>1</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.9100000262260437</real>
-		<key>Red Component</key>
-		<real>0.64999997615814209</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.062745101749897003</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.062745101749897003</real>
 		<key>Red Component</key>
@@ -290,38 +184,17 @@
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89713811874389648</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.8579363226890564</real>
 		<key>Red Component</key>
 		<real>0.84028750658035278</real>
 	</dict>
-	<key>Link Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.67799997329711914</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.27000001072883606</real>
-		<key>Red Component</key>
-		<real>0.023000000044703484</real>
-	</dict>
 	<key>Selected Text Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
 		<real>0.89713811874389648</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
 		<key>Green Component</key>
 		<real>0.8579363226890564</real>
 		<key>Red Component</key>
@@ -329,29 +202,12 @@
 	</dict>
 	<key>Selection Color</key>
 	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.22888745367527008</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
+		<real>0.12343787401914597</real>
 		<key>Green Component</key>
-		<real>0.22888357937335968</real>
+		<real>0.12343578040599823</real>
 		<key>Red Component</key>
-		<real>0.22889041900634766</real>
-	</dict>
-	<key>Tab Color</key>
-	<dict>
-		<key>Alpha Component</key>
-		<real>1</real>
-		<key>Blue Component</key>
-		<real>0.0</real>
-		<key>Color Space</key>
-		<string>Calibrated</string>
-		<key>Green Component</key>
-		<real>0.0</real>
-		<key>Red Component</key>
-		<real>0.0</real>
+		<real>0.1234394758939743</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
In iTerm2 Brogrammer theme could be imported, but when selected, it failed silently. This fix is updated version from the same source as mentioned in credits, [bahlo](https://github.com/bahlo/iterm-colors).