### PR TITLE
Fix typos problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ To include a screenshot, please generate the output using the [screenshotTable.s
 
 ![Screenshot](screenshots/github.png)
 
-##Glacier###
+###Glacier###
 
 ![Screenshot](screenshots/glacier.png)
 
@@ -377,7 +377,6 @@ To include a screenshot, please generate the output using the [screenshotTable.s
 
 ![Screenshot](screenshots/neutron.png)
 
-
 ###NightLion v1###
 
 ![Screenshot](screenshots/nightlion_v1.png)
@@ -407,7 +406,7 @@ To include a screenshot, please generate the output using the [screenshotTable.s
 
 ![Screenshot](screenshots/ollie.png)
 
-###Parasio Dark###
+###Paraiso Dark###
 
 ![Screenshot](screenshots/paraiso_dark.png)
 

--- a/terminator/Parasio Dark.config
+++ b/terminator/Parasio Dark.config
@@ -1,7 +1,0 @@
-
-[[Parasio Dark]]
-    palette = "#2f1e2e:#ef6155:#48b685:#fec418:#06b6ef:#815ba4:#5bc4bf:#a39e9b:#776e71:#ef6155:#48b685:#fec418:#06b6ef:#815ba4:#5bc4bf:#e7e9db"
-    background_color = "#2f1e2e"
-    cursor_color = "#a39e9b"
-    foreground_color = "#a39e9b"
-    background_image = None


### PR DESCRIPTION
There was a typo in Paraiso Dark color scheme name. This pull request fixes it and removes duplicated style also. 