### PR TITLE
Update python modules interfaces, improve update_all.py

### DIFF
--- a/tools/update_all.py
+++ b/tools/update_all.py
@@ -5,23 +5,29 @@ from glob import glob
 
 from os.path import basename, splitext, join
 
+import xrdb2konsole
+import xrdb2terminator
+import xrdb2Xresources
+import xrdb2putty
+import xrdb2xfce_terminal
+
 if __name__ == '__main__':
 
     for f in glob("../schemes/*.itermcolors"):
         base_name = splitext(basename(f))[0]
         xrdb_filepath = join('../xrdb', base_name + '.xrdb')
         with open(xrdb_filepath, 'w') as fout:
-            print("--> " + xrdb_filepath)
-            subprocess.Popen(['./iterm2xrdb', f], stdout=fout).wait()
+            ret_code = subprocess.Popen(['./iterm2xrdb', f], stdout=fout).wait()
+            print(ret_code and "ERROR" or "OK" + " --> " + xrdb_filepath)
 
-    konsole_path = "../konsole/"
-    print("--> " + konsole_path)
-    subprocess.Popen(['./xrdb2konsole.py', '../xrdb/', '-d', konsole_path])
-
-    terminator_path = '../terminator/'
-    print("--> " + terminator_path)
-    subprocess.Popen(['./xrdb2terminator.py', '../xrdb/', '-d', terminator_path])
-
-    putty_path = '../putty/'
-    print("--> " + putty_path)
-    subprocess.Popen(['./xrdb2putty.py', '../xrdb/', '-d', putty_path])
+    print()
+    xrdb2konsole.main('../xrdb/', '../konsole/')
+    print('OK --> ' + '../konsole/')
+    xrdb2terminator.main('../xrdb/', '../terminator/')
+    print('OK --> ' + '../terminator/')
+    xrdb2Xresources.main('../xrdb/', '../Xresources/')
+    print('OK --> ' + '../Xresources/')
+    xrdb2putty.main('../xrdb/', '../putty/')
+    print('OK --> ' + '../putty/')
+    xrdb2xfce_terminal.main('../xrdb/', '../xfce4terminal/colorschemes/')
+    print('OK --> ' + '../xfce4terminal/colorschemes/')

--- a/tools/xrdb2putty.py
+++ b/tools/xrdb2putty.py
@@ -23,17 +23,7 @@ def hex_to_rgb(color):
 def build_putty_color(name, r, g, b):
 	return "\"%s\"=\"%d,%d,%d\"\n" % (name, r, g, b)
 
-if __name__ == "__main__":
-
-	parser = argparse.ArgumentParser(
-		description='Translate X color schemes to termiantor format')
-	parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
-	parser.add_argument('-d', '--out-directory', type=str, dest='output_path',
-		help='path where putty config files will be' +
-		' created, if not provided then will be printed')
-
-	args = parser.parse_args()
-
+def main(xrdb_path, output_path=None):
 
 	# The regexes to match the colors
 	color_regex = re.compile("#define +Ansi_(\d+)_Color +(#[A-Fa-f0-9]{6})")
@@ -46,18 +36,18 @@ if __name__ == "__main__":
 	# File regex
 	xrdb_regex = re.compile("(.+)\.[xX][rR][dD][bB]")
 
-	for i in filter(lambda x: xrdb_regex.match(x), os.listdir(args.xrdb_path)):
+	for i in filter(lambda x: xrdb_regex.match(x), os.listdir(xrdb_path)):
 		name = xrdb_regex.match(i).group(1)
 
 		# Read XRDB file
-		with open(os.path.join(args.xrdb_path, i)) as f:
+		with open(os.path.join(xrdb_path, i)) as f:
 			xrdb_data = f.read()
 
 		# Open output file
 		output = sys.stdout
 
-		if args.output_path:
-			dest = os.path.join(args.output_path, name)
+		if output_path:
+			dest = os.path.join(output_path, name)
 			output = open('{0}.reg'.format(dest), 'w+')
 		else:
 			output.write('\n%s:\n' % name)
@@ -121,5 +111,19 @@ if __name__ == "__main__":
 
 			output.write(build_putty_color(color_name, *color_rgb))
 
-		if args.output_path:
+		if output_path:
 			output.close()
+
+if __name__ == "__main__":
+
+	parser = argparse.ArgumentParser(
+		description='Translate X color schemes to termiantor format')
+	parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
+	parser.add_argument('-d', '--out-directory', type=str, dest='output_path',
+		help='path where putty config files will be' +
+		' created, if not provided then will be printed')
+
+	args = parser.parse_args()
+	main(args.xrdb_path, args.output_path)
+
+

