### PR TITLE
Fix OneHalfDark and OneHalfLight termite configs

### DIFF
--- a/termite/OneHalfDark
+++ b/termite/OneHalfDark
@@ -1,7 +1,7 @@
 [colors]
-background = "#282c34"
-cursor = "#a3b3cc"
-foreground = "#dcdfe4"
+background = #282c34
+cursor = #a3b3cc
+foreground = #dcdfe4
 color0 = #282c34
 color1 = #e06c75
 color2 = #98c379

--- a/termite/OneHalfLight
+++ b/termite/OneHalfLight
@@ -1,7 +1,7 @@
 [colors]
-background = "#fafafa"
-cursor = "#bfceff"
-foreground = "#383a42"
+background = #fafafa
+cursor = #bfceff
+foreground = #383a42
 color0 = #383a42
 color1 = #e45649
 color2 = #50a14f


### PR DESCRIPTION
The Xorg logs error when there're double quotes in the termite configs