### PR TITLE
Support mobaxterm.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - [Xfce Terminal color schemes](#xfce-terminal-color-schemes)
   - [FreeBSD vt(4) color schemes](#freebsd-vt-color-schemes)
   - [Previewing color schemes](#previewing-color-schemes)
-
+  - [MobaXterm color schemes](#mobaxterm-color-schemes)
 ## Intro
 This is a set of color schemes for iTerm (aka iTerm2). Screenshots below and in the [screenshots](screenshots/) directory.
 
@@ -1258,6 +1258,9 @@ Copy the `colorschemes` folder to `~/.local/share/xfce4/terminal/` and restart T
 ### FreeBSD vt color schemes
 Append your favourite theme from `freebsd_vt/` to `/boot/loader.conf`
 or `/boot/loader.conf.local` and reboot.
+
+### MobaXterm color schemes
+Copy the theme content form `mobaxterm/` and paste the content to your `MobaXterm.ini` in the corresponding place. (`[Colors]`)
 
 ### Previewing color schemes
 

--- a/mobaxterm/3024 Day.ini
+++ b/mobaxterm/3024 Day.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: 3024 Day
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=247,247,247
+ForegroundColour=74,69,67
+CursorColour=74,69,67
+Black=9,3,0
+Red=219,45,32
+BoldGreen=58,52,50
+BoldYellow=74,69,67
+BoldBlue=128,125,124
+BoldMagenta=214,213,212
+BoldCyan=205,171,83
+BoldWhite=247,247,247
+Green=1,162,82
+Yellow=253,237,2
+Blue=1,160,228
+Magenta=161,106,148
+Cyan=181,228,244
+White=165,162,162
+BoldBlack=92,88,85
+BoldRed=232,187,208

--- a/mobaxterm/3024 Night.ini
+++ b/mobaxterm/3024 Night.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: 3024 Night
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=9,3,0
+ForegroundColour=165,162,162
+CursorColour=165,162,162
+Black=9,3,0
+Red=219,45,32
+BoldGreen=58,52,50
+BoldYellow=74,69,67
+BoldBlue=128,125,124
+BoldMagenta=214,213,212
+BoldCyan=205,171,83
+BoldWhite=247,247,247
+Green=1,162,82
+Yellow=253,237,2
+Blue=1,160,228
+Magenta=161,106,148
+Cyan=181,228,244
+White=165,162,162
+BoldBlack=92,88,85
+BoldRed=232,187,208

--- a/mobaxterm/AdventureTime.ini
+++ b/mobaxterm/AdventureTime.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: AdventureTime
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=31,29,69
+ForegroundColour=248,220,192
+CursorColour=239,191,56
+Black=5,4,4
+Red=189,0,19
+BoldGreen=158,255,110
+BoldYellow=239,193,26
+BoldBlue=25,151,198
+BoldMagenta=155,89,83
+BoldCyan=200,250,244
+BoldWhite=246,245,251
+Green=74,177,24
+Yellow=231,116,30
+Blue=15,74,198
+Magenta=102,89,147
+Cyan=112,165,152
+White=248,220,192
+BoldBlack=78,124,191
+BoldRed=252,95,90

--- a/mobaxterm/Afterglow.ini
+++ b/mobaxterm/Afterglow.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Afterglow
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=33,33,33
+ForegroundColour=208,208,208
+CursorColour=208,208,208
+Black=21,21,21
+Red=172,65,66
+BoldGreen=126,142,80
+BoldYellow=229,181,103
+BoldBlue=108,153,187
+BoldMagenta=159,78,133
+BoldCyan=125,214,207
+BoldWhite=245,245,245
+Green=126,142,80
+Yellow=229,181,103
+Blue=108,153,187
+Magenta=159,78,133
+Cyan=125,214,207
+White=208,208,208
+BoldBlack=80,80,80
+BoldRed=172,65,66

--- a/mobaxterm/AlienBlood.ini
+++ b/mobaxterm/AlienBlood.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: AlienBlood
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=15,22,16
+ForegroundColour=99,125,117
+CursorColour=115,250,145
+Black=17,38,22
+Red=127,43,39
+BoldGreen=24,224,0
+BoldYellow=189,224,0
+BoldBlue=0,170,224
+BoldMagenta=0,88,224
+BoldCyan=0,224,196
+BoldWhite=115,250,145
+Green=47,126,37
+Yellow=113,127,36
+Blue=47,106,127
+Magenta=71,88,127
+Cyan=50,127,119
+White=100,125,117
+BoldBlack=60,72,18
+BoldRed=224,128,9

--- a/mobaxterm/Argonaut.ini
+++ b/mobaxterm/Argonaut.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Argonaut
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=14,16,25
+ForegroundColour=255,250,244
+CursorColour=255,0,24
+Black=35,35,35
+Red=255,0,15
+BoldGreen=171,225,91
+BoldYellow=255,210,66
+BoldBlue=0,146,255
+BoldMagenta=154,95,235
+BoldCyan=103,255,240
+BoldWhite=255,255,255
+Green=140,225,11
+Yellow=255,185,0
+Blue=0,141,248
+Magenta=109,67,166
+Cyan=0,216,235
+White=255,255,255
+BoldBlack=68,68,68
+BoldRed=255,39,64

--- a/mobaxterm/Arthur.ini
+++ b/mobaxterm/Arthur.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Arthur
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=28,28,28
+ForegroundColour=221,238,221
+CursorColour=226,187,239
+Black=61,53,42
+Red=205,92,92
+BoldGreen=136,170,34
+BoldYellow=255,167,93
+BoldBlue=135,206,235
+BoldMagenta=153,102,0
+BoldCyan=176,196,222
+BoldWhite=221,204,187
+Green=134,175,128
+Yellow=232,174,91
+Blue=100,149,237
+Magenta=222,184,135
+Cyan=176,196,222
+White=187,170,153
+BoldBlack=85,68,68
+BoldRed=204,85,51

--- a/mobaxterm/AtelierSulphurpool.ini
+++ b/mobaxterm/AtelierSulphurpool.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: AtelierSulphurpool
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=32,39,70
+ForegroundColour=151,157,180
+CursorColour=151,157,180
+Black=32,39,70
+Red=201,73,34
+BoldGreen=41,50,86
+BoldYellow=94,102,135
+BoldBlue=137,142,164
+BoldMagenta=223,226,241
+BoldCyan=156,99,122
+BoldWhite=245,247,255
+Green=172,151,57
+Yellow=192,139,48
+Blue=61,143,209
+Magenta=102,121,204
+Cyan=34,162,201
+White=151,157,180
+BoldBlack=107,115,148
+BoldRed=199,107,41

--- a/mobaxterm/Atom.ini
+++ b/mobaxterm/Atom.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Atom
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=22,23,25
+ForegroundColour=197,200,198
+CursorColour=208,208,208
+Black=0,0,0
+Red=253,95,241
+BoldGreen=148,250,54
+BoldYellow=245,255,168
+BoldBlue=150,203,254
+BoldMagenta=185,182,252
+BoldCyan=133,190,253
+BoldWhite=224,224,224
+Green=135,195,138
+Yellow=255,215,177
+Blue=133,190,253
+Magenta=185,182,252
+Cyan=133,190,253
+White=224,224,224
+BoldBlack=0,0,0
+BoldRed=253,95,241

--- a/mobaxterm/AtomOneLight.ini
+++ b/mobaxterm/AtomOneLight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: AtomOneLight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=249,249,249
+ForegroundColour=42,44,51
+CursorColour=187,187,187
+Black=0,0,0
+Red=222,62,53
+BoldGreen=63,149,58
+BoldYellow=210,182,124
+BoldBlue=47,90,243
+BoldMagenta=160,0,149
+BoldCyan=63,149,58
+BoldWhite=255,255,255
+Green=63,149,58
+Yellow=210,182,124
+Blue=47,90,243
+Magenta=149,0,149
+Cyan=63,149,58
+White=187,187,187
+BoldBlack=0,0,0
+BoldRed=222,62,53

--- a/mobaxterm/Batman.ini
+++ b/mobaxterm/Batman.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Batman
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,29,30
+ForegroundColour=111,111,111
+CursorColour=252,239,12
+Black=27,29,30
+Red=230,220,68
+BoldGreen=255,242,125
+BoldYellow=254,237,108
+BoldBlue=145,148,149
+BoldMagenta=154,154,157
+BoldCyan=163,163,166
+BoldWhite=218,219,214
+Green=200,190,70
+Yellow=244,253,34
+Blue=115,113,116
+Magenta=116,114,113
+Cyan=98,96,95
+White=198,197,191
+BoldBlack=80,83,84
+BoldRed=255,247,142

--- a/mobaxterm/Belafonte Day.ini
+++ b/mobaxterm/Belafonte Day.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Belafonte Day
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=213,204,186
+ForegroundColour=69,55,60
+CursorColour=69,55,60
+Black=32,17,27
+Red=190,16,14
+BoldGreen=133,129,98
+BoldYellow=234,165,73
+BoldBlue=66,106,121
+BoldMagenta=151,82,44
+BoldCyan=152,154,156
+BoldWhite=213,204,186
+Green=133,129,98
+Yellow=234,165,73
+Blue=66,106,121
+Magenta=151,82,44
+Cyan=152,154,156
+White=150,140,131
+BoldBlack=94,82,82
+BoldRed=190,16,14

--- a/mobaxterm/Belafonte Night.ini
+++ b/mobaxterm/Belafonte Night.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Belafonte Night
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=32,17,27
+ForegroundColour=150,140,131
+CursorColour=150,140,131
+Black=32,17,27
+Red=190,16,14
+BoldGreen=133,129,98
+BoldYellow=234,165,73
+BoldBlue=66,106,121
+BoldMagenta=151,82,44
+BoldCyan=152,154,156
+BoldWhite=213,204,186
+Green=133,129,98
+Yellow=234,165,73
+Blue=66,106,121
+Magenta=151,82,44
+Cyan=152,154,156
+White=150,140,131
+BoldBlack=94,82,82
+BoldRed=190,16,14

--- a/mobaxterm/BirdsOfParadise.ini
+++ b/mobaxterm/BirdsOfParadise.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: BirdsOfParadise
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=42,31,29
+ForegroundColour=224,219,183
+CursorColour=87,61,38
+Black=87,61,38
+Red=190,45,38
+BoldGreen=149,216,186
+BoldYellow=208,209,80
+BoldBlue=184,211,237
+BoldMagenta=209,158,203
+BoldCyan=147,207,215
+BoldWhite=255,249,213
+Green=107,161,138
+Yellow=233,157,42
+Blue=90,134,173
+Magenta=172,128,166
+Cyan=116,166,173
+White=224,219,183
+BoldBlack=155,108,74
+BoldRed=232,70,39

--- a/mobaxterm/Blazer.ini
+++ b/mobaxterm/Blazer.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Blazer
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=13,25,38
+ForegroundColour=217,230,242
+CursorColour=217,230,242
+Black=0,0,0
+BoldBlack=38,38,38
+Red=184,122,122
+BoldRed=219,189,189
+Green=122,184,122
+BoldGreen=189,219,189
+Yellow=184,184,122
+BoldYellow=219,219,189
+Blue=122,122,184
+BoldBlue=189,189,219
+Magenta=184,122,184
+BoldMagenta=219,189,219
+Cyan=122,184,184
+BoldCyan=189,219,219
+White=217,217,217
+BoldWhite=255,255,255

--- a/mobaxterm/BlulocoDark.ini
+++ b/mobaxterm/BlulocoDark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: BlulocoDark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,33,39
+ForegroundColour=171,178,191
+CursorColour=254,195,9
+Black=74,80,93
+Red=248,17,65
+BoldGreen=55,189,88
+BoldYellow=246,190,72
+BoldBlue=25,159,253
+BoldMagenta=252,88,246
+BoldCyan=80,172,174
+BoldWhite=255,255,255
+Green=35,151,74
+Yellow=253,126,87
+Blue=40,91,255
+Magenta=140,98,253
+Cyan=54,111,154
+White=204,213,229
+BoldBlack=97,105,122
+BoldRed=252,74,109

--- a/mobaxterm/BlulocoLight.ini
+++ b/mobaxterm/BlulocoLight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: BlulocoLight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=247,247,247
+ForegroundColour=42,44,51
+CursorColour=237,0,71
+Black=203,204,213
+Red=201,14,66
+BoldGreen=52,179,84
+BoldYellow=184,148,39
+BoldBlue=16,133,217
+BoldMagenta=192,13,179
+BoldCyan=91,128,173
+BoldWhite=29,29,34
+Green=33,136,58
+Yellow=213,77,23
+Blue=30,68,221
+Magenta=109,27,237
+Cyan=31,77,122
+White=0,0,0
+BoldBlack=222,223,232
+BoldRed=252,74,109

--- a/mobaxterm/Borland.ini
+++ b/mobaxterm/Borland.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Borland
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,164
+ForegroundColour=255,255,78
+CursorColour=255,165,96
+Black=79,79,79
+Red=255,108,96
+BoldGreen=206,255,172
+BoldYellow=255,255,204
+BoldBlue=181,220,255
+BoldMagenta=255,156,254
+BoldCyan=223,223,254
+BoldWhite=255,255,255
+Green=168,255,96
+Yellow=255,255,182
+Blue=150,203,254
+Magenta=255,115,253
+Cyan=198,197,254
+White=238,238,238
+BoldBlack=124,124,124
+BoldRed=255,182,176

--- a/mobaxterm/Bright Lights.ini
+++ b/mobaxterm/Bright Lights.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Bright Lights
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=25,25,25
+ForegroundColour=179,201,215
+CursorColour=243,75,0
+Black=25,25,25
+Red=255,53,91
+BoldGreen=183,232,118
+BoldYellow=255,194,81
+BoldBlue=118,213,255
+BoldMagenta=186,118,231
+BoldCyan=108,191,181
+BoldWhite=194,200,215
+Green=183,232,118
+Yellow=255,194,81
+Blue=118,212,255
+Magenta=186,118,231
+Cyan=108,191,181
+White=194,200,215
+BoldBlack=25,25,25
+BoldRed=255,53,91

--- a/mobaxterm/Broadcast.ini
+++ b/mobaxterm/Broadcast.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Broadcast
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=43,43,43
+ForegroundColour=230,225,220
+CursorColour=255,255,255
+Black=0,0,0
+Red=218,73,57
+BoldGreen=131,209,130
+BoldYellow=255,255,124
+BoldBlue=159,206,240
+BoldMagenta=255,255,255
+BoldCyan=160,206,240
+BoldWhite=255,255,255
+Green=81,159,80
+Yellow=255,210,74
+Blue=109,156,190
+Magenta=208,208,255
+Cyan=110,156,190
+White=255,255,255
+BoldBlack=50,50,50
+BoldRed=255,123,107

--- a/mobaxterm/Brogrammer.ini
+++ b/mobaxterm/Brogrammer.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Brogrammer
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=19,19,19
+ForegroundColour=214,219,229
+CursorColour=185,185,185
+Black=31,31,31
+Red=248,17,24
+BoldGreen=29,211,97
+BoldYellow=243,189,9
+BoldBlue=16,129,214
+BoldMagenta=83,80,185
+BoldCyan=15,125,219
+BoldWhite=255,255,255
+Green=45,197,94
+Yellow=236,186,15
+Blue=42,132,210
+Magenta=78,90,183
+Cyan=16,129,214
+White=214,219,229
+BoldBlack=214,219,229
+BoldRed=222,53,46

--- a/mobaxterm/Builtin Dark.ini
+++ b/mobaxterm/Builtin Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=187,187,187
+CursorColour=187,187,187
+Black=0,0,0
+Red=187,0,0
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=0,187,0
+Yellow=187,187,0
+Blue=0,0,187
+Magenta=187,0,187
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Builtin Light.ini
+++ b/mobaxterm/Builtin Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=0,0,0
+Black=0,0,0
+Red=187,0,0
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=0,187,0
+Yellow=187,187,0
+Blue=0,0,187
+Magenta=187,0,187
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Builtin Pastel Dark.ini
+++ b/mobaxterm/Builtin Pastel Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Pastel Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=187,187,187
+CursorColour=255,165,96
+Black=79,79,79
+Red=255,108,96
+BoldGreen=206,255,172
+BoldYellow=255,255,204
+BoldBlue=181,220,255
+BoldMagenta=255,156,254
+BoldCyan=223,223,254
+BoldWhite=255,255,255
+Green=168,255,96
+Yellow=255,255,182
+Blue=150,203,254
+Magenta=255,115,253
+Cyan=198,197,254
+White=238,238,238
+BoldBlack=124,124,124
+BoldRed=255,182,176

--- a/mobaxterm/Builtin Solarized Dark.ini
+++ b/mobaxterm/Builtin Solarized Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Solarized Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,30,39
+ForegroundColour=112,130,132
+CursorColour=112,130,132
+Black=0,40,49
+Red=209,28,36
+BoldGreen=71,91,98
+BoldYellow=83,104,112
+BoldBlue=112,130,132
+BoldMagenta=89,86,186
+BoldCyan=129,144,144
+BoldWhite=252,244,220
+Green=115,138,5
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=0,30,39
+BoldRed=189,54,19

--- a/mobaxterm/Builtin Solarized Light.ini
+++ b/mobaxterm/Builtin Solarized Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Solarized Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=252,244,220
+ForegroundColour=83,104,112
+CursorColour=83,104,112
+Black=0,40,49
+Red=209,28,36
+BoldGreen=71,91,98
+BoldYellow=83,104,112
+BoldBlue=112,130,132
+BoldMagenta=89,86,186
+BoldCyan=129,144,144
+BoldWhite=252,244,220
+Green=115,138,5
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=0,30,39
+BoldRed=189,54,19

--- a/mobaxterm/Builtin Tango Dark.ini
+++ b/mobaxterm/Builtin Tango Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Tango Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=255,255,255
+CursorColour=255,255,255
+Black=0,0,0
+Red=204,0,0
+BoldGreen=138,226,52
+BoldYellow=252,233,79
+BoldBlue=114,159,207
+BoldMagenta=173,127,168
+BoldCyan=52,226,226
+BoldWhite=238,238,236
+Green=78,154,6
+Yellow=196,160,0
+Blue=52,101,164
+Magenta=117,80,123
+Cyan=6,152,154
+White=211,215,207
+BoldBlack=85,87,83
+BoldRed=239,41,41

--- a/mobaxterm/Builtin Tango Light.ini
+++ b/mobaxterm/Builtin Tango Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Builtin Tango Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=0,0,0
+Black=0,0,0
+Red=204,0,0
+BoldGreen=138,226,52
+BoldYellow=252,233,79
+BoldBlue=114,159,207
+BoldMagenta=173,127,168
+BoldCyan=52,226,226
+BoldWhite=238,238,236
+Green=78,154,6
+Yellow=196,160,0
+Blue=52,101,164
+Magenta=117,80,123
+Cyan=6,152,154
+White=211,215,207
+BoldBlack=85,87,83
+BoldRed=239,41,41

--- a/mobaxterm/C64.ini
+++ b/mobaxterm/C64.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: C64
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=64,49,141
+ForegroundColour=120,105,196
+CursorColour=120,105,196
+Black=9,3,0
+Red=136,57,50
+BoldGreen=85,160,73
+BoldYellow=191,206,114
+BoldBlue=64,49,141
+BoldMagenta=139,63,150
+BoldCyan=103,182,189
+BoldWhite=247,247,247
+Green=85,160,73
+Yellow=191,206,114
+Blue=64,49,141
+Magenta=139,63,150
+Cyan=103,182,189
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=136,57,50

--- a/mobaxterm/CLRS.ini
+++ b/mobaxterm/CLRS.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: CLRS
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=38,38,38
+CursorColour=111,211,252
+Black=0,0,0
+Red=248,40,42
+BoldGreen=44,198,49
+BoldYellow=253,215,39
+BoldBlue=22,112,255
+BoldMagenta=233,0,176
+BoldCyan=58,213,206
+BoldWhite=238,238,236
+Green=50,138,93
+Yellow=250,112,29
+Blue=19,92,208
+Magenta=159,0,189
+Cyan=51,195,193
+White=179,179,179
+BoldBlack=85,87,83
+BoldRed=251,4,22

--- a/mobaxterm/Calamity.ini
+++ b/mobaxterm/Calamity.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Calamity
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=47,40,51
+ForegroundColour=213,206,217
+CursorColour=213,206,217
+Black=47,40,51
+Red=252,100,77
+BoldGreen=165,246,156
+BoldYellow=233,215,165
+BoldBlue=59,121,199
+BoldMagenta=249,38,114
+BoldCyan=116,211,222
+BoldWhite=255,255,255
+Green=165,246,156
+Yellow=233,215,165
+Blue=59,121,199
+Magenta=249,38,114
+Cyan=116,211,222
+White=213,206,217
+BoldBlack=126,108,136
+BoldRed=252,100,77

--- a/mobaxterm/Chalk.ini
+++ b/mobaxterm/Chalk.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Chalk
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=43,45,46
+ForegroundColour=210,216,217
+CursorColour=112,130,132
+Black=125,139,143
+Red=178,58,82
+BoldGreen=128,196,112
+BoldYellow=255,235,98
+BoldBlue=65,150,255
+BoldMagenta=252,82,117
+BoldCyan=83,205,189
+BoldWhite=210,216,217
+Green=120,155,106
+Yellow=185,172,74
+Blue=42,127,172
+Magenta=189,79,90
+Cyan=68,167,153
+White=210,216,217
+BoldBlack=136,136,136
+BoldRed=242,72,64

--- a/mobaxterm/Chalkboard.ini
+++ b/mobaxterm/Chalkboard.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Chalkboard
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=41,38,47
+ForegroundColour=217,230,242
+CursorColour=217,230,242
+Black=0,0,0
+Red=195,115,114
+BoldGreen=170,219,170
+BoldYellow=218,219,170
+BoldBlue=170,170,219
+BoldMagenta=219,170,218
+BoldCyan=170,218,219
+BoldWhite=255,255,255
+Green=114,195,115
+Yellow=194,195,114
+Blue=115,114,195
+Magenta=195,114,194
+Cyan=114,194,195
+White=217,217,217
+BoldBlack=50,50,50
+BoldRed=219,170,170

--- a/mobaxterm/ChallengerDeep.ini
+++ b/mobaxterm/ChallengerDeep.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ChallengerDeep
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,28,49
+ForegroundColour=203,225,231
+CursorColour=251,252,252
+Black=20,18,40
+Red=255,84,88
+BoldGreen=149,255,164
+BoldYellow=255,233,170
+BoldBlue=145,221,255
+BoldMagenta=201,145,225
+BoldCyan=170,255,228
+BoldWhite=203,227,231
+Green=98,209,150
+Yellow=255,179,120
+Blue=101,178,255
+Magenta=144,108,255
+Cyan=99,242,241
+White=166,179,204
+BoldBlack=86,85,117
+BoldRed=255,128,128

--- a/mobaxterm/Chester.ini
+++ b/mobaxterm/Chester.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Chester
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=44,54,67
+ForegroundColour=255,255,255
+CursorColour=180,177,177
+Black=8,2,0
+Red=250,94,91
+BoldGreen=22,201,141
+BoldYellow=254,239,109
+BoldBlue=39,138,214
+BoldMagenta=211,69,144
+BoldCyan=39,222,222
+BoldWhite=255,255,255
+Green=22,201,141
+Yellow=255,200,63
+Blue=40,138,214
+Magenta=211,69,144
+Cyan=40,221,222
+White=231,231,231
+BoldBlack=111,107,104
+BoldRed=250,94,91

--- a/mobaxterm/Ciapre.ini
+++ b/mobaxterm/Ciapre.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Ciapre
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=25,28,39
+ForegroundColour=174,164,122
+CursorColour=146,128,91
+Black=24,24,24
+Red=129,0,9
+BoldGreen=166,167,93
+BoldYellow=220,223,124
+BoldBlue=48,151,198
+BoldMagenta=211,48,97
+BoldCyan=243,219,178
+BoldWhite=244,244,244
+Green=72,81,59
+Yellow=204,139,63
+Blue=87,109,140
+Magenta=114,77,124
+Cyan=92,79,75
+White=174,164,127
+BoldBlack=85,85,85
+BoldRed=172,56,53

--- a/mobaxterm/Cobalt Neon.ini
+++ b/mobaxterm/Cobalt Neon.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Cobalt Neon
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=20,40,56
+ForegroundColour=143,245,134
+CursorColour=196,32,111
+Black=20,38,49
+Red=255,35,32
+BoldGreen=143,245,134
+BoldYellow=233,240,109
+BoldBlue=60,125,210
+BoldMagenta=130,48,167
+BoldCyan=108,188,103
+BoldWhite=143,245,134
+Green=59,165,255
+Yellow=233,231,92
+Blue=143,245,134
+Magenta=120,26,160
+Cyan=143,245,134
+White=186,70,178
+BoldBlack=255,246,136
+BoldRed=212,49,46

--- a/mobaxterm/Cobalt2.ini
+++ b/mobaxterm/Cobalt2.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Cobalt2
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=19,39,56
+ForegroundColour=255,255,255
+CursorColour=240,204,9
+Black=0,0,0
+Red=255,0,0
+BoldGreen=59,208,29
+BoldYellow=237,200,9
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=106,227,250
+BoldWhite=255,255,255
+Green=56,222,33
+Yellow=255,229,10
+Blue=20,96,210
+Magenta=255,0,93
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=244,14,23

--- a/mobaxterm/CrayonPonyFish.ini
+++ b/mobaxterm/CrayonPonyFish.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: CrayonPonyFish
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=21,7,7
+ForegroundColour=104,82,90
+CursorColour=104,82,90
+Black=43,27,29
+Red=145,0,43
+BoldGreen=141,255,87
+BoldYellow=200,56,29
+BoldBlue=207,201,255
+BoldMagenta=252,108,186
+BoldCyan=255,206,175
+BoldWhite=176,148,157
+Green=87,149,36
+Yellow=171,49,27
+Blue=140,135,176
+Magenta=105,47,80
+Cyan=232,168,102
+White=104,82,90
+BoldBlack=61,43,46
+BoldRed=197,37,93

--- a/mobaxterm/Dark Pastel.ini
+++ b/mobaxterm/Dark Pastel.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Dark Pastel
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=255,255,255
+CursorColour=187,187,187
+Black=0,0,0
+Red=255,85,85
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=85,255,85
+Yellow=255,255,85
+Blue=85,85,255
+Magenta=255,85,255
+Cyan=85,255,255
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Dark+.ini
+++ b/mobaxterm/Dark+.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Dark+
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=14,14,14
+ForegroundColour=204,204,204
+CursorColour=255,255,255
+Black=0,0,0
+Red=205,49,49
+BoldGreen=35,209,139
+BoldYellow=245,245,67
+BoldBlue=59,142,234
+BoldMagenta=214,112,214
+BoldCyan=41,184,219
+BoldWhite=229,229,229
+Green=13,188,121
+Yellow=229,229,16
+Blue=36,114,200
+Magenta=188,63,188
+Cyan=17,168,205
+White=229,229,229
+BoldBlack=102,102,102
+BoldRed=241,76,76

--- a/mobaxterm/Darkside.ini
+++ b/mobaxterm/Darkside.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Darkside
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,35,36
+ForegroundColour=186,186,186
+CursorColour=187,187,187
+Black=0,0,0
+Red=232,52,28
+BoldGreen=119,184,105
+BoldYellow=239,214,75
+BoldBlue=56,124,211
+BoldMagenta=149,123,190
+BoldCyan=61,151,226
+BoldWhite=186,186,186
+Green=104,194,86
+Yellow=242,212,44
+Blue=28,152,232
+Magenta=142,105,201
+Cyan=28,152,232
+White=186,186,186
+BoldBlack=0,0,0
+BoldRed=224,90,79

--- a/mobaxterm/Desert.ini
+++ b/mobaxterm/Desert.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Desert
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=51,51,51
+ForegroundColour=255,255,255
+CursorColour=0,255,0
+Black=77,77,77
+Red=255,43,43
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=135,206,255
+BoldMagenta=255,85,255
+BoldCyan=255,215,0
+BoldWhite=255,255,255
+Green=152,251,152
+Yellow=240,230,140
+Blue=205,133,63
+Magenta=255,222,173
+Cyan=255,160,160
+White=245,222,179
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/DimmedMonokai.ini
+++ b/mobaxterm/DimmedMonokai.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: DimmedMonokai
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=31,31,31
+ForegroundColour=185,188,186
+CursorColour=248,62,25
+Black=58,61,67
+Red=190,63,72
+BoldGreen=15,114,47
+BoldYellow=196,112,51
+BoldBlue=24,109,227
+BoldMagenta=251,0,103
+BoldCyan=46,112,109
+BoldWhite=253,255,185
+Green=135,154,59
+Yellow=197,166,53
+Blue=79,118,161
+Magenta=133,92,141
+Cyan=87,143,164
+White=185,188,186
+BoldBlack=136,137,135
+BoldRed=251,0,31

--- a/mobaxterm/DotGov.ini
+++ b/mobaxterm/DotGov.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: DotGov
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=38,44,53
+ForegroundColour=235,235,235
+CursorColour=217,0,47
+Black=25,25,25
+Red=191,9,29
+BoldGreen=61,151,81
+BoldYellow=246,187,52
+BoldBlue=23,178,224
+BoldMagenta=120,48,176
+BoldCyan=139,210,237
+BoldWhite=255,255,255
+Green=61,151,81
+Yellow=246,187,52
+Blue=23,178,224
+Magenta=120,48,176
+Cyan=139,210,237
+White=255,255,255
+BoldBlack=25,25,25
+BoldRed=191,9,29

--- a/mobaxterm/Dracula.ini
+++ b/mobaxterm/Dracula.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Dracula
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,31,41
+ForegroundColour=248,248,242
+CursorColour=187,187,187
+Black=0,0,0
+Red=255,85,85
+BoldGreen=80,250,123
+BoldYellow=241,250,140
+BoldBlue=189,147,249
+BoldMagenta=255,121,198
+BoldCyan=139,233,253
+BoldWhite=255,255,255
+Green=80,250,123
+Yellow=241,250,140
+Blue=189,147,249
+Magenta=255,121,198
+Cyan=139,233,253
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Duotone Dark.ini
+++ b/mobaxterm/Duotone Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Duotone Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=31,29,39
+ForegroundColour=183,161,255
+CursorColour=255,152,57
+Black=31,29,39
+Red=217,57,62
+BoldGreen=45,205,115
+BoldYellow=217,183,110
+BoldBlue=255,194,132
+BoldMagenta=222,141,64
+BoldCyan=36,136,255
+BoldWhite=234,229,255
+Green=45,205,115
+Yellow=217,183,110
+Blue=255,194,132
+Magenta=222,141,64
+Cyan=36,136,255
+White=183,161,255
+BoldBlack=53,49,71
+BoldRed=217,57,62

--- a/mobaxterm/ENCOM.ini
+++ b/mobaxterm/ENCOM.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ENCOM
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=0,165,149
+CursorColour=187,187,187
+Black=0,0,0
+Red=159,0,0
+BoldGreen=0,238,0
+BoldYellow=255,255,0
+BoldBlue=0,0,255
+BoldMagenta=255,0,255
+BoldCyan=0,205,205
+BoldWhite=255,255,255
+Green=0,139,0
+Yellow=255,208,0
+Blue=0,129,255
+Magenta=188,0,202
+Cyan=0,139,139
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,0,0

--- a/mobaxterm/Earthsong.ini
+++ b/mobaxterm/Earthsong.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Earthsong
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=41,37,32
+ForegroundColour=229,199,169
+CursorColour=246,247,236
+Black=18,20,24
+Red=201,66,52
+BoldGreen=152,224,54
+BoldYellow=224,213,97
+BoldBlue=95,218,255
+BoldMagenta=255,146,105
+BoldCyan=132,240,136
+BoldWhite=246,247,236
+Green=133,197,76
+Yellow=245,174,46
+Blue=19,152,185
+Magenta=208,99,61
+Cyan=80,149,82
+White=229,198,170
+BoldBlack=103,95,84
+BoldRed=255,100,90

--- a/mobaxterm/Elemental.ini
+++ b/mobaxterm/Elemental.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Elemental
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,33,29
+ForegroundColour=128,122,116
+CursorColour=250,203,128
+Black=60,60,48
+Red=152,41,15
+BoldGreen=97,224,112
+BoldYellow=214,153,39
+BoldBlue=121,217,217
+BoldMagenta=205,124,84
+BoldCyan=89,213,153
+BoldWhite=255,241,233
+Green=71,154,67
+Yellow=127,113,17
+Blue=73,127,125
+Magenta=127,78,47
+Cyan=56,127,88
+White=128,121,116
+BoldBlack=85,84,69
+BoldRed=224,80,42

--- a/mobaxterm/Elementary.ini
+++ b/mobaxterm/Elementary.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Elementary
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=24,24,24
+ForegroundColour=239,239,239
+CursorColour=187,187,187
+Black=36,36,36
+Red=215,28,21
+BoldGreen=107,194,25
+BoldYellow=254,200,14
+BoldBlue=9,85,255
+BoldMagenta=251,0,80
+BoldCyan=62,168,252
+BoldWhite=140,0,236
+Green=90,165,19
+Yellow=253,180,12
+Blue=6,59,140
+Magenta=228,0,56
+Cyan=37,149,225
+White=239,239,239
+BoldBlack=75,75,75
+BoldRed=252,28,24

--- a/mobaxterm/Espresso Libre.ini
+++ b/mobaxterm/Espresso Libre.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Espresso Libre
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=42,33,28
+ForegroundColour=184,168,152
+CursorColour=255,255,255
+Black=0,0,0
+Red=204,0,0
+BoldGreen=154,255,135
+BoldYellow=255,251,92
+BoldBlue=67,168,237
+BoldMagenta=255,129,138
+BoldCyan=52,226,226
+BoldWhite=238,238,236
+Green=26,146,28
+Yellow=240,229,58
+Blue=0,102,255
+Magenta=197,101,107
+Cyan=6,152,154
+White=211,215,207
+BoldBlack=85,87,83
+BoldRed=239,41,41

--- a/mobaxterm/Espresso.ini
+++ b/mobaxterm/Espresso.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Espresso
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=50,50,50
+ForegroundColour=255,255,255
+CursorColour=214,214,214
+Black=53,53,53
+Red=210,82,82
+BoldGreen=194,224,117
+BoldYellow=225,228,139
+BoldBlue=138,183,217
+BoldMagenta=239,181,247
+BoldCyan=220,244,255
+BoldWhite=255,255,255
+Green=165,194,97
+Yellow=255,198,109
+Blue=108,153,187
+Magenta=209,151,217
+Cyan=190,214,255
+White=238,238,236
+BoldBlack=83,83,83
+BoldRed=240,12,12

--- a/mobaxterm/Fahrenheit.ini
+++ b/mobaxterm/Fahrenheit.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Fahrenheit
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=255,255,206
+CursorColour=187,187,187
+Black=29,29,29
+Red=205,160,116
+BoldGreen=204,115,77
+BoldYellow=253,159,77
+BoldBlue=203,74,5
+BoldMagenta=78,115,159
+BoldCyan=254,208,77
+BoldWhite=255,255,255
+Green=158,116,77
+Yellow=254,207,117
+Blue=114,1,2
+Magenta=115,76,77
+Cyan=151,151,151
+White=255,255,206
+BoldBlack=0,0,0
+BoldRed=254,206,160

--- a/mobaxterm/Fideloper.ini
+++ b/mobaxterm/Fideloper.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Fideloper
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=41,47,51
+ForegroundColour=219,218,224
+CursorColour=212,96,90
+Black=41,47,51
+Red=203,30,45
+BoldGreen=212,96,90
+BoldYellow=168,102,113
+BoldBlue=124,133,196
+BoldMagenta=92,93,178
+BoldCyan=129,144,144
+BoldWhite=252,244,223
+Green=237,184,172
+Yellow=183,171,155
+Blue=46,120,194
+Magenta=192,35,111
+Cyan=48,145,134
+White=234,227,206
+BoldBlack=9,32,40
+BoldRed=212,96,90

--- a/mobaxterm/FirefoxDev.ini
+++ b/mobaxterm/FirefoxDev.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: FirefoxDev
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=14,16,17
+ForegroundColour=124,143,164
+CursorColour=112,130,132
+Black=0,40,49
+Red=230,56,83
+BoldGreen=29,144,0
+BoldYellow=205,148,9
+BoldBlue=0,111,192
+BoldMagenta=162,0,218
+BoldCyan=0,87,148
+BoldWhite=226,226,226
+Green=94,184,60
+Yellow=165,119,6
+Blue=53,157,223
+Magenta=215,92,255
+Cyan=75,115,162
+White=220,220,220
+BoldBlack=0,30,39
+BoldRed=225,0,63

--- a/mobaxterm/Firewatch.ini
+++ b/mobaxterm/Firewatch.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Firewatch
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,32,39
+ForegroundColour=155,162,178
+CursorColour=246,247,236
+Black=88,95,109
+Red=217,83,96
+BoldGreen=90,185,119
+BoldYellow=223,181,99
+BoldBlue=76,137,197
+BoldMagenta=213,81,25
+BoldCyan=68,168,182
+BoldWhite=230,229,255
+Green=90,185,119
+Yellow=223,181,99
+Blue=77,137,196
+Magenta=213,81,25
+Cyan=68,168,182
+White=230,229,255
+BoldBlack=88,95,109
+BoldRed=217,83,96

--- a/mobaxterm/FishTank.ini
+++ b/mobaxterm/FishTank.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: FishTank
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=35,37,55
+ForegroundColour=236,240,254
+CursorColour=254,205,94
+Black=3,7,60
+Red=198,0,74
+BoldGreen=219,255,169
+BoldYellow=254,230,169
+BoldBlue=178,190,250
+BoldMagenta=253,165,205
+BoldCyan=165,189,134
+BoldWhite=246,255,236
+Green=172,241,87
+Yellow=254,205,94
+Blue=82,95,184
+Magenta=152,111,130
+Cyan=150,135,99
+White=236,240,252
+BoldBlack=108,91,48
+BoldRed=218,75,138

--- a/mobaxterm/Flat.ini
+++ b/mobaxterm/Flat.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Flat
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,34,64
+ForegroundColour=44,197,93
+CursorColour=229,190,12
+Black=34,45,63
+Red=168,35,32
+BoldGreen=45,148,64
+BoldYellow=229,190,12
+BoldBlue=60,125,210
+BoldMagenta=130,48,167
+BoldCyan=53,179,135
+BoldWhite=231,236,237
+Green=50,165,72
+Yellow=229,141,17
+Blue=49,103,172
+Magenta=120,26,160
+Cyan=44,147,112
+White=176,182,186
+BoldBlack=33,44,60
+BoldRed=212,49,46

--- a/mobaxterm/Flatland.ini
+++ b/mobaxterm/Flatland.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Flatland
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,31,33
+ForegroundColour=184,219,239
+CursorColour=112,130,132
+Black=29,29,25
+Red=241,131,57
+BoldGreen=167,212,44
+BoldYellow=255,137,73
+BoldBlue=97,185,208
+BoldMagenta=105,90,188
+BoldCyan=214,56,101
+BoldWhite=255,255,255
+Green=159,211,100
+Yellow=244,239,109
+Blue=80,150,190
+Magenta=105,90,188
+Cyan=214,56,101
+White=255,255,255
+BoldBlack=29,29,25
+BoldRed=210,42,36

--- a/mobaxterm/Floraverse.ini
+++ b/mobaxterm/Floraverse.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Floraverse
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=14,13,21
+ForegroundColour=219,209,185
+CursorColour=187,187,187
+Black=8,0,46
+Red=100,0,44
+BoldGreen=180,206,89
+BoldYellow=250,195,87
+BoldBlue=64,164,207
+BoldMagenta=241,42,174
+BoldCyan=98,202,168
+BoldWhite=255,245,219
+Green=93,115,26
+Yellow=205,117,28
+Blue=29,109,161
+Magenta=183,7,126
+Cyan=66,163,140
+White=243,224,184
+BoldBlack=51,30,77
+BoldRed=208,32,99

--- a/mobaxterm/ForestBlue.ini
+++ b/mobaxterm/ForestBlue.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ForestBlue
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=5,21,25
+ForegroundColour=226,216,205
+CursorColour=158,158,203
+Black=51,51,51
+Red=248,129,142
+BoldGreen=107,180,141
+BoldYellow=48,200,90
+BoldBlue=57,167,162
+BoldMagenta=126,98,179
+BoldCyan=96,150,191
+BoldWhite=226,216,205
+Green=146,211,162
+Yellow=26,142,99
+Blue=142,208,206
+Magenta=94,70,140
+Cyan=49,101,140
+White=226,216,205
+BoldBlack=61,61,61
+BoldRed=251,61,102

--- a/mobaxterm/Framer.ini
+++ b/mobaxterm/Framer.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Framer
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=17,17,17
+ForegroundColour=119,119,119
+CursorColour=252,220,8
+Black=20,20,20
+Red=255,85,85
+BoldGreen=182,242,146
+BoldYellow=255,217,102
+BoldBlue=51,187,255
+BoldMagenta=206,187,255
+BoldCyan=187,236,255
+BoldWhite=255,255,255
+Green=152,236,101
+Yellow=255,204,51
+Blue=0,170,255
+Magenta=170,136,255
+Cyan=136,221,255
+White=204,204,204
+BoldBlack=65,65,65
+BoldRed=255,136,136

--- a/mobaxterm/FrontEndDelight.ini
+++ b/mobaxterm/FrontEndDelight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: FrontEndDelight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,28,29
+ForegroundColour=173,173,173
+CursorColour=205,205,205
+Black=36,37,38
+Red=248,81,27
+BoldGreen=116,236,76
+BoldYellow=253,195,37
+BoldBlue=51,147,202
+BoldMagenta=231,94,79
+BoldCyan=79,188,230
+BoldWhite=140,115,91
+Green=86,87,71
+Yellow=250,119,29
+Blue=44,112,183
+Magenta=240,46,79
+Cyan=60,161,166
+White=173,173,173
+BoldBlack=95,172,109
+BoldRed=247,67,25

--- a/mobaxterm/FunForrest.ini
+++ b/mobaxterm/FunForrest.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: FunForrest
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=37,18,0
+ForegroundColour=222,193,101
+CursorColour=229,89,28
+Black=0,0,0
+Red=214,38,43
+BoldGreen=191,198,90
+BoldYellow=255,203,27
+BoldBlue=124,201,207
+BoldMagenta=210,99,73
+BoldCyan=230,169,107
+BoldWhite=255,234,163
+Green=145,156,0
+Yellow=190,138,19
+Blue=70,153,163
+Magenta=141,67,49
+Cyan=218,130,19
+White=221,194,101
+BoldBlack=127,106,85
+BoldRed=229,90,28

--- a/mobaxterm/Galaxy.ini
+++ b/mobaxterm/Galaxy.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Galaxy
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,40,55
+ForegroundColour=255,255,255
+CursorColour=187,187,187
+Black=0,0,0
+Red=249,85,95
+BoldGreen=53,187,154
+BoldYellow=255,255,85
+BoldBlue=88,157,246
+BoldMagenta=231,86,153
+BoldCyan=57,121,188
+BoldWhite=255,255,255
+Green=33,176,137
+Yellow=254,240,42
+Blue=88,157,246
+Magenta=148,77,149
+Cyan=31,158,231
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=250,140,143

--- a/mobaxterm/Github.ini
+++ b/mobaxterm/Github.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Github
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=244,244,244
+ForegroundColour=62,62,62
+CursorColour=63,63,63
+Black=62,62,62
+Red=151,11,22
+BoldGreen=135,213,162
+BoldYellow=241,208,7
+BoldBlue=46,108,186
+BoldMagenta=255,162,159
+BoldCyan=28,250,254
+BoldWhite=255,255,255
+Green=7,150,42
+Yellow=248,238,199
+Blue=0,62,138
+Magenta=233,70,145
+Cyan=137,209,236
+White=255,255,255
+BoldBlack=102,102,102
+BoldRed=222,0,0

--- a/mobaxterm/Glacier.ini
+++ b/mobaxterm/Glacier.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Glacier
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=12,17,21
+ForegroundColour=255,255,255
+CursorColour=108,108,108
+Black=46,52,60
+Red=189,15,47
+BoldGreen=73,233,152
+BoldYellow=253,223,110
+BoldBlue=42,139,193
+BoldMagenta=234,71,39
+BoldCyan=160,182,211
+BoldWhite=255,255,255
+Green=53,167,112
+Yellow=251,148,53
+Blue=31,88,114
+Magenta=189,37,35
+Cyan=119,131,151
+White=255,255,255
+BoldBlack=64,74,85
+BoldRed=189,15,47

--- a/mobaxterm/Grape.ini
+++ b/mobaxterm/Grape.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Grape
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=23,20,35
+ForegroundColour=159,159,161
+CursorColour=162,136,247
+Black=45,40,63
+Red=237,34,97
+BoldGreen=83,170,94
+BoldYellow=178,220,135
+BoldBlue=169,188,236
+BoldMagenta=173,129,194
+BoldCyan=157,227,235
+BoldWhite=162,136,247
+Green=31,169,27
+Yellow=141,220,32
+Blue=72,125,244
+Magenta=141,53,201
+Cyan=59,222,237
+White=158,158,160
+BoldBlack=89,81,106
+BoldRed=240,114,154

--- a/mobaxterm/Grass.ini
+++ b/mobaxterm/Grass.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Grass
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=19,119,61
+ForegroundColour=255,240,165
+CursorColour=140,40,0
+Black=0,0,0
+Red=187,0,0
+BoldGreen=0,187,0
+BoldYellow=231,176,0
+BoldBlue=0,0,187
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=0,187,0
+Yellow=231,176,0
+Blue=0,0,163
+Magenta=149,0,98
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=187,0,0

--- a/mobaxterm/Gruvbox Dark.ini
+++ b/mobaxterm/Gruvbox Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Gruvbox Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,30,30
+ForegroundColour=230,212,163
+CursorColour=187,187,187
+Black=22,24,25
+Red=247,48,40
+BoldGreen=134,135,21
+BoldYellow=204,136,26
+BoldBlue=55,115,117
+BoldMagenta=160,75,115
+BoldCyan=87,142,87
+BoldWhite=230,212,163
+Green=170,176,30
+Yellow=247,177,37
+Blue=113,149,134
+Magenta=199,112,137
+Cyan=125,182,105
+White=250,239,187
+BoldBlack=127,112,97
+BoldRed=190,15,23

--- a/mobaxterm/Hacktober.ini
+++ b/mobaxterm/Hacktober.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hacktober
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=20,20,20
+ForegroundColour=201,201,201
+CursorColour=201,201,201
+Black=25,25,24
+Red=179,69,56
+BoldGreen=66,130,74
+BoldYellow=199,90,34
+BoldBlue=83,137,197
+BoldMagenta=231,149,165
+BoldCyan=235,197,135
+BoldWhite=255,255,255
+Green=88,119,68
+Yellow=208,137,73
+Blue=32,110,197
+Magenta=134,70,81
+Cyan=172,145,102
+White=241,238,231
+BoldBlack=44,43,42
+BoldRed=179,51,35

--- a/mobaxterm/Hardcore.ini
+++ b/mobaxterm/Hardcore.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hardcore
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=18,18,18
+ForegroundColour=160,160,160
+CursorColour=187,187,187
+Black=27,29,30
+Red=249,38,114
+BoldGreen=190,237,95
+BoldYellow=230,219,116
+BoldBlue=102,217,239
+BoldMagenta=158,111,254
+BoldCyan=163,186,191
+BoldWhite=248,248,242
+Green=166,226,46
+Yellow=253,151,31
+Blue=102,217,239
+Magenta=158,111,254
+Cyan=94,113,117
+White=204,204,198
+BoldBlack=80,83,84
+BoldRed=255,102,157

--- a/mobaxterm/Harper.ini
+++ b/mobaxterm/Harper.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Harper
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=1,1,1
+ForegroundColour=168,164,157
+CursorColour=168,164,157
+Black=1,1,1
+Red=248,182,63
+BoldGreen=127,181,225
+BoldYellow=214,218,37
+BoldBlue=72,158,72
+BoldMagenta=178,150,198
+BoldCyan=245,191,215
+BoldWhite=254,251,234
+Green=127,181,225
+Yellow=214,218,37
+Blue=72,158,72
+Magenta=178,150,198
+Cyan=245,191,215
+White=168,164,157
+BoldBlack=114,110,106
+BoldRed=248,182,63

--- a/mobaxterm/Highway.ini
+++ b/mobaxterm/Highway.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Highway
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,37
+ForegroundColour=237,237,237
+CursorColour=224,217,185
+Black=0,0,0
+Red=208,14,24
+BoldGreen=177,209,48
+BoldYellow=255,241,32
+BoldBlue=79,194,253
+BoldMagenta=222,0,113
+BoldCyan=93,80,74
+BoldWhite=255,255,255
+Green=19,128,52
+Yellow=255,203,62
+Blue=0,107,179
+Magenta=107,39,117
+Cyan=56,69,100
+White=237,237,237
+BoldBlack=93,80,74
+BoldRed=240,126,24

--- a/mobaxterm/Hipster Green.ini
+++ b/mobaxterm/Hipster Green.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hipster Green
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=16,11,5
+ForegroundColour=132,193,56
+CursorColour=35,255,24
+Black=0,0,0
+Red=182,33,74
+BoldGreen=134,169,62
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=191,191,0
+Blue=36,110,178
+Magenta=178,0,178
+Cyan=0,166,178
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Homebrew.ini
+++ b/mobaxterm/Homebrew.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Homebrew
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=0,255,0
+CursorColour=35,255,24
+Black=0,0,0
+Red=153,0,0
+BoldGreen=0,217,0
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=153,153,0
+Blue=0,0,178
+Magenta=178,0,178
+Cyan=0,166,178
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Hopscotch.256.ini
+++ b/mobaxterm/Hopscotch.256.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hopscotch.256
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=50,41,49
+ForegroundColour=185,181,184
+CursorColour=185,181,184
+Black=50,41,49
+Red=221,70,76
+BoldGreen=143,193,62
+BoldYellow=253,204,89
+BoldBlue=18,144,191
+BoldMagenta=200,94,124
+BoldCyan=20,155,147
+BoldWhite=255,255,255
+Green=143,193,62
+Yellow=253,204,89
+Blue=18,144,191
+Magenta=200,94,124
+Cyan=20,155,147
+White=185,181,184
+BoldBlack=121,115,121
+BoldRed=221,70,76

--- a/mobaxterm/Hopscotch.ini
+++ b/mobaxterm/Hopscotch.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hopscotch
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=50,41,49
+ForegroundColour=185,181,184
+CursorColour=185,181,184
+Black=50,41,49
+Red=221,70,76
+BoldGreen=67,59,66
+BoldYellow=92,84,91
+BoldBlue=152,148,152
+BoldMagenta=213,211,213
+BoldCyan=179,53,8
+BoldWhite=255,255,255
+Green=143,193,62
+Yellow=253,204,89
+Blue=18,144,191
+Magenta=200,94,124
+Cyan=20,155,147
+White=185,181,184
+BoldBlack=121,115,121
+BoldRed=253,139,25

--- a/mobaxterm/Hurtado.ini
+++ b/mobaxterm/Hurtado.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hurtado
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=219,219,219
+CursorColour=187,187,187
+Black=87,87,87
+Red=255,27,0
+BoldGreen=165,223,85
+BoldYellow=251,232,74
+BoldBlue=137,190,255
+BoldMagenta=192,1,193
+BoldCyan=134,234,254
+BoldWhite=219,219,219
+Green=165,224,85
+Yellow=251,231,74
+Blue=73,100,135
+Magenta=253,95,241
+Cyan=134,233,254
+White=203,204,203
+BoldBlack=38,38,38
+BoldRed=213,29,0

--- a/mobaxterm/Hybrid.ini
+++ b/mobaxterm/Hybrid.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Hybrid
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=22,23,25
+ForegroundColour=183,188,186
+CursorColour=183,188,186
+Black=42,46,51
+Red=184,77,81
+BoldGreen=121,132,49
+BoldYellow=229,138,80
+BoldBlue=75,107,136
+BoldMagenta=110,80,121
+BoldCyan=77,123,116
+BoldWhite=90,98,106
+Green=179,191,90
+Yellow=228,181,94
+Blue=110,144,176
+Magenta=161,126,172
+Cyan=127,191,180
+White=181,185,182
+BoldBlack=29,31,34
+BoldRed=141,46,50

--- a/mobaxterm/IC_Green_PPL.ini
+++ b/mobaxterm/IC_Green_PPL.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: IC_Green_PPL
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=58,61,63
+ForegroundColour=217,239,211
+CursorColour=66,255,88
+Black=31,31,31
+Red=251,0,42
+BoldGreen=159,255,109
+BoldYellow=210,255,109
+BoldBlue=114,255,181
+BoldMagenta=80,255,62
+BoldCyan=34,255,113
+BoldWhite=218,239,208
+Green=51,156,36
+Yellow=101,155,37
+Blue=20,155,69
+Magenta=83,184,44
+Cyan=44,184,104
+White=224,255,239
+BoldBlack=3,39,16
+BoldRed=167,255,63

--- a/mobaxterm/IC_Orange_PPL.ini
+++ b/mobaxterm/IC_Orange_PPL.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: IC_Orange_PPL
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=38,38,38
+ForegroundColour=255,203,131
+CursorColour=252,83,29
+Black=0,0,0
+Red=193,57,0
+BoldGreen=246,255,64
+BoldYellow=255,227,110
+BoldBlue=255,190,85
+BoldMagenta=252,135,79
+BoldCyan=198,151,82
+BoldWhite=250,250,255
+Green=164,169,0
+Yellow=202,175,0
+Blue=189,109,0
+Magenta=252,94,0
+Cyan=247,149,0
+White=255,200,138
+BoldBlack=106,79,42
+BoldRed=255,140,104

--- a/mobaxterm/IR_Black.ini
+++ b/mobaxterm/IR_Black.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: IR_Black
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=241,241,241
+CursorColour=128,128,128
+Black=79,79,79
+Red=250,108,96
+BoldGreen=207,255,171
+BoldYellow=255,255,204
+BoldBlue=181,220,255
+BoldMagenta=251,156,254
+BoldCyan=224,224,254
+BoldWhite=255,255,255
+Green=168,255,96
+Yellow=255,254,183
+Blue=150,202,254
+Magenta=250,115,253
+Cyan=198,197,254
+White=239,237,239
+BoldBlack=123,123,123
+BoldRed=252,182,176

--- a/mobaxterm/Jackie Brown.ini
+++ b/mobaxterm/Jackie Brown.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Jackie Brown
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=44,29,22
+ForegroundColour=255,204,47
+CursorColour=35,255,24
+Black=44,29,22
+Red=239,87,52
+BoldGreen=134,169,62
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=43,175,43
+Yellow=190,191,0
+Blue=36,110,178
+Magenta=208,94,193
+Cyan=0,172,238
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Japanesque.ini
+++ b/mobaxterm/Japanesque.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Japanesque
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,30,30
+ForegroundColour=247,246,236
+CursorColour=237,207,79
+Black=52,57,53
+Red=207,63,97
+BoldGreen=118,127,44
+BoldYellow=120,89,47
+BoldBlue=19,89,121
+BoldMagenta=96,66,145
+BoldCyan=118,187,202
+BoldWhite=178,181,174
+Green=123,183,91
+Yellow=233,179,42
+Blue=76,154,212
+Magenta=165,127,196
+Cyan=56,154,173
+White=250,250,246
+BoldBlack=89,91,89
+BoldRed=209,143,166

--- a/mobaxterm/Jellybeans.ini
+++ b/mobaxterm/Jellybeans.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Jellybeans
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=18,18,18
+ForegroundColour=222,222,222
+CursorColour=255,165,96
+Black=146,146,146
+Red=226,115,115
+BoldGreen=189,222,171
+BoldYellow=255,220,160
+BoldBlue=177,216,246
+BoldMagenta=251,218,255
+BoldCyan=26,178,168
+BoldWhite=255,255,255
+Green=148,185,121
+Yellow=255,186,123
+Blue=151,190,220
+Magenta=225,192,250
+Cyan=0,152,142
+White=222,222,222
+BoldBlack=189,189,189
+BoldRed=255,161,161

--- a/mobaxterm/JetBrains Darcula.ini
+++ b/mobaxterm/JetBrains Darcula.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: JetBrains Darcula
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=32,32,32
+ForegroundColour=173,173,173
+CursorColour=255,255,255
+Black=0,0,0
+Red=250,83,85
+BoldGreen=103,255,79
+BoldYellow=255,255,0
+BoldBlue=109,157,241
+BoldMagenta=251,130,255
+BoldCyan=96,211,209
+BoldWhite=238,238,238
+Green=18,110,0
+Yellow=194,195,0
+Blue=69,129,235
+Magenta=250,84,255
+Cyan=51,194,193
+White=173,173,173
+BoldBlack=85,85,85
+BoldRed=251,113,114

--- a/mobaxterm/Kibble.ini
+++ b/mobaxterm/Kibble.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Kibble
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=14,16,10
+ForegroundColour=247,247,247
+CursorColour=159,218,156
+Black=77,77,77
+Red=199,0,49
+BoldGreen=108,224,92
+BoldYellow=243,247,158
+BoldBlue=151,164,247
+BoldMagenta=196,149,240
+BoldCyan=104,242,224
+BoldWhite=255,255,255
+Green=41,207,19
+Yellow=216,227,14
+Blue=52,73,209
+Magenta=132,0,255
+Cyan=7,152,171
+White=226,209,227
+BoldBlack=90,90,90
+BoldRed=240,21,120

--- a/mobaxterm/Kolorit.ini
+++ b/mobaxterm/Kolorit.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Kolorit
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,26,30
+ForegroundColour=239,236,236
+CursorColour=199,199,199
+Black=29,26,30
+Red=255,91,130
+BoldGreen=71,215,161
+BoldYellow=232,229,98
+BoldBlue=93,180,238
+BoldMagenta=218,108,218
+BoldCyan=87,233,235
+BoldWhite=237,237,237
+Green=71,215,161
+Yellow=232,229,98
+Blue=93,180,238
+Magenta=218,108,218
+Cyan=87,233,235
+White=237,237,237
+BoldBlack=29,26,30
+BoldRed=255,91,130

--- a/mobaxterm/Lab Fox.ini
+++ b/mobaxterm/Lab Fox.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Lab Fox
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=46,46,46
+ForegroundColour=255,255,255
+CursorColour=127,127,127
+Black=46,46,46
+Red=252,109,38
+BoldGreen=83,234,168
+BoldYellow=252,160,19
+BoldBlue=219,80,31
+BoldMagenta=68,16,144
+BoldCyan=125,83,231
+BoldWhite=255,255,255
+Green=62,179,131
+Yellow=252,161,33
+Blue=219,59,33
+Magenta=56,13,117
+Cyan=110,73,203
+White=255,255,255
+BoldBlack=70,70,70
+BoldRed=255,101,23

--- a/mobaxterm/Later This Evening.ini
+++ b/mobaxterm/Later This Evening.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Later This Evening
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=149,149,149
+CursorColour=66,66,66
+Black=43,43,43
+Red=212,90,96
+BoldGreen=170,187,57
+BoldYellow=229,190,57
+BoldBlue=102,153,214
+BoldMagenta=171,83,214
+BoldCyan=95,192,174
+BoldWhite=193,194,194
+Green=175,186,103
+Yellow=229,210,137
+Blue=160,186,214
+Magenta=192,146,214
+Cyan=145,191,183
+White=60,61,61
+BoldBlack=69,71,71
+BoldRed=211,35,47

--- a/mobaxterm/Lavandula.ini
+++ b/mobaxterm/Lavandula.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Lavandula
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=5,0,20
+ForegroundColour=115,110,125
+CursorColour=140,145,250
+Black=35,0,70
+Red=125,22,37
+BoldGreen=82,224,196
+BoldYellow=224,195,134
+BoldBlue=142,135,224
+BoldMagenta=167,118,224
+BoldCyan=154,212,224
+BoldWhite=140,145,250
+Green=51,126,111
+Yellow=127,111,73
+Blue=79,74,127
+Magenta=90,63,127
+Cyan=88,119,127
+White=115,110,125
+BoldBlack=55,45,70
+BoldRed=224,81,103

--- a/mobaxterm/LiquidCarbon.ini
+++ b/mobaxterm/LiquidCarbon.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: LiquidCarbon
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=48,48,48
+ForegroundColour=175,194,194
+CursorColour=255,255,255
+Black=0,0,0
+Red=255,48,48
+BoldGreen=85,154,112
+BoldYellow=204,172,0
+BoldBlue=0,153,204
+BoldMagenta=204,105,200
+BoldCyan=122,196,204
+BoldWhite=188,204,204
+Green=85,154,112
+Yellow=204,172,0
+Blue=0,153,204
+Magenta=204,105,200
+Cyan=122,196,204
+White=188,204,204
+BoldBlack=0,0,0
+BoldRed=255,48,48

--- a/mobaxterm/LiquidCarbonTransparent.ini
+++ b/mobaxterm/LiquidCarbonTransparent.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: LiquidCarbonTransparent
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=175,194,194
+CursorColour=255,255,255
+Black=0,0,0
+Red=255,48,48
+BoldGreen=85,154,112
+BoldYellow=204,172,0
+BoldBlue=0,153,204
+BoldMagenta=204,105,200
+BoldCyan=122,196,204
+BoldWhite=188,204,204
+Green=85,154,112
+Yellow=204,172,0
+Blue=0,153,204
+Magenta=204,105,200
+Cyan=122,196,204
+White=188,204,204
+BoldBlack=0,0,0
+BoldRed=255,48,48

--- a/mobaxterm/LiquidCarbonTransparentInverse.ini
+++ b/mobaxterm/LiquidCarbonTransparentInverse.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: LiquidCarbonTransparentInverse
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=175,194,194
+CursorColour=255,255,255
+Black=188,204,205
+Red=255,48,48
+BoldGreen=85,154,112
+BoldYellow=204,172,0
+BoldBlue=0,153,204
+BoldMagenta=204,105,200
+BoldCyan=122,196,204
+BoldWhite=0,0,0
+Green=85,154,112
+Yellow=204,172,0
+Blue=0,153,204
+Magenta=204,105,200
+Cyan=122,196,204
+White=0,0,0
+BoldBlack=255,255,255
+BoldRed=255,48,48

--- a/mobaxterm/Man Page.ini
+++ b/mobaxterm/Man Page.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Man Page
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=254,244,156
+ForegroundColour=0,0,0
+CursorColour=127,127,127
+Black=0,0,0
+Red=204,0,0
+BoldGreen=0,217,0
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=153,153,0
+Blue=0,0,178
+Magenta=178,0,178
+Cyan=0,166,178
+White=204,204,204
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Material.ini
+++ b/mobaxterm/Material.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Material
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=234,234,234
+ForegroundColour=35,35,34
+CursorColour=22,175,202
+Black=33,33,33
+Red=183,20,31
+BoldGreen=122,186,58
+BoldYellow=255,234,46
+BoldBlue=84,164,243
+BoldMagenta=170,77,188
+BoldCyan=38,187,209
+BoldWhite=217,217,217
+Green=69,123,36
+Yellow=246,152,30
+Blue=19,78,178
+Magenta=86,0,136
+Cyan=14,113,124
+White=239,239,239
+BoldBlack=66,66,66
+BoldRed=232,59,63

--- a/mobaxterm/MaterialDark.ini
+++ b/mobaxterm/MaterialDark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: MaterialDark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=35,35,34
+ForegroundColour=229,229,229
+CursorColour=22,175,202
+Black=33,33,33
+Red=183,20,31
+BoldGreen=122,186,58
+BoldYellow=255,234,46
+BoldBlue=84,164,243
+BoldMagenta=170,77,188
+BoldCyan=38,187,209
+BoldWhite=217,217,217
+Green=69,123,36
+Yellow=246,152,30
+Blue=19,78,178
+Magenta=86,0,136
+Cyan=14,113,124
+White=239,239,239
+BoldBlack=66,66,66
+BoldRed=232,59,63

--- a/mobaxterm/Mathias.ini
+++ b/mobaxterm/Mathias.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Mathias
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=187,187,187
+CursorColour=187,187,187
+Black=0,0,0
+Red=229,34,34
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=166,227,45
+Yellow=252,149,30
+Blue=196,141,255
+Magenta=250,37,115
+Cyan=103,217,240
+White=242,242,242
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Medallion.ini
+++ b/mobaxterm/Medallion.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Medallion
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,25,8
+ForegroundColour=202,194,150
+CursorColour=211,186,48
+Black=0,0,0
+Red=182,76,0
+BoldGreen=178,202,59
+BoldYellow=255,229,74
+BoldBlue=172,184,255
+BoldMagenta=255,160,255
+BoldCyan=255,188,81
+BoldWhite=254,214,152
+Green=124,139,22
+Yellow=211,189,38
+Blue=97,107,176
+Magenta=140,90,144
+Cyan=145,108,37
+White=202,194,154
+BoldBlack=94,82,25
+BoldRed=255,145,73

--- a/mobaxterm/Misterioso.ini
+++ b/mobaxterm/Misterioso.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Misterioso
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=45,55,67
+ForegroundColour=225,225,224
+CursorColour=0,0,0
+Black=0,0,0
+Red=255,66,66
+BoldGreen=116,205,104
+BoldYellow=255,185,41
+BoldBlue=35,215,215
+BoldMagenta=255,55,255
+BoldCyan=0,237,225
+BoldWhite=255,255,255
+Green=116,175,104
+Yellow=255,173,41
+Blue=51,143,134
+Magenta=148,20,230
+Cyan=35,215,215
+White=225,225,224
+BoldBlack=85,85,85
+BoldRed=255,50,66

--- a/mobaxterm/Molokai.ini
+++ b/mobaxterm/Molokai.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Molokai
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=18,18,18
+ForegroundColour=187,187,187
+CursorColour=187,187,187
+Black=18,18,18
+Red=250,37,115
+BoldGreen=177,224,95
+BoldYellow=255,242,109
+BoldBlue=0,175,255
+BoldMagenta=175,135,255
+BoldCyan=81,206,255
+BoldWhite=255,255,255
+Green=152,225,35
+Yellow=223,212,96
+Blue=16,128,208
+Magenta=135,0,255
+Cyan=67,168,208
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=246,102,157

--- a/mobaxterm/MonaLisa.ini
+++ b/mobaxterm/MonaLisa.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: MonaLisa
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=18,11,13
+ForegroundColour=247,214,106
+CursorColour=196,108,50
+Black=53,27,14
+Red=155,41,28
+BoldGreen=180,178,100
+BoldYellow=255,149,102
+BoldBlue=158,178,180
+BoldMagenta=255,91,106
+BoldCyan=138,205,143
+BoldWhite=255,229,152
+Green=99,98,50
+Yellow=195,110,40
+Blue=81,92,93
+Magenta=155,29,41
+Cyan=88,128,86
+White=247,215,92
+BoldBlack=135,66,40
+BoldRed=255,67,49

--- a/mobaxterm/Monokai Remastered.ini
+++ b/mobaxterm/Monokai Remastered.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Monokai Remastered
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=12,12,12
+ForegroundColour=217,217,217
+CursorColour=252,151,31
+Black=26,26,26
+Red=244,0,95
+BoldGreen=152,224,36
+BoldYellow=224,213,97
+BoldBlue=157,101,255
+BoldMagenta=244,0,95
+BoldCyan=88,209,235
+BoldWhite=246,246,239
+Green=152,224,36
+Yellow=253,151,31
+Blue=157,101,255
+Magenta=244,0,95
+Cyan=88,209,235
+White=196,197,181
+BoldBlack=98,94,76
+BoldRed=244,0,95

--- a/mobaxterm/Monokai Soda.ini
+++ b/mobaxterm/Monokai Soda.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Monokai Soda
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=26,26,26
+ForegroundColour=196,197,181
+CursorColour=246,247,236
+Black=26,26,26
+Red=244,0,95
+BoldGreen=152,224,36
+BoldYellow=224,213,97
+BoldBlue=157,101,255
+BoldMagenta=244,0,95
+BoldCyan=88,209,235
+BoldWhite=246,246,239
+Green=152,224,36
+Yellow=250,132,25
+Blue=157,101,255
+Magenta=244,0,95
+Cyan=88,209,235
+White=196,197,181
+BoldBlack=98,94,76
+BoldRed=244,0,95

--- a/mobaxterm/Monokai Vivid.ini
+++ b/mobaxterm/Monokai Vivid.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Monokai Vivid
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=18,18,18
+ForegroundColour=249,249,249
+CursorColour=251,0,7
+Black=18,18,18
+Red=250,41,52
+BoldGreen=177,224,95
+BoldYellow=255,242,109
+BoldBlue=4,67,255
+BoldMagenta=242,0,246
+BoldCyan=81,206,255
+BoldWhite=255,255,255
+Green=152,225,35
+Yellow=255,243,10
+Blue=4,67,255
+Magenta=248,0,248
+Cyan=1,182,237
+White=255,255,255
+BoldBlack=131,131,131
+BoldRed=246,102,157

--- a/mobaxterm/N0tch2k.ini
+++ b/mobaxterm/N0tch2k.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: N0tch2k
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=160,160,160
+CursorColour=170,145,117
+Black=56,56,56
+Red=169,85,81
+BoldGreen=140,140,140
+BoldYellow=169,145,117
+BoldBlue=152,189,94
+BoldMagenta=163,163,163
+BoldCyan=220,220,220
+BoldWhite=216,200,187
+Green=102,102,102
+Yellow=169,128,81
+Blue=101,125,62
+Magenta=118,118,118
+Cyan=201,201,201
+White=208,184,163
+BoldBlack=71,71,71
+BoldRed=169,119,117

--- a/mobaxterm/Neopolitan.ini
+++ b/mobaxterm/Neopolitan.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Neopolitan
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=39,31,25
+ForegroundColour=255,255,255
+CursorColour=255,255,255
+Black=0,0,0
+Red=128,0,0
+BoldGreen=97,206,60
+BoldYellow=251,222,45
+BoldBlue=37,59,118
+BoldMagenta=255,0,128
+BoldCyan=141,166,206
+BoldWhite=248,248,248
+Green=97,206,60
+Yellow=251,222,45
+Blue=37,59,118
+Magenta=255,0,128
+Cyan=141,166,206
+White=248,248,248
+BoldBlack=0,0,0
+BoldRed=128,0,0

--- a/mobaxterm/Neutron.ini
+++ b/mobaxterm/Neutron.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Neutron
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=28,30,34
+ForegroundColour=230,232,239
+CursorColour=246,247,236
+Black=35,37,43
+Red=181,64,54
+BoldGreen=90,185,119
+BoldYellow=222,181,102
+BoldBlue=106,124,147
+BoldMagenta=164,121,157
+BoldCyan=63,148,168
+BoldWhite=235,237,242
+Green=90,185,119
+Yellow=222,181,102
+Blue=106,124,147
+Magenta=164,121,157
+Cyan=63,148,168
+White=230,232,239
+BoldBlack=35,37,43
+BoldRed=181,64,54

--- a/mobaxterm/NightLion v1.ini
+++ b/mobaxterm/NightLion v1.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: NightLion v1
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=187,187,187
+CursorColour=187,187,187
+Black=76,76,76
+Red=187,0,0
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=95,222,143
+Yellow=243,241,103
+Blue=39,107,216
+Magenta=187,0,187
+Cyan=0,218,223
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/NightLion v2.ini
+++ b/mobaxterm/NightLion v2.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: NightLion v2
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=23,23,23
+ForegroundColour=187,187,187
+CursorColour=187,187,187
+Black=76,76,76
+Red=187,0,0
+BoldGreen=125,247,29
+BoldYellow=255,255,85
+BoldBlue=98,203,232
+BoldMagenta=255,155,245
+BoldCyan=0,204,216
+BoldWhite=255,255,255
+Green=4,246,35
+Yellow=243,241,103
+Blue=100,208,240
+Magenta=206,111,219
+Cyan=0,218,223
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Nocturnal Winter.ini
+++ b/mobaxterm/Nocturnal Winter.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Nocturnal Winter
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=13,13,23
+ForegroundColour=230,229,229
+CursorColour=230,229,229
+Black=77,77,77
+Red=241,45,82
+BoldGreen=10,231,141
+BoldYellow=255,252,103
+BoldBlue=96,150,255
+BoldMagenta=255,120,162
+BoldCyan=10,231,141
+BoldWhite=255,255,255
+Green=9,205,126
+Yellow=245,241,122
+Blue=49,130,224
+Magenta=255,43,109
+Cyan=9,200,122
+White=252,252,252
+BoldBlack=128,128,128
+BoldRed=241,109,134

--- a/mobaxterm/Novel.ini
+++ b/mobaxterm/Novel.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Novel
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=223,219,195
+ForegroundColour=59,35,34
+CursorColour=115,99,90
+Black=0,0,0
+Red=204,0,0
+BoldGreen=0,150,0
+BoldYellow=208,107,0
+BoldBlue=0,0,204
+BoldMagenta=204,0,204
+BoldCyan=0,135,204
+BoldWhite=255,255,255
+Green=0,150,0
+Yellow=208,107,0
+Blue=0,0,204
+Magenta=204,0,204
+Cyan=0,135,204
+White=204,204,204
+BoldBlack=128,128,128
+BoldRed=204,0,0

--- a/mobaxterm/Obsidian.ini
+++ b/mobaxterm/Obsidian.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Obsidian
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=40,48,51
+ForegroundColour=205,205,205
+CursorColour=192,202,208
+Black=0,0,0
+Red=166,0,1
+BoldGreen=147,200,99
+BoldYellow=254,248,116
+BoldBlue=161,215,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=0,187,0
+Yellow=254,205,34
+Blue=58,155,219
+Magenta=187,0,187
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=255,0,3

--- a/mobaxterm/Ocean.ini
+++ b/mobaxterm/Ocean.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Ocean
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,79,188
+ForegroundColour=255,255,255
+CursorColour=127,127,127
+Black=0,0,0
+Red=153,0,0
+BoldGreen=0,217,0
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=153,153,0
+Blue=0,0,178
+Magenta=178,0,178
+Cyan=0,166,178
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/OceanicMaterial.ini
+++ b/mobaxterm/OceanicMaterial.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: OceanicMaterial
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=28,38,43
+ForegroundColour=194,200,215
+CursorColour=179,184,195
+Black=0,0,0
+Red=238,43,42
+BoldGreen=112,190,113
+BoldYellow=255,241,99
+BoldBlue=84,164,243
+BoldMagenta=170,77,188
+BoldCyan=66,199,218
+BoldWhite=255,255,255
+Green=64,163,63
+Yellow=255,234,46
+Blue=30,128,240
+Magenta=136,0,160
+Cyan=22,175,202
+White=164,164,164
+BoldBlack=119,119,119
+BoldRed=220,92,96

--- a/mobaxterm/Ollie.ini
+++ b/mobaxterm/Ollie.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Ollie
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,33,37
+ForegroundColour=138,141,174
+CursorColour=91,110,167
+Black=0,0,0
+Red=172,46,49
+BoldGreen=59,255,153
+BoldYellow=255,94,30
+BoldBlue=68,136,255
+BoldMagenta=255,194,29
+BoldCyan=31,250,255
+BoldWhite=91,110,167
+Green=49,172,97
+Yellow=172,67,0
+Blue=45,87,172
+Magenta=176,133,40
+Cyan=31,166,172
+White=138,142,172
+BoldBlack=91,55,37
+BoldRed=255,61,72

--- a/mobaxterm/OneHalfDark.ini
+++ b/mobaxterm/OneHalfDark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: OneHalfDark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=40,44,52
+ForegroundColour=220,223,228
+CursorColour=163,179,204
+Black=40,44,52
+Red=224,108,117
+BoldGreen=152,195,121
+BoldYellow=229,192,123
+BoldBlue=97,175,239
+BoldMagenta=198,120,221
+BoldCyan=86,182,194
+BoldWhite=220,223,228
+Green=152,195,121
+Yellow=229,192,123
+Blue=97,175,239
+Magenta=198,120,221
+Cyan=86,182,194
+White=220,223,228
+BoldBlack=40,44,52
+BoldRed=224,108,117

--- a/mobaxterm/OneHalfLight.ini
+++ b/mobaxterm/OneHalfLight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: OneHalfLight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=250,250,250
+ForegroundColour=56,58,66
+CursorColour=191,206,255
+Black=56,58,66
+Red=228,86,73
+BoldGreen=152,195,121
+BoldYellow=229,192,123
+BoldBlue=97,175,239
+BoldMagenta=198,120,221
+BoldCyan=86,182,194
+BoldWhite=255,255,255
+Green=80,161,79
+Yellow=193,132,1
+Blue=1,132,188
+Magenta=166,38,164
+Cyan=9,151,179
+White=250,250,250
+BoldBlack=79,82,94
+BoldRed=224,108,117

--- a/mobaxterm/Operator Mono Dark.ini
+++ b/mobaxterm/Operator Mono Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Operator Mono Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=25,25,25
+ForegroundColour=195,202,194
+CursorColour=252,220,8
+Black=90,90,90
+Red=202,55,45
+BoldGreen=131,208,162
+BoldYellow=253,253,197
+BoldBlue=137,211,246
+BoldMagenta=255,44,122
+BoldCyan=130,234,218
+BoldWhite=253,253,246
+Green=77,123,58
+Yellow=212,214,151
+Blue=67,135,207
+Magenta=184,108,180
+Cyan=114,213,198
+White=206,212,205
+BoldBlack=154,155,153
+BoldRed=195,125,98

--- a/mobaxterm/Pandora.ini
+++ b/mobaxterm/Pandora.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Pandora
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=20,30,67
+ForegroundColour=225,225,225
+CursorColour=67,213,142
+Black=0,0,0
+Red=255,66,66
+BoldGreen=116,205,104
+BoldYellow=255,185,41
+BoldBlue=35,215,215
+BoldMagenta=255,55,255
+BoldCyan=0,237,225
+BoldWhite=255,255,255
+Green=116,175,104
+Yellow=255,173,41
+Blue=51,143,134
+Magenta=148,20,230
+Cyan=35,215,215
+White=226,226,226
+BoldBlack=63,86,72
+BoldRed=255,50,66

--- a/mobaxterm/Paraiso Dark.ini
+++ b/mobaxterm/Paraiso Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Paraiso Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=47,30,46
+ForegroundColour=163,158,155
+CursorColour=163,158,155
+Black=47,30,46
+Red=239,97,85
+BoldGreen=72,182,133
+BoldYellow=254,196,24
+BoldBlue=6,182,239
+BoldMagenta=129,91,164
+BoldCyan=91,196,191
+BoldWhite=231,233,219
+Green=72,182,133
+Yellow=254,196,24
+Blue=6,182,239
+Magenta=129,91,164
+Cyan=91,196,191
+White=163,158,155
+BoldBlack=119,110,113
+BoldRed=239,97,85

--- a/mobaxterm/Parasio Dark.ini
+++ b/mobaxterm/Parasio Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Parasio Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=47,30,46
+ForegroundColour=163,158,155
+CursorColour=163,158,155
+Black=47,30,46
+Red=239,97,85
+BoldGreen=72,182,133
+BoldYellow=254,196,24
+BoldBlue=6,182,239
+BoldMagenta=129,91,164
+BoldCyan=91,196,191
+BoldWhite=231,233,219
+Green=72,182,133
+Yellow=254,196,24
+Blue=6,182,239
+Magenta=129,91,164
+Cyan=91,196,191
+White=163,158,155
+BoldBlack=119,110,113
+BoldRed=239,97,85

--- a/mobaxterm/PaulMillr.ini
+++ b/mobaxterm/PaulMillr.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: PaulMillr
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=242,242,242
+CursorColour=77,77,77
+Black=42,42,42
+Red=255,0,0
+BoldGreen=102,255,102
+BoldYellow=243,214,78
+BoldBlue=112,154,237
+BoldMagenta=219,103,230
+BoldCyan=122,223,242
+BoldWhite=255,255,255
+Green=121,255,15
+Yellow=231,191,0
+Blue=57,107,215
+Magenta=180,73,190
+Cyan=102,204,255
+White=187,187,187
+BoldBlack=102,102,102
+BoldRed=255,0,128

--- a/mobaxterm/PencilDark.ini
+++ b/mobaxterm/PencilDark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: PencilDark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=33,33,33
+ForegroundColour=241,241,241
+CursorColour=32,187,252
+Black=33,33,33
+Red=195,7,113
+BoldGreen=95,215,175
+BoldYellow=243,228,48
+BoldBlue=32,187,252
+BoldMagenta=104,85,222
+BoldCyan=79,184,204
+BoldWhite=241,241,241
+Green=16,167,120
+Yellow=168,156,20
+Blue=0,142,196
+Magenta=82,60,121
+Cyan=32,165,186
+White=217,217,217
+BoldBlack=66,66,66
+BoldRed=251,0,122

--- a/mobaxterm/PencilLight.ini
+++ b/mobaxterm/PencilLight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: PencilLight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=241,241,241
+ForegroundColour=66,66,66
+CursorColour=32,187,252
+Black=33,33,33
+Red=195,7,113
+BoldGreen=95,215,175
+BoldYellow=243,228,48
+BoldBlue=32,187,252
+BoldMagenta=104,85,222
+BoldCyan=79,184,204
+BoldWhite=241,241,241
+Green=16,167,120
+Yellow=168,156,20
+Blue=0,142,196
+Magenta=82,60,121
+Cyan=32,165,186
+White=217,217,217
+BoldBlack=66,66,66
+BoldRed=251,0,122

--- a/mobaxterm/Piatto Light.ini
+++ b/mobaxterm/Piatto Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Piatto Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=65,65,65
+CursorColour=94,119,200
+Black=65,65,65
+Red=178,55,113
+BoldGreen=130,148,41
+BoldYellow=205,111,52
+BoldBlue=60,94,168
+BoldMagenta=164,84,178
+BoldCyan=130,148,41
+BoldWhite=242,242,242
+Green=102,120,30
+Yellow=205,111,52
+Blue=60,94,168
+Magenta=164,84,178
+Cyan=102,120,30
+White=255,255,255
+BoldBlack=63,63,63
+BoldRed=219,51,101

--- a/mobaxterm/Pnevma.ini
+++ b/mobaxterm/Pnevma.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Pnevma
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=28,28,28
+ForegroundColour=208,208,208
+CursorColour=228,201,175
+Black=47,46,45
+Red=163,102,102
+BoldGreen=175,190,162
+BoldYellow=228,201,175
+BoldBlue=161,189,206
+BoldMagenta=215,190,218
+BoldCyan=177,231,221
+BoldWhite=239,239,239
+Green=144,165,125
+Yellow=215,175,135
+Blue=127,165,189
+Magenta=199,158,196
+Cyan=138,219,180
+White=208,208,208
+BoldBlack=74,72,69
+BoldRed=215,135,135

--- a/mobaxterm/Pro Light.ini
+++ b/mobaxterm/Pro Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Pro Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=25,25,25
+CursorColour=77,77,77
+Black=0,0,0
+Red=229,73,43
+BoldGreen=97,239,87
+BoldYellow=242,241,86
+BoldBlue=0,130,255
+BoldMagenta=255,126,255
+BoldCyan=97,247,248
+BoldWhite=242,242,242
+Green=80,209,72
+Yellow=198,196,64
+Blue=59,117,255
+Magenta=237,102,232
+Cyan=78,210,222
+White=220,220,220
+BoldBlack=159,159,159
+BoldRed=255,102,64

--- a/mobaxterm/Pro.ini
+++ b/mobaxterm/Pro.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Pro
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=242,242,242
+CursorColour=77,77,77
+Black=0,0,0
+Red=153,0,0
+BoldGreen=0,217,0
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=153,153,0
+Blue=32,9,219
+Magenta=178,0,178
+Cyan=0,166,178
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Purple Rain.ini
+++ b/mobaxterm/Purple Rain.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Purple Rain
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=33,8,74
+ForegroundColour=255,251,246
+CursorColour=255,39,29
+Black=0,0,0
+Red=255,38,14
+BoldGreen=184,227,110
+BoldYellow=255,216,82
+BoldBlue=0,166,255
+BoldMagenta=172,123,240
+BoldCyan=116,253,243
+BoldWhite=255,255,255
+Green=155,226,5
+Yellow=255,196,0
+Blue=0,162,250
+Magenta=129,91,181
+Cyan=0,222,239
+White=255,255,255
+BoldBlack=86,86,86
+BoldRed=255,66,80

--- a/mobaxterm/Red Alert.ini
+++ b/mobaxterm/Red Alert.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Red Alert
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=118,36,35
+ForegroundColour=255,255,255
+CursorColour=255,255,255
+Black=0,0,0
+Red=214,46,78
+BoldGreen=175,240,140
+BoldYellow=223,221,183
+BoldBlue=101,170,241
+BoldMagenta=221,183,223
+BoldCyan=183,223,221
+BoldWhite=255,255,255
+Green=113,190,107
+Yellow=190,184,107
+Blue=72,155,238
+Magenta=233,121,215
+Cyan=107,190,184
+White=214,214,214
+BoldBlack=38,38,38
+BoldRed=224,37,83

--- a/mobaxterm/Red Planet.ini
+++ b/mobaxterm/Red Planet.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Red Planet
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=194,183,144
+CursorColour=194,183,144
+Black=32,32,32
+Red=140,52,50
+BoldGreen=134,153,133
+BoldYellow=235,235,145
+BoldBlue=96,130,126
+BoldMagenta=222,73,116
+BoldCyan=56,173,216
+BoldWhite=214,191,184
+Green=114,130,113
+Yellow=232,191,106
+Blue=105,129,158
+Magenta=137,100,146
+Cyan=91,131,144
+White=185,170,153
+BoldBlack=103,103,103
+BoldRed=181,82,66

--- a/mobaxterm/Red Sands.ini
+++ b/mobaxterm/Red Sands.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Red Sands
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=122,37,30
+ForegroundColour=215,201,167
+CursorColour=255,255,255
+Black=0,0,0
+Red=255,63,0
+BoldGreen=0,187,0
+BoldYellow=231,176,0
+BoldBlue=0,114,174
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=0,187,0
+Yellow=231,176,0
+Blue=0,114,255
+Magenta=187,0,187
+Cyan=0,187,187
+White=187,187,187
+BoldBlack=85,85,85
+BoldRed=187,0,0

--- a/mobaxterm/Relaxed.ini
+++ b/mobaxterm/Relaxed.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Relaxed
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=53,58,68
+ForegroundColour=217,217,217
+CursorColour=217,217,217
+Black=21,21,21
+Red=188,86,83
+BoldGreen=160,172,119
+BoldYellow=235,193,122
+BoldBlue=126,170,199
+BoldMagenta=176,102,152
+BoldCyan=172,187,208
+BoldWhite=247,247,247
+Green=144,157,99
+Yellow=235,193,122
+Blue=106,135,153
+Magenta=176,102,152
+Cyan=201,223,255
+White=217,217,217
+BoldBlack=99,99,99
+BoldRed=188,86,83

--- a/mobaxterm/Rippedcasts.ini
+++ b/mobaxterm/Rippedcasts.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Rippedcasts
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=43,43,43
+ForegroundColour=255,255,255
+CursorColour=127,127,127
+Black=0,0,0
+Red=205,175,149
+BoldGreen=188,238,104
+BoldYellow=229,229,0
+BoldBlue=134,189,201
+BoldMagenta=229,0,229
+BoldCyan=140,155,196
+BoldWhite=229,229,229
+Green=168,255,96
+Yellow=191,187,31
+Blue=117,165,176
+Magenta=255,115,253
+Cyan=90,100,126
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=238,203,173

--- a/mobaxterm/Royal.ini
+++ b/mobaxterm/Royal.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Royal
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=16,8,21
+ForegroundColour=81,73,104
+CursorColour=82,73,102
+Black=36,31,43
+Red=145,40,76
+BoldGreen=44,217,70
+BoldYellow=253,232,59
+BoldBlue=144,186,249
+BoldMagenta=164,121,227
+BoldCyan=172,212,235
+BoldWhite=158,140,189
+Green=35,128,28
+Yellow=180,157,39
+Blue=101,128,176
+Magenta=103,77,150
+Cyan=138,170,190
+White=82,73,102
+BoldBlack=49,45,61
+BoldRed=213,53,108

--- a/mobaxterm/Ryuuko.ini
+++ b/mobaxterm/Ryuuko.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Ryuuko
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=44,57,65
+ForegroundColour=236,236,236
+CursorColour=236,236,236
+Black=44,57,65
+Red=134,95,91
+BoldGreen=102,144,125
+BoldYellow=177,169,144
+BoldBlue=106,142,149
+BoldMagenta=177,138,115
+BoldCyan=136,178,172
+BoldWhite=236,236,236
+Green=102,144,125
+Yellow=177,169,144
+Blue=106,142,149
+Magenta=177,138,115
+Cyan=136,178,172
+White=236,236,236
+BoldBlack=93,112,121
+BoldRed=134,95,91

--- a/mobaxterm/SeaShells.ini
+++ b/mobaxterm/SeaShells.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: SeaShells
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=9,20,27
+ForegroundColour=222,184,141
+CursorColour=252,160,47
+Black=23,56,76
+Red=209,81,35
+BoldGreen=98,141,152
+BoldYellow=253,211,159
+BoldBlue=27,188,221
+BoldMagenta=187,227,238
+BoldCyan=135,172,180
+BoldWhite=254,228,206
+Green=2,124,155
+Yellow=252,160,47
+Blue=30,73,80
+Magenta=104,212,241
+Cyan=80,163,181
+White=222,184,141
+BoldBlack=67,75,83
+BoldRed=212,134,120

--- a/mobaxterm/Seafoam Pastel.ini
+++ b/mobaxterm/Seafoam Pastel.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Seafoam Pastel
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=36,52,53
+ForegroundColour=212,231,212
+CursorColour=87,100,122
+Black=117,117,117
+Red=130,93,77
+BoldGreen=152,217,170
+BoldYellow=250,231,157
+BoldBlue=122,195,207
+BoldMagenta=214,178,161
+BoldCyan=173,224,224
+BoldWhite=224,224,224
+Green=114,140,98
+Yellow=173,161,109
+Blue=77,123,130
+Magenta=138,114,103
+Cyan=114,148,148
+White=224,224,224
+BoldBlack=138,138,138
+BoldRed=207,147,122

--- a/mobaxterm/Seti.ini
+++ b/mobaxterm/Seti.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Seti
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=17,18,19
+ForegroundColour=202,206,205
+CursorColour=227,191,33
+Black=50,50,50
+Red=194,40,50
+BoldGreen=142,196,61
+BoldYellow=224,198,79
+BoldBlue=67,165,213
+BoldMagenta=139,87,181
+BoldCyan=142,196,61
+BoldWhite=255,255,255
+Green=142,196,61
+Yellow=224,198,79
+Blue=67,165,213
+Magenta=139,87,181
+Cyan=142,196,61
+White=238,238,238
+BoldBlack=50,50,50
+BoldRed=194,40,50

--- a/mobaxterm/Shaman.ini
+++ b/mobaxterm/Shaman.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Shaman
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,16,21
+ForegroundColour=64,85,85
+CursorColour=74,252,214
+Black=1,32,38
+Red=178,48,45
+BoldGreen=42,234,94
+BoldYellow=142,212,253
+BoldBlue=97,213,186
+BoldMagenta=18,152,255
+BoldCyan=152,208,40
+BoldWhite=88,251,214
+Green=0,169,65
+Yellow=94,139,170
+Blue=68,154,134
+Magenta=0,89,157
+Cyan=93,126,25
+White=64,85,85
+BoldBlack=56,68,81
+BoldRed=255,66,66

--- a/mobaxterm/Slate.ini
+++ b/mobaxterm/Slate.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Slate
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=53,177,210
+CursorColour=135,211,196
+Black=34,34,34
+Red=226,168,191
+BoldGreen=190,255,168
+BoldYellow=208,204,202
+BoldBlue=122,176,210
+BoldMagenta=197,167,217
+BoldCyan=140,223,224
+BoldWhite=224,224,224
+Green=129,215,120
+Yellow=196,201,192
+Blue=38,75,73
+Magenta=164,129,211
+Cyan=21,171,156
+White=2,197,224
+BoldBlack=255,255,255
+BoldRed=255,205,217

--- a/mobaxterm/Smyck.ini
+++ b/mobaxterm/Smyck.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Smyck
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,27,27
+ForegroundColour=247,247,247
+CursorColour=187,187,187
+Black=0,0,0
+Red=184,65,49
+BoldGreen=196,241,55
+BoldYellow=254,225,77
+BoldBlue=141,207,240
+BoldMagenta=247,154,255
+BoldCyan=106,217,207
+BoldWhite=247,247,247
+Green=125,169,0
+Yellow=196,165,0
+Blue=98,163,196
+Magenta=186,138,204
+Cyan=32,115,131
+White=161,161,161
+BoldBlack=122,122,122
+BoldRed=214,131,124

--- a/mobaxterm/Snazzy.ini
+++ b/mobaxterm/Snazzy.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Snazzy
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=30,31,41
+ForegroundColour=235,236,230
+CursorColour=228,228,228
+Black=0,0,0
+Red=252,67,70
+BoldGreen=80,251,124
+BoldYellow=240,251,140
+BoldBlue=73,186,255
+BoldMagenta=252,76,180
+BoldCyan=139,233,254
+BoldWhite=237,237,236
+Green=80,251,124
+Yellow=240,251,140
+Blue=73,186,255
+Magenta=252,76,180
+Cyan=139,233,254
+White=237,237,236
+BoldBlack=85,85,85
+BoldRed=252,67,70

--- a/mobaxterm/SoftServer.ini
+++ b/mobaxterm/SoftServer.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: SoftServer
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=36,38,38
+ForegroundColour=153,163,162
+CursorColour=210,224,222
+Black=0,0,0
+Red=162,104,106
+BoldGreen=191,223,85
+BoldYellow=222,179,96
+BoldBlue=98,177,223
+BoldMagenta=96,110,223
+BoldCyan=100,227,156
+BoldWhite=210,224,222
+Green=154,165,106
+Yellow=163,144,106
+Blue=107,143,163
+Magenta=106,113,163
+Cyan=107,165,143
+White=153,163,162
+BoldBlack=102,108,108
+BoldRed=221,92,96

--- a/mobaxterm/Solarized Darcula.ini
+++ b/mobaxterm/Solarized Darcula.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Solarized Darcula
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=61,63,65
+ForegroundColour=210,216,217
+CursorColour=112,130,132
+Black=37,41,42
+Red=242,72,64
+BoldGreen=98,150,85
+BoldYellow=182,136,0
+BoldBlue=32,117,199
+BoldMagenta=121,127,212
+BoldCyan=21,150,141
+BoldWhite=210,216,217
+Green=98,150,85
+Yellow=182,136,0
+Blue=32,117,199
+Magenta=121,127,212
+Cyan=21,150,141
+White=210,216,217
+BoldBlack=37,41,42
+BoldRed=242,72,64

--- a/mobaxterm/Solarized Dark - Patched.ini
+++ b/mobaxterm/Solarized Dark - Patched.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Solarized Dark - Patched
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,30,39
+ForegroundColour=112,130,132
+CursorColour=112,130,132
+Black=0,40,49
+Red=209,28,36
+BoldGreen=71,91,98
+BoldYellow=83,104,112
+BoldBlue=112,130,132
+BoldMagenta=89,86,186
+BoldCyan=129,144,144
+BoldWhite=252,244,220
+Green=115,138,5
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=71,91,98
+BoldRed=189,54,19

--- a/mobaxterm/Solarized Dark Higher Contrast.ini
+++ b/mobaxterm/Solarized Dark Higher Contrast.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Solarized Dark Higher Contrast
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,30,39
+ForegroundColour=156,194,195
+CursorColour=243,75,0
+Black=0,40,49
+Red=209,28,36
+BoldGreen=81,239,132
+BoldYellow=178,126,40
+BoldBlue=23,142,200
+BoldMagenta=226,77,142
+BoldCyan=0,179,158
+BoldWhite=252,244,220
+Green=108,190,108
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=0,100,136
+BoldRed=245,22,59

--- a/mobaxterm/Solarized Dark.ini
+++ b/mobaxterm/Solarized Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Solarized Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,30,39
+ForegroundColour=112,130,132
+CursorColour=112,130,132
+Black=0,40,49
+Red=209,28,36
+BoldGreen=71,91,98
+BoldYellow=83,104,112
+BoldBlue=112,130,132
+BoldMagenta=89,86,186
+BoldCyan=129,144,144
+BoldWhite=252,244,220
+Green=115,138,5
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=0,30,39
+BoldRed=189,54,19

--- a/mobaxterm/Solarized Light.ini
+++ b/mobaxterm/Solarized Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Solarized Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=252,244,220
+ForegroundColour=83,104,112
+CursorColour=83,104,112
+Black=0,40,49
+Red=209,28,36
+BoldGreen=71,91,98
+BoldYellow=83,104,112
+BoldBlue=112,130,132
+BoldMagenta=89,86,186
+BoldCyan=129,144,144
+BoldWhite=252,244,220
+Green=115,138,5
+Yellow=165,119,6
+Blue=33,118,199
+Magenta=198,28,111
+Cyan=37,146,134
+White=234,227,203
+BoldBlack=0,30,39
+BoldRed=189,54,19

--- a/mobaxterm/SpaceGray Eighties Dull.ini
+++ b/mobaxterm/SpaceGray Eighties Dull.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: SpaceGray Eighties Dull
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=201,198,188
+CursorColour=187,187,187
+Black=21,23,28
+Red=178,74,86
+BoldGreen=137,233,134
+BoldYellow=254,194,84
+BoldBlue=84,134,192
+BoldMagenta=191,131,193
+BoldCyan=88,194,193
+BoldWhite=255,255,255
+Green=146,180,119
+Yellow=198,115,90
+Blue=124,143,165
+Magenta=165,120,158
+Cyan=128,205,203
+White=179,184,195
+BoldBlack=85,85,85
+BoldRed=236,95,103

--- a/mobaxterm/SpaceGray Eighties.ini
+++ b/mobaxterm/SpaceGray Eighties.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: SpaceGray Eighties
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=34,34,34
+ForegroundColour=189,186,174
+CursorColour=187,187,187
+Black=21,23,28
+Red=236,95,103
+BoldGreen=147,212,147
+BoldYellow=255,210,86
+BoldBlue=77,132,209
+BoldMagenta=255,85,255
+BoldCyan=131,233,228
+BoldWhite=255,255,255
+Green=129,167,100
+Yellow=254,194,84
+Blue=84,134,192
+Magenta=191,131,193
+Cyan=87,194,193
+White=239,236,231
+BoldBlack=85,85,85
+BoldRed=255,105,115

--- a/mobaxterm/SpaceGray.ini
+++ b/mobaxterm/SpaceGray.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: SpaceGray
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=32,36,45
+ForegroundColour=179,184,195
+CursorColour=179,184,195
+Black=0,0,0
+Red=176,75,87
+BoldGreen=135,179,121
+BoldYellow=229,193,121
+BoldBlue=125,143,164
+BoldMagenta=164,121,150
+BoldCyan=133,167,165
+BoldWhite=255,255,255
+Green=135,179,121
+Yellow=229,193,121
+Blue=125,143,164
+Magenta=164,121,150
+Cyan=133,167,165
+White=179,184,195
+BoldBlack=0,0,0
+BoldRed=176,75,87

--- a/mobaxterm/Spacedust.ini
+++ b/mobaxterm/Spacedust.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Spacedust
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=10,30,36
+ForegroundColour=236,240,193
+CursorColour=112,130,132
+Black=110,83,70
+Red=227,91,0
+BoldGreen=174,202,184
+BoldYellow=255,200,120
+BoldBlue=103,160,206
+BoldMagenta=255,138,58
+BoldCyan=131,167,180
+BoldWhite=254,255,241
+Green=92,171,150
+Yellow=227,205,123
+Blue=15,84,139
+Magenta=227,91,0
+Cyan=6,175,199
+White=240,241,206
+BoldBlack=104,76,49
+BoldRed=255,138,58

--- a/mobaxterm/Spiderman.ini
+++ b/mobaxterm/Spiderman.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Spiderman
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,29,30
+ForegroundColour=227,227,227
+CursorColour=44,63,255
+Black=27,29,30
+Red=230,8,19
+BoldGreen=255,51,56
+BoldYellow=254,58,53
+BoldBlue=29,80,255
+BoldMagenta=116,124,255
+BoldCyan=97,132,255
+BoldWhite=255,255,249
+Green=226,41,40
+Yellow=226,71,86
+Blue=44,63,255
+Magenta=36,53,219
+Cyan=50,86,255
+White=255,254,246
+BoldBlack=80,83,84
+BoldRed=255,3,37

--- a/mobaxterm/Spring.ini
+++ b/mobaxterm/Spring.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Spring
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=77,77,76
+CursorColour=77,77,76
+Black=0,0,0
+Red=255,77,131
+BoldGreen=31,194,49
+BoldYellow=213,184,7
+BoldBlue=21,169,253
+BoldMagenta=137,89,168
+BoldCyan=62,153,159
+BoldWhite=255,255,255
+Green=31,140,59
+Yellow=31,201,91
+Blue=29,211,238
+Magenta=137,89,168
+Cyan=62,153,159
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=255,0,33

--- a/mobaxterm/Square.ini
+++ b/mobaxterm/Square.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Square
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=26,26,26
+ForegroundColour=172,172,171
+CursorColour=252,251,204
+Black=5,5,5
+Red=233,137,124
+BoldGreen=195,247,134
+BoldYellow=252,251,204
+BoldBlue=182,222,251
+BoldMagenta=173,127,168
+BoldCyan=215,217,252
+BoldWhite=226,226,226
+Green=182,55,125
+Yellow=236,235,190
+Blue=169,205,235
+Magenta=117,80,123
+Cyan=201,202,236
+White=242,242,242
+BoldBlack=20,20,20
+BoldRed=249,146,134

--- a/mobaxterm/Sundried.ini
+++ b/mobaxterm/Sundried.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Sundried
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=26,24,24
+ForegroundColour=201,201,201
+CursorColour=255,255,255
+Black=48,43,42
+Red=167,70,61
+BoldGreen=18,140,33
+BoldYellow=252,106,33
+BoldBlue=121,153,247
+BoldMagenta=253,138,161
+BoldCyan=250,212,132
+BoldWhite=255,255,255
+Green=88,119,68
+Yellow=157,96,42
+Blue=72,91,152
+Magenta=134,70,81
+Cyan=156,129,79
+White=201,201,201
+BoldBlack=77,78,72
+BoldRed=170,0,12

--- a/mobaxterm/Symfonic.ini
+++ b/mobaxterm/Symfonic.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Symfonic
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=255,255,255
+CursorColour=220,50,47
+Black=0,0,0
+Red=220,50,47
+BoldGreen=86,219,58
+BoldYellow=255,132,0
+BoldBlue=0,132,212
+BoldMagenta=183,41,217
+BoldCyan=204,204,255
+BoldWhite=255,255,255
+Green=86,219,58
+Yellow=255,132,0
+Blue=0,132,212
+Magenta=183,41,217
+Cyan=204,204,255
+White=255,255,255
+BoldBlack=27,29,33
+BoldRed=220,50,47

--- a/mobaxterm/Tango Adapted.ini
+++ b/mobaxterm/Tango Adapted.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tango Adapted
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=0,0,0
+Black=0,0,0
+Red=255,0,0
+BoldGreen=147,255,0
+BoldYellow=255,241,33
+BoldBlue=136,201,255
+BoldMagenta=233,167,225
+BoldCyan=0,254,255
+BoldWhite=246,246,244
+Green=89,214,0
+Yellow=240,203,0
+Blue=0,162,255
+Magenta=193,126,204
+Cyan=0,208,214
+White=230,235,225
+BoldBlack=143,146,139
+BoldRed=255,0,19

--- a/mobaxterm/Tango Half Adapted.ini
+++ b/mobaxterm/Tango Half Adapted.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tango Half Adapted
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=0,0,0
+Black=0,0,0
+Red=255,0,0
+BoldGreen=138,246,0
+BoldYellow=255,236,0
+BoldBlue=118,191,255
+BoldMagenta=216,152,209
+BoldCyan=0,246,250
+BoldWhite=244,244,242
+Green=76,195,0
+Yellow=226,192,0
+Blue=0,142,246
+Magenta=169,108,179
+Cyan=0,189,195
+White=224,229,219
+BoldBlack=121,125,118
+BoldRed=255,0,19

--- a/mobaxterm/Teerb.ini
+++ b/mobaxterm/Teerb.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Teerb
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=38,38,38
+ForegroundColour=208,208,208
+CursorColour=228,201,175
+Black=28,28,28
+Red=214,134,134
+BoldGreen=174,214,134
+BoldYellow=228,201,175
+BoldBlue=134,174,214
+BoldMagenta=214,174,214
+BoldCyan=177,231,221
+BoldWhite=239,239,239
+Green=174,214,134
+Yellow=215,175,135
+Blue=134,174,214
+Magenta=214,174,214
+Cyan=138,219,180
+White=208,208,208
+BoldBlack=28,28,28
+BoldRed=214,134,134

--- a/mobaxterm/Terminal Basic.ini
+++ b/mobaxterm/Terminal Basic.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Terminal Basic
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=127,127,127
+Black=0,0,0
+Red=153,0,0
+BoldGreen=0,217,0
+BoldYellow=229,229,0
+BoldBlue=0,0,255
+BoldMagenta=229,0,229
+BoldCyan=0,229,229
+BoldWhite=229,229,229
+Green=0,166,0
+Yellow=153,153,0
+Blue=0,0,178
+Magenta=178,0,178
+Cyan=0,166,178
+White=191,191,191
+BoldBlack=102,102,102
+BoldRed=229,0,0

--- a/mobaxterm/Thayer Bright.ini
+++ b/mobaxterm/Thayer Bright.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Thayer Bright
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,29,30
+ForegroundColour=248,248,248
+CursorColour=252,151,31
+Black=27,29,30
+Red=249,38,114
+BoldGreen=182,227,84
+BoldYellow=254,237,108
+BoldBlue=63,120,255
+BoldMagenta=158,111,254
+BoldCyan=35,207,213
+BoldWhite=248,248,242
+Green=77,248,64
+Yellow=244,253,34
+Blue=39,87,214
+Magenta=140,84,254
+Cyan=56,200,181
+White=204,204,198
+BoldBlack=80,83,84
+BoldRed=255,89,149

--- a/mobaxterm/The Hulk.ini
+++ b/mobaxterm/The Hulk.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: The Hulk
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,29,30
+ForegroundColour=181,181,181
+CursorColour=22,182,27
+Black=27,29,30
+Red=38,157,27
+BoldGreen=72,255,119
+BoldYellow=58,254,22
+BoldBlue=80,107,149
+BoldMagenta=114,88,157
+BoldCyan=64,133,166
+BoldWhite=229,230,225
+Green=19,206,48
+Yellow=99,228,87
+Blue=37,37,245
+Magenta=100,31,116
+Cyan=55,140,169
+White=217,216,209
+BoldBlack=80,83,84
+BoldRed=141,255,42

--- a/mobaxterm/Tomorrow Night Blue.ini
+++ b/mobaxterm/Tomorrow Night Blue.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow Night Blue
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,36,81
+ForegroundColour=255,255,255
+CursorColour=255,255,255
+Black=0,0,0
+Red=255,157,164
+BoldGreen=209,241,169
+BoldYellow=255,238,173
+BoldBlue=187,218,255
+BoldMagenta=235,187,255
+BoldCyan=153,255,255
+BoldWhite=255,255,255
+Green=209,241,169
+Yellow=255,238,173
+Blue=187,218,255
+Magenta=235,187,255
+Cyan=153,255,255
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=255,157,164

--- a/mobaxterm/Tomorrow Night Bright.ini
+++ b/mobaxterm/Tomorrow Night Bright.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow Night Bright
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=234,234,234
+CursorColour=234,234,234
+Black=0,0,0
+Red=213,78,83
+BoldGreen=185,202,74
+BoldYellow=231,197,71
+BoldBlue=122,166,218
+BoldMagenta=195,151,216
+BoldCyan=112,192,177
+BoldWhite=255,255,255
+Green=185,202,74
+Yellow=231,197,71
+Blue=122,166,218
+Magenta=195,151,216
+Cyan=112,192,177
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=213,78,83

--- a/mobaxterm/Tomorrow Night Burns.ini
+++ b/mobaxterm/Tomorrow Night Burns.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow Night Burns
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=21,21,21
+ForegroundColour=161,176,184
+CursorColour=255,68,62
+Black=37,37,37
+Red=131,46,49
+BoldGreen=166,60,64
+BoldYellow=210,73,78
+BoldBlue=252,89,95
+BoldMagenta=223,147,149
+BoldCyan=186,133,134
+BoldWhite=245,245,245
+Green=166,60,64
+Yellow=211,73,78
+Blue=252,89,95
+Magenta=223,147,149
+Cyan=186,133,134
+White=245,245,245
+BoldBlack=93,111,113
+BoldRed=131,46,49

--- a/mobaxterm/Tomorrow Night Eighties.ini
+++ b/mobaxterm/Tomorrow Night Eighties.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow Night Eighties
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=45,45,45
+ForegroundColour=204,204,204
+CursorColour=204,204,204
+Black=0,0,0
+Red=242,119,122
+BoldGreen=153,204,153
+BoldYellow=255,204,102
+BoldBlue=102,153,204
+BoldMagenta=204,153,204
+BoldCyan=102,204,204
+BoldWhite=255,255,255
+Green=153,204,153
+Yellow=255,204,102
+Blue=102,153,204
+Magenta=204,153,204
+Cyan=102,204,204
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=242,119,122

--- a/mobaxterm/Tomorrow Night.ini
+++ b/mobaxterm/Tomorrow Night.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow Night
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,31,33
+ForegroundColour=197,200,198
+CursorColour=197,200,198
+Black=0,0,0
+Red=204,102,102
+BoldGreen=181,189,104
+BoldYellow=240,198,116
+BoldBlue=129,162,190
+BoldMagenta=178,148,187
+BoldCyan=138,190,183
+BoldWhite=255,255,255
+Green=181,189,104
+Yellow=240,198,116
+Blue=129,162,190
+Magenta=178,148,187
+Cyan=138,190,183
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=204,102,102

--- a/mobaxterm/Tomorrow.ini
+++ b/mobaxterm/Tomorrow.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Tomorrow
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=77,77,76
+CursorColour=77,77,76
+Black=0,0,0
+Red=200,40,41
+BoldGreen=113,140,0
+BoldYellow=234,183,0
+BoldBlue=66,113,174
+BoldMagenta=137,89,168
+BoldCyan=62,153,159
+BoldWhite=255,255,255
+Green=113,140,0
+Yellow=234,183,0
+Blue=66,113,174
+Magenta=137,89,168
+Cyan=62,153,159
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=200,40,41

--- a/mobaxterm/ToyChest.ini
+++ b/mobaxterm/ToyChest.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ToyChest
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=36,54,75
+ForegroundColour=49,208,123
+CursorColour=213,213,213
+Black=44,63,88
+Red=190,45,38
+BoldGreen=49,208,123
+BoldYellow=231,216,75
+BoldBlue=52,166,218
+BoldMagenta=174,107,220
+BoldCyan=66,195,174
+BoldWhite=213,213,213
+Green=26,145,114
+Yellow=219,142,39
+Blue=50,93,150
+Magenta=138,94,220
+Cyan=53,160,143
+White=35,209,131
+BoldBlack=51,104,137
+BoldRed=221,89,68

--- a/mobaxterm/Treehouse.ini
+++ b/mobaxterm/Treehouse.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Treehouse
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=25,25,25
+ForegroundColour=120,107,83
+CursorColour=250,200,20
+Black=50,19,0
+Red=178,39,14
+BoldGreen=85,242,56
+BoldYellow=242,183,50
+BoldBlue=133,207,237
+BoldMagenta=225,76,90
+BoldCyan=240,125,20
+BoldWhite=255,200,0
+Green=68,169,0
+Yellow=170,130,12
+Blue=88,133,154
+Magenta=151,54,61
+Cyan=178,90,30
+White=120,107,83
+BoldBlack=67,54,38
+BoldRed=237,93,32

--- a/mobaxterm/Twilight.ini
+++ b/mobaxterm/Twilight.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Twilight
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=20,20,20
+ForegroundColour=255,255,212
+CursorColour=255,255,255
+Black=20,20,20
+Red=192,109,68
+BoldGreen=204,216,140
+BoldYellow=226,196,126
+BoldBlue=90,94,98
+BoldMagenta=208,220,142
+BoldCyan=138,152,155
+BoldWhite=255,255,212
+Green=175,185,122
+Yellow=194,168,108
+Blue=68,71,74
+Magenta=180,190,124
+Cyan=119,131,133
+White=255,255,212
+BoldBlack=38,38,38
+BoldRed=222,124,76

--- a/mobaxterm/Ubuntu.ini
+++ b/mobaxterm/Ubuntu.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Ubuntu
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=48,10,36
+ForegroundColour=238,238,236
+CursorColour=187,187,187
+Black=46,52,54
+Red=204,0,0
+BoldGreen=138,226,52
+BoldYellow=252,233,79
+BoldBlue=114,159,207
+BoldMagenta=173,127,168
+BoldCyan=52,226,226
+BoldWhite=238,238,236
+Green=78,154,6
+Yellow=196,160,0
+Blue=52,101,164
+Magenta=117,80,123
+Cyan=6,152,154
+White=211,215,207
+BoldBlack=85,87,83
+BoldRed=239,41,41

--- a/mobaxterm/UltraViolent.ini
+++ b/mobaxterm/UltraViolent.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: UltraViolent
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=36,39,40
+ForegroundColour=193,193,193
+CursorColour=193,193,193
+Black=36,39,40
+Red=255,0,144
+BoldGreen=222,255,140
+BoldYellow=235,224,135
+BoldBlue=127,236,255
+BoldMagenta=230,129,255
+BoldCyan=105,252,211
+BoldWhite=249,249,245
+Green=182,255,0
+Yellow=255,247,39
+Blue=71,224,251
+Magenta=215,49,255
+Cyan=14,255,187
+White=225,225,225
+BoldBlack=99,102,103
+BoldRed=251,88,180

--- a/mobaxterm/UnderTheSea.ini
+++ b/mobaxterm/UnderTheSea.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: UnderTheSea
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=1,17,22
+ForegroundColour=255,255,255
+CursorColour=74,252,214
+Black=2,32,38
+Red=178,48,45
+BoldGreen=42,234,94
+BoldYellow=142,212,253
+BoldBlue=97,213,186
+BoldMagenta=18,152,255
+BoldCyan=152,208,40
+BoldWhite=88,251,214
+Green=0,169,65
+Yellow=89,129,156
+Blue=69,154,134
+Magenta=0,89,157
+Cyan=93,126,25
+White=64,85,85
+BoldBlack=56,68,81
+BoldRed=255,66,66

--- a/mobaxterm/Unikitty.ini
+++ b/mobaxterm/Unikitty.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Unikitty
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,140,217
+ForegroundColour=11,11,11
+CursorColour=186,252,139
+Black=12,12,12
+Red=168,15,32
+BoldGreen=211,255,175
+BoldYellow=255,239,80
+BoldBlue=0,117,234
+BoldMagenta=253,213,229
+BoldCyan=121,236,213
+BoldWhite=255,243,254
+Green=186,252,139
+Yellow=238,223,75
+Blue=20,95,205
+Magenta=255,54,162
+Cyan=107,209,188
+White=226,215,225
+BoldBlack=67,67,67
+BoldRed=217,19,41

--- a/mobaxterm/Urple.ini
+++ b/mobaxterm/Urple.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Urple
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=27,27,35
+ForegroundColour=135,122,155
+CursorColour=160,99,235
+Black=0,0,0
+Red=176,66,91
+BoldGreen=41,230,32
+BoldYellow=240,129,97
+BoldBlue=134,122,237
+BoldMagenta=160,94,238
+BoldCyan=234,234,234
+BoldWhite=191,163,255
+Green=55,164,21
+Yellow=173,92,66
+Blue=86,77,155
+Magenta=108,60,161
+Cyan=128,128,128
+White=135,121,156
+BoldBlack=93,50,37
+BoldRed=255,99,136

--- a/mobaxterm/Vaughn.ini
+++ b/mobaxterm/Vaughn.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Vaughn
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=37,35,79
+ForegroundColour=220,220,204
+CursorColour=255,85,85
+Black=37,35,79
+Red=112,80,80
+BoldGreen=96,180,138
+BoldYellow=240,223,175
+BoldBlue=85,85,255
+BoldMagenta=236,147,211
+BoldCyan=147,224,227
+BoldWhite=255,255,255
+Green=96,180,138
+Yellow=223,175,143
+Blue=85,85,255
+Magenta=240,140,195
+Cyan=140,208,211
+White=112,144,128
+BoldBlack=112,144,128
+BoldRed=220,163,163

--- a/mobaxterm/VibrantInk.ini
+++ b/mobaxterm/VibrantInk.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: VibrantInk
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=255,255,255
+CursorColour=255,255,255
+Black=135,135,135
+Red=255,102,0
+BoldGreen=0,255,0
+BoldYellow=255,255,0
+BoldBlue=0,0,255
+BoldMagenta=255,0,255
+BoldCyan=0,255,255
+BoldWhite=229,229,229
+Green=204,255,4
+Yellow=255,204,0
+Blue=68,180,204
+Magenta=153,51,204
+Cyan=68,180,204
+White=245,245,245
+BoldBlack=85,85,85
+BoldRed=255,0,0

--- a/mobaxterm/Violet Dark.ini
+++ b/mobaxterm/Violet Dark.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Violet Dark
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=28,29,31
+ForegroundColour=112,130,132
+CursorColour=112,130,132
+Black=86,89,92
+Red=201,76,34
+BoldGreen=115,138,4
+BoldYellow=165,119,5
+BoldBlue=33,118,199
+BoldMagenta=198,28,111
+BoldCyan=37,146,134
+BoldWhite=201,198,189
+Green=133,152,28
+Yellow=180,136,29
+Blue=46,139,206
+Magenta=209,58,130
+Cyan=50,161,152
+White=201,198,189
+BoldBlack=69,72,75
+BoldRed=189,54,19

--- a/mobaxterm/Violet Light.ini
+++ b/mobaxterm/Violet Light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Violet Light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=252,244,220
+ForegroundColour=83,104,112
+CursorColour=83,104,112
+Black=86,89,92
+Red=201,76,34
+BoldGreen=115,138,4
+BoldYellow=165,119,5
+BoldBlue=33,118,199
+BoldMagenta=198,28,111
+BoldCyan=37,146,134
+BoldWhite=201,198,189
+Green=133,152,28
+Yellow=180,136,29
+Blue=46,139,206
+Magenta=209,58,130
+Cyan=50,161,152
+White=211,208,201
+BoldBlack=69,72,75
+BoldRed=189,54,19

--- a/mobaxterm/WarmNeon.ini
+++ b/mobaxterm/WarmNeon.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: WarmNeon
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=64,64,64
+ForegroundColour=175,218,182
+CursorColour=48,255,36
+Black=0,0,0
+Red=226,67,70
+BoldGreen=156,192,144
+BoldYellow=221,218,122
+BoldBlue=123,145,214
+BoldMagenta=246,116,186
+BoldCyan=94,209,229
+BoldWhite=216,200,187
+Green=57,177,58
+Yellow=218,225,69
+Blue=66,97,197
+Magenta=249,32,251
+Cyan=42,187,212
+White=208,184,163
+BoldBlack=254,252,252
+BoldRed=233,112,113

--- a/mobaxterm/Wez.ini
+++ b/mobaxterm/Wez.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Wez
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=179,179,179
+CursorColour=83,174,113
+Black=0,0,0
+Red=204,85,85
+BoldGreen=85,255,85
+BoldYellow=255,255,85
+BoldBlue=85,85,255
+BoldMagenta=255,85,255
+BoldCyan=85,255,255
+BoldWhite=255,255,255
+Green=85,204,85
+Yellow=205,205,85
+Blue=85,85,204
+Magenta=204,85,204
+Cyan=122,202,202
+White=204,204,204
+BoldBlack=85,85,85
+BoldRed=255,85,85

--- a/mobaxterm/Whimsy.ini
+++ b/mobaxterm/Whimsy.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Whimsy
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=41,40,59
+ForegroundColour=179,176,214
+CursorColour=179,176,214
+Black=83,81,120
+Red=239,100,135
+BoldGreen=94,202,137
+BoldYellow=253,216,119
+BoldBlue=101,174,247
+BoldMagenta=170,127,240
+BoldCyan=67,193,190
+BoldWhite=255,255,255
+Green=94,202,137
+Yellow=253,216,119
+Blue=101,174,247
+Magenta=170,127,240
+Cyan=67,193,190
+White=255,255,255
+BoldBlack=83,81,120
+BoldRed=239,100,135

--- a/mobaxterm/WildCherry.ini
+++ b/mobaxterm/WildCherry.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: WildCherry
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=31,23,38
+ForegroundColour=218,250,255
+CursorColour=221,0,255
+Black=0,5,7
+Red=217,64,133
+BoldGreen=244,220,165
+BoldYellow=234,192,102
+BoldBlue=48,140,186
+BoldMagenta=174,99,107
+BoldCyan=255,145,157
+BoldWhite=228,131,141
+Green=42,178,80
+Yellow=255,209,111
+Blue=136,60,220
+Magenta=236,236,236
+Cyan=193,184,183
+White=255,248,222
+BoldBlack=0,156,201
+BoldRed=218,107,172

--- a/mobaxterm/Wombat.ini
+++ b/mobaxterm/Wombat.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Wombat
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=23,23,23
+ForegroundColour=222,218,207
+CursorColour=187,187,187
+Black=0,0,0
+Red=255,97,90
+BoldGreen=221,248,143
+BoldYellow=238,229,178
+BoldBlue=165,199,255
+BoldMagenta=221,170,255
+BoldCyan=183,255,249
+BoldWhite=255,255,255
+Green=177,233,105
+Yellow=235,217,156
+Blue=93,169,246
+Magenta=232,106,255
+Cyan=130,255,247
+White=222,218,207
+BoldBlack=49,49,49
+BoldRed=245,140,128

--- a/mobaxterm/Wryan.ini
+++ b/mobaxterm/Wryan.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Wryan
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=16,16,16
+ForegroundColour=153,153,147
+CursorColour=158,158,203
+Black=51,51,51
+Red=140,70,101
+BoldGreen=83,166,166
+BoldYellow=158,158,203
+BoldBlue=71,122,179
+BoldMagenta=126,98,179
+BoldCyan=96,150,191
+BoldWhite=192,192,192
+Green=40,115,115
+Yellow=124,124,153
+Blue=57,85,115
+Magenta=94,70,140
+Cyan=49,101,140
+White=137,156,161
+BoldBlack=61,61,61
+BoldRed=191,77,128

--- a/mobaxterm/Zenburn.ini
+++ b/mobaxterm/Zenburn.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: Zenburn
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=63,63,63
+ForegroundColour=220,220,204
+CursorColour=115,99,90
+Black=77,77,77
+Red=112,80,80
+BoldGreen=195,191,159
+BoldYellow=224,207,159
+BoldBlue=148,191,243
+BoldMagenta=236,147,211
+BoldCyan=147,224,227
+BoldWhite=255,255,255
+Green=96,180,138
+Yellow=240,223,175
+Blue=80,96,112
+Magenta=220,140,195
+Cyan=140,208,211
+White=220,220,204
+BoldBlack=112,144,128
+BoldRed=220,163,163

--- a/mobaxterm/ayu.ini
+++ b/mobaxterm/ayu.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ayu
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=15,20,25
+ForegroundColour=230,225,207
+CursorColour=242,151,24
+Black=0,0,0
+Red=255,51,51
+BoldGreen=234,254,132
+BoldYellow=255,247,121
+BoldBlue=104,213,255
+BoldMagenta=255,163,170
+BoldCyan=199,255,253
+BoldWhite=255,255,255
+Green=184,204,82
+Yellow=231,197,71
+Blue=54,163,217
+Magenta=240,113,120
+Cyan=149,230,203
+White=255,255,255
+BoldBlack=50,50,50
+BoldRed=255,101,101

--- a/mobaxterm/ayu_light.ini
+++ b/mobaxterm/ayu_light.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: ayu_light
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=250,250,250
+ForegroundColour=92,103,115
+CursorColour=255,106,0
+Black=0,0,0
+Red=255,51,51
+BoldGreen=184,229,50
+BoldYellow=255,201,74
+BoldBlue=115,216,255
+BoldMagenta=255,163,170
+BoldCyan=127,241,203
+BoldWhite=255,255,255
+Green=134,179,0
+Yellow=242,151,24
+Blue=65,166,217
+Magenta=240,113,120
+Cyan=77,191,153
+White=255,255,255
+BoldBlack=50,50,50
+BoldRed=255,101,101

--- a/mobaxterm/cyberpunk.ini
+++ b/mobaxterm/cyberpunk.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: cyberpunk
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=51,42,87
+ForegroundColour=229,229,229
+CursorColour=33,246,188
+Black=0,0,0
+Red=255,112,146
+BoldGreen=33,246,188
+BoldYellow=255,247,135
+BoldBlue=27,204,253
+BoldMagenta=230,174,254
+BoldCyan=153,214,252
+BoldWhite=255,255,255
+Green=0,251,172
+Yellow=255,250,106
+Blue=0,191,255
+Magenta=223,149,255
+Cyan=134,203,254
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=255,138,164

--- a/mobaxterm/deep.ini
+++ b/mobaxterm/deep.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: deep
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=9,9,9
+ForegroundColour=205,205,205
+CursorColour=208,208,208
+Black=0,0,0
+Red=215,0,5
+BoldGreen=34,255,24
+BoldYellow=254,220,43
+BoldBlue=159,169,255
+BoldMagenta=224,154,255
+BoldCyan=141,249,255
+BoldWhite=255,255,255
+Green=28,217,21
+Yellow=217,189,38
+Blue=86,101,255
+Magenta=176,82,218
+Cyan=80,210,218
+White=224,224,224
+BoldBlack=83,83,83
+BoldRed=251,0,7

--- a/mobaxterm/idea.ini
+++ b/mobaxterm/idea.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: idea
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=32,32,32
+ForegroundColour=173,173,173
+CursorColour=187,187,187
+Black=173,173,173
+Red=252,82,86
+BoldGreen=152,182,28
+BoldYellow=255,255,11
+BoldBlue=108,156,237
+BoldMagenta=252,126,255
+BoldCyan=36,136,135
+BoldWhite=24,24,24
+Green=152,182,28
+Yellow=204,180,68
+Blue=67,126,231
+Magenta=157,116,176
+Cyan=36,136,135
+White=24,24,24
+BoldBlack=255,255,255
+BoldRed=252,112,114

--- a/mobaxterm/idleToes.ini
+++ b/mobaxterm/idleToes.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: idleToes
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=50,50,50
+ForegroundColour=255,255,255
+CursorColour=214,214,214
+Black=50,50,50
+Red=210,82,82
+BoldGreen=157,255,145
+BoldYellow=255,228,139
+BoldBlue=94,183,247
+BoldMagenta=255,157,255
+BoldCyan=220,244,255
+BoldWhite=255,255,255
+Green=127,225,115
+Yellow=255,198,109
+Blue=64,153,255
+Magenta=246,128,255
+Cyan=190,214,255
+White=238,238,236
+BoldBlack=83,83,83
+BoldRed=240,112,112

--- a/mobaxterm/lovelace.ini
+++ b/mobaxterm/lovelace.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: lovelace
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=29,31,40
+ForegroundColour=253,253,253
+CursorColour=197,116,221
+Black=40,42,54
+Red=243,127,151
+BoldGreen=24,227,200
+BoldYellow=255,128,55
+BoldBlue=85,111,255
+BoldMagenta=176,67,209
+BoldCyan=63,220,238
+BoldWhite=190,190,193
+Green=90,222,205
+Yellow=242,162,114
+Blue=136,151,244
+Magenta=197,116,221
+Cyan=121,230,243
+White=253,253,253
+BoldBlack=65,68,88
+BoldRed=255,73,113

--- a/mobaxterm/primary.ini
+++ b/mobaxterm/primary.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: primary
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=255,255,255
+ForegroundColour=0,0,0
+CursorColour=0,0,0
+Black=0,0,0
+Red=219,68,55
+BoldGreen=15,157,88
+BoldYellow=244,180,0
+BoldBlue=66,133,244
+BoldMagenta=66,133,244
+BoldCyan=15,157,88
+BoldWhite=255,255,255
+Green=15,157,88
+Yellow=244,180,0
+Blue=66,133,244
+Magenta=219,68,55
+Cyan=66,133,244
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=219,68,55

--- a/mobaxterm/purplepeter.ini
+++ b/mobaxterm/purplepeter.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: purplepeter
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=42,26,74
+ForegroundColour=236,231,250
+CursorColour=199,199,199
+Black=10,5,32
+Red=255,121,109
+BoldGreen=180,190,143
+BoldYellow=242,233,191
+BoldBlue=121,218,237
+BoldMagenta=186,145,212
+BoldCyan=160,160,214
+BoldWhite=185,174,211
+Green=153,180,129
+Yellow=239,223,172
+Blue=102,217,239
+Magenta=231,143,205
+Cyan=186,140,255
+White=255,186,129
+BoldBlack=16,11,35
+BoldRed=249,159,146

--- a/mobaxterm/rebecca.ini
+++ b/mobaxterm/rebecca.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: rebecca
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=41,42,68
+ForegroundColour=232,230,237
+CursorColour=184,155,249
+Black=18,19,30
+Red=221,119,85
+BoldGreen=1,234,192
+BoldYellow=255,252,168
+BoldBlue=105,192,250
+BoldMagenta=193,127,248
+BoldCyan=139,253,225
+BoldWhite=244,242,249
+Green=4,219,181
+Yellow=242,231,183
+Blue=122,165,255
+Magenta=191,156,249
+Cyan=86,211,194
+White=228,227,233
+BoldBlack=102,102,153
+BoldRed=255,146,205

--- a/mobaxterm/synthwave.ini
+++ b/mobaxterm/synthwave.ini
@@ -1,0 +1,23 @@
+;Paste the following configurations in the corresponding place in MobaXterm.ini.
+;Theme: synthwave
+[Colors]
+DefaultColorScheme=0
+BackgroundColour=0,0,0
+ForegroundColour=218,217,199
+CursorColour=25,205,230
+Black=0,0,0
+Red=246,24,143
+BoldGreen=37,193,65
+BoldYellow=253,244,84
+BoldBlue=47,157,237
+BoldMagenta=249,113,55
+BoldCyan=25,205,230
+BoldWhite=255,255,255
+Green=30,187,43
+Yellow=253,248,52
+Blue=33,134,236
+Magenta=248,90,33
+Cyan=18,195,226
+White=255,255,255
+BoldBlack=0,0,0
+BoldRed=248,65,160

--- a/tools/update_all.py
+++ b/tools/update_all.py
@@ -14,6 +14,7 @@ import xrdb2Remmina
 import xrdb2Termite
 import xrdb2freebsd_vt
 import xrdb2kitty
+import xrdb2moba
 if __name__ == '__main__':
 
     for f in glob("../schemes/*.itermcolors"):
@@ -42,3 +43,5 @@ if __name__ == '__main__':
     print('OK --> ' + '../freebsd_vt/')
     xrdb2kitty.main('../xrdb/', '../kitty/')
     print('OK --> ' + '../kitty/')
+    xrdb2moba.main('../xrdb', '../mobaxterm')
+    print('OK --> ' + '../mobaxterm/')

--- a/tools/xrdb2moba.py
+++ b/tools/xrdb2moba.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# coding: utf-8
+#
+# This script converts xrdb (X11) color scheme  MobaXterm.ini file format
+# Users can paste the color configuration in the MobaXterm.ini file (Must close the MobaXterm beforehand)
+# Modify from "xrdb2putty.py"
+#
+# Usage:
+# xrdb2moba.py path/to/xrdb/files -d path/to/moba/files
+#
+
+
+
+import os
+import sys
+import re
+import argparse
+
+# Takes #000A0B and returns (0, 10, 11)
+def hex_to_rgb(color):
+    return (int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16))
+
+def build_moba_color(name, r, g, b):
+    return "%s=%d,%d,%d\n" % (name, r, g, b)
+
+def main(xrdb_path, output_path=None):
+
+    # The regexes to match the colors
+    color_regex = re.compile("#define +Ansi_(\d+)_Color +(#[A-Fa-f0-9]{6})")
+    bg_regex = re.compile("#define +Background_Color +(#[A-Fa-f0-9]{6})")
+    fg_regex = re.compile("#define +Foreground_Color +(#[A-Fa-f0-9]{6})")
+    bold_regex = re.compile("#define +Bold_Color +(#[A-Fa-f0-9]{6})")
+    cursor_regex = re.compile("#define +Cursor_Color +(#[A-Fa-f0-9]{6})")
+    cursor_text_regex = re.compile("#define +Cursor_Text_Color +(#[A-Fa-f0-9]{6})")
+
+    # File regex
+    xrdb_regex = re.compile("(.+)\.[xX][rR][dD][bB]")
+
+    for i in filter(lambda x: xrdb_regex.match(x), os.listdir(xrdb_path)):
+        name = xrdb_regex.match(i).group(1)
+
+        # Read XRDB file
+        with open(os.path.join(xrdb_path, i)) as f:
+            xrdb_data = f.read()
+
+            # Open output file
+            output = sys.stdout
+
+            if output_path:
+                dest = os.path.join(output_path, name)
+                output = open('{0}.ini'.format(dest), 'w+')
+            else:
+                output.write('\n%s:\n' % name)
+
+            # Emit header
+            output.write(";Paste the following configurations in the corresponding place in MobaXterm.ini.\n")
+            output.write(";Theme: %s\n" % name)
+            output.write("[Colors]\n")
+            output.write("DefaultColorScheme=0\n")
+            # Emit background color
+            bg_color = hex_to_rgb(bg_regex.search(xrdb_data).group(1))
+            output.write(build_moba_color('BackgroundColour', *bg_color))
+
+            # Emit foreground color
+            fg_color = hex_to_rgb(fg_regex.search(xrdb_data).group(1))
+            output.write(build_moba_color('ForegroundColour', *fg_color))
+            
+            # Emit cursor color
+            cursor_color = hex_to_rgb(cursor_regex.search(xrdb_data).group(1))
+            output.write(build_moba_color('CursorColour', *cursor_color))
+
+
+            # The table for the ANSI colors mapping to the mobaxterm color name
+            xrdb_to_moba_dict = {
+                0 :  "Black",
+                1 :  "Red",
+                2 :  "Green",
+                3 :  "Yellow",
+                4 :  "Blue",
+                5 :  "Magenta",
+                6 :  "Cyan",
+                7 :  "White",
+                8 :  "BoldBlack",
+                9 :  "BoldRed",
+                10 : "BoldGreen",
+                11 : "BoldYellow",
+                12 : "BoldBlue",
+                13 : "BoldMagenta",
+                14 : "BoldCyan",
+                15 : "BoldWhite",
+            }
+
+            # Emit other colors
+            for match in color_regex.findall(xrdb_data):
+                color_index = int(match[0])
+                color_rgb = hex_to_rgb(match[1])
+                color_name = xrdb_to_moba_dict[color_index]
+                output.write(build_moba_color(color_name, *color_rgb))
+
+            if output_path:
+                output.flush()
+                output.close()
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description='Translate X color schemes to termiantor format')
+    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
+    parser.add_argument('-d', '--out-directory', type=str, dest='output_path',
+                        help='path where putty config files will be' +
+                        ' created, if not provided then will be printed')
+
+    args = parser.parse_args()
+    main(args.xrdb_path, args.output_path)
+
+


### PR DESCRIPTION
Hi,
I add support for mobaxterm color theme including the color theme files in the __mobaxterm/__ and the __tools/xrdb2moba.py__. People can change the default terminal theme by pasting the theme.ini to the __MobaXterm.ini__
By the way, this is an awesome project because it is convenient for me to make a colorful terminal.