--- a/tools/xrdb2terminator.py
+++ b/tools/xrdb2terminator.py
@@ -9,35 +9,23 @@
 # Author: Xabier Larrakoetxea
 
 import os
-import sys
 import re
 import argparse
 
-if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser(
-        description='Translate X color schemes to termiantor format')
-    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
-    parser.add_argument('-d', '--destiny', type=str, dest='output_path',
-                        help='path where terminator config files will be' +
-                        ' created, if not provided then will be printed')
-
-    args = parser.parse_args()
-
-
+def main(xrdb_path, output_path=None):
+    global color_regex, xrdb_regex
     # The regexes to match the colors
     color_regex = re.compile("#define +Ansi_(\d+)_Color +(#[A-Fa-f0-9]{6})")
     bg_regex = re.compile("#define +Background_Color +(#[A-Fa-f0-9]{6})")
     fg_regex = re.compile("#define +Foreground_Color +(#[A-Fa-f0-9]{6})")
     cursor_regex = re.compile("#define +Cursor_Color +(#[A-Fa-f0-9]{6})")
-
     # File regex
     xrdb_regex = re.compile("(.+)\.[xX][rR][dD][bB]")
-
-    for i in filter(lambda x: xrdb_regex.match(x), os.listdir(args.xrdb_path)):
+    for i in filter(lambda x: xrdb_regex.match(x), os.listdir(xrdb_path)):
 
         # per file
-        with open(os.path.join(args.xrdb_path, i)) as f:
+        with open(os.path.join(xrdb_path, i)) as f:
             lines = f.readlines()
 
         # Search special colors
@@ -69,9 +57,23 @@ if __name__ == "__main__":
                                cr=cursor_color,
                                fg=fg_color)
 
-        if not args.output_path:
+        if not output_path:
             print(output)
         else:
-            dest = os.path.join(args.output_path, xrdb_regex.match(i).group(1))
+            dest = os.path.join(output_path, xrdb_regex.match(i).group(1))
             with open('{0}.config'.format(dest), 'w+') as f:
                 f.write(output)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description='Translate X color schemes to termiantor format')
+    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
+    parser.add_argument('-d', '--destiny', type=str, dest='output_path',
+                        help='path where terminator config files will be' +
+                        ' created, if not provided then will be printed')
+
+    args = parser.parse_args()
+
+    main(args.xrdb_path, args.output_path)

--- a/tools/xrdb2xfce_terminal.py
+++ b/tools/xrdb2xfce_terminal.py
@@ -14,17 +14,7 @@ import sys
 import re
 import argparse
 
-if __name__ == "__main__":
-
-    parser = argparse.ArgumentParser(
-        description='Translate X color schemes to termiantor format')
-    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
-    parser.add_argument('-d', '--destiny', type=str, dest='output_path',
-                        help='path where terminator config files will be' +
-                        ' created, if not provided then will be printed')
-
-    args = parser.parse_args()
-
+def main(xrdb_path, output_path=None):
 
     # The regexes to match the colors
     color_regex = re.compile("#define +Ansi_(\d+)_Color +(#[A-Fa-f0-9]{6})")
@@ -35,10 +25,10 @@ if __name__ == "__main__":
     # File regex
     xrdb_regex = re.compile("(.+)\.[xX][rR][dD][bB]")
 
-    for i in filter(lambda x: xrdb_regex.match(x), os.listdir(args.xrdb_path)):
+    for i in filter(lambda x: xrdb_regex.match(x), os.listdir(xrdb_path)):
 
         # per file
-        with open(os.path.join(args.xrdb_path, i)) as f:
+        with open(os.path.join(xrdb_path, i)) as f:
             lines = f.readlines()
 
         # Search special colors
@@ -70,9 +60,23 @@ ColorPalette={pl}
                                cr=cursor_color,
                                fg=fg_color)
 
-        if not args.output_path:
+        if not output_path:
             print(output)
         else:
-            dest = os.path.join(args.output_path, xrdb_regex.match(i).group(1))
+            dest = os.path.join(output_path, xrdb_regex.match(i).group(1))
             with open('{0}.theme'.format(dest), 'w+') as f:
                 f.write(output)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description='Translate X color schemes to termiantor format')
+    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
+    parser.add_argument('-d', '--destiny', type=str, dest='output_path',
+                        help='path where terminator config files will be' +
+                        ' created, if not provided then will be printed')
+
+    args = parser.parse_args()
+
+    main(args.xrdb_path, args.output_path)
+


### PR DESCRIPTION
Create basic `main(xrdb_path, output_path=None)` interface to all python modules, so they can be imported by `update_all.py` instead of using subprocess.

 - Added `xrdb2Xresources` conversion into `update_all.py`
 - Added `xrdb2xfce_terminal` conversion into `update_all.py`