### PR TITLE
Fixes #59

### DIFF
--- a/schemes/Solarized Dark.itermcolors
+++ b/schemes/Solarized Dark.itermcolors
@@ -131,11 +131,11 @@
 	<key>Ansi 8 Color</key>
 	<dict>
 		<key>Blue Component</key>
-		<real>0.15170273184776306</real>
+		<real>0.38298487663269043</real>
 		<key>Green Component</key>
-		<real>0.11783610284328461</real>
+		<real>0.35665956139564514</real>
 		<key>Red Component</key>
-		<real>0.0</real>
+		<real>0.27671992778778076</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>


### PR DESCRIPTION
Fixes #59 

Before:
<img width="212" alt="screen shot 2015-12-06 at 20 55 31" src="https://cloud.githubusercontent.com/assets/4222494/11615276/a45ed92a-9c5c-11e5-845d-ed14f201cbf2.png">

After:
<img width="178" alt="screen shot 2015-12-06 at 21 29 04" src="https://cloud.githubusercontent.com/assets/4222494/11615421/c01721aa-9c60-11e5-8965-abf38c33e36d.png">
