### PR TITLE
New Windows Terminal themes and script

### DIFF
--- a/tools/update_all.py
+++ b/tools/update_all.py
@@ -18,6 +18,7 @@ import xrdb2moba
 import xrdb2lxterm
 import xrdb2pantheon_terminal
 import xrdb2wezterm
+import xrdb2windowsterminal
 import xrdb2dynamic_color
 
 if __name__ == '__main__':
@@ -56,5 +57,7 @@ if __name__ == '__main__':
     print('OK --> ' + '../pantheonterminal/')
     xrdb2wezterm.main('../xrdb/', '../wezterm/')
     print('OK --> ' + '../wezterm/')
+    xrdb2windowsterminal.main('../xrdb/', '../windowsterminal/')
+    print('OK --> ' + '../windowsterminal/')
     xrdb2dynamic_color.main('../xrdb/', '../dynamic-colors/')
     print('OK --> ' + '../dynamic-colors/')

--- a/tools/xrdb2windowsterminal.py
+++ b/tools/xrdb2windowsterminal.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+# This script converts xrdb (X11) color scheme format to
+# the new Windows Terminal color scheme format
+#
+# Usage:
+# xrdb2windowsterminal.py path/to/xrdb/files -d /wezterm/output
+
+import os
+import re
+import argparse
+from xrdbparser import Xrdb
+
+
+def process_file(data):
+    # map to Windows Terminal names
+    pairs = [
+        ("background", "Background_Color"),
+        ("foreground", "Foreground_Color"),
+    ]
+
+    ansi = [
+        "black",
+        "red",
+        "green",
+        "yellow",
+        "blue",
+        "purple",
+        "cyan",
+        "white",
+        "brightBlack",
+        "brightRed",
+        "brightGreen",
+        "brightYellow",
+        "brightBlue",
+        "brightPurple",
+        "brightCyan",
+        "brightWhite",
+    ]
+
+    lines = ""
+    for i, name in enumerate(ansi):
+        color = data.colors[i]
+        if color:
+            lines += f',\n  "{name}": "{color}"'
+    
+    for windowsterminal, xrdb in pairs:
+        color = getattr(data, xrdb, None)
+        if color:
+            lines += f',\n  "{windowsterminal}": "{color}"'
+
+    lines.rstrip(",")
+
+    return f'''{{
+  "name": "{data.name}"{lines}
+}}
+'''
+
+
+def main(xrdb_path, output_path=None):
+    for data in Xrdb.parse_all(xrdb_path):
+        output = process_file(data)
+        if not output_path:
+            print(output)
+        else:
+            dest = os.path.join(output_path, data.name)
+            with open('{0}.json'.format(dest), 'w+') as f:
+                f.write(output)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description='Translate X color schemes to Windows Terminal format')
+    parser.add_argument('xrdb_path', type=str, help='path to xrdb files')
+    parser.add_argument('-d', '--destiny', type=str, dest='output_path',
+                        help='path where Windows Terminal config files will be' +
+                        ' created, if not provided then will be printed')
+
+    args = parser.parse_args()
+
+    main(args.xrdb_path, args.output_path)

--- a/tools/xrdb2windowsterminal.py
+++ b/tools/xrdb2windowsterminal.py
@@ -4,7 +4,7 @@
 # the new Windows Terminal color scheme format
 #
 # Usage:
-# xrdb2windowsterminal.py path/to/xrdb/files -d /wezterm/output
+# xrdb2windowsterminal.py path/to/xrdb/files -d /windowsterminal/output
 
 import os
 import re

--- a/windowsterminal/3024 Day.json
+++ b/windowsterminal/3024 Day.json
@@ -1,0 +1,21 @@
+{
+  "name": "3024 Day",
+  "black": "#090300",
+  "red": "#db2d20",
+  "green": "#01a252",
+  "yellow": "#fded02",
+  "blue": "#01a0e4",
+  "purple": "#a16a94",
+  "cyan": "#b5e4f4",
+  "white": "#a5a2a2",
+  "brightBlack": "#5c5855",
+  "brightRed": "#e8bbd0",
+  "brightGreen": "#3a3432",
+  "brightYellow": "#4a4543",
+  "brightBlue": "#807d7c",
+  "brightPurple": "#d6d5d4",
+  "brightCyan": "#cdab53",
+  "brightWhite": "#f7f7f7",
+  "background": "#f7f7f7",
+  "foreground": "#4a4543"
+}

--- a/windowsterminal/3024 Night.json
+++ b/windowsterminal/3024 Night.json
@@ -1,0 +1,21 @@
+{
+  "name": "3024 Night",
+  "black": "#090300",
+  "red": "#db2d20",
+  "green": "#01a252",
+  "yellow": "#fded02",
+  "blue": "#01a0e4",
+  "purple": "#a16a94",
+  "cyan": "#b5e4f4",
+  "white": "#a5a2a2",
+  "brightBlack": "#5c5855",
+  "brightRed": "#e8bbd0",
+  "brightGreen": "#3a3432",
+  "brightYellow": "#4a4543",
+  "brightBlue": "#807d7c",
+  "brightPurple": "#d6d5d4",
+  "brightCyan": "#cdab53",
+  "brightWhite": "#f7f7f7",
+  "background": "#090300",
+  "foreground": "#a5a2a2"
+}

--- a/windowsterminal/AdventureTime.json
+++ b/windowsterminal/AdventureTime.json
@@ -1,0 +1,21 @@
+{
+  "name": "AdventureTime",
+  "black": "#050404",
+  "red": "#bd0013",
+  "green": "#4ab118",
+  "yellow": "#e7741e",
+  "blue": "#0f4ac6",
+  "purple": "#665993",
+  "cyan": "#70a598",
+  "white": "#f8dcc0",
+  "brightBlack": "#4e7cbf",
+  "brightRed": "#fc5f5a",
+  "brightGreen": "#9eff6e",
+  "brightYellow": "#efc11a",
+  "brightBlue": "#1997c6",
+  "brightPurple": "#9b5953",
+  "brightCyan": "#c8faf4",
+  "brightWhite": "#f6f5fb",
+  "background": "#1f1d45",
+  "foreground": "#f8dcc0"
+}

--- a/windowsterminal/Afterglow.json
+++ b/windowsterminal/Afterglow.json
@@ -1,0 +1,21 @@
+{
+  "name": "Afterglow",
+  "black": "#151515",
+  "red": "#ac4142",
+  "green": "#7e8e50",
+  "yellow": "#e5b567",
+  "blue": "#6c99bb",
+  "purple": "#9f4e85",
+  "cyan": "#7dd6cf",
+  "white": "#d0d0d0",
+  "brightBlack": "#505050",
+  "brightRed": "#ac4142",
+  "brightGreen": "#7e8e50",
+  "brightYellow": "#e5b567",
+  "brightBlue": "#6c99bb",
+  "brightPurple": "#9f4e85",
+  "brightCyan": "#7dd6cf",
+  "brightWhite": "#f5f5f5",
+  "background": "#212121",
+  "foreground": "#d0d0d0"
+}

--- a/windowsterminal/AlienBlood.json
+++ b/windowsterminal/AlienBlood.json
@@ -1,0 +1,21 @@
+{
+  "name": "AlienBlood",
+  "black": "#112616",
+  "red": "#7f2b27",
+  "green": "#2f7e25",
+  "yellow": "#717f24",
+  "blue": "#2f6a7f",
+  "purple": "#47587f",
+  "cyan": "#327f77",
+  "white": "#647d75",
+  "brightBlack": "#3c4812",
+  "brightRed": "#e08009",
+  "brightGreen": "#18e000",
+  "brightYellow": "#bde000",
+  "brightBlue": "#00aae0",
+  "brightPurple": "#0058e0",
+  "brightCyan": "#00e0c4",
+  "brightWhite": "#73fa91",
+  "background": "#0f1610",
+  "foreground": "#637d75"
+}

--- a/windowsterminal/Andromeda.json
+++ b/windowsterminal/Andromeda.json
@@ -1,0 +1,21 @@
+{
+  "name": "Andromeda",
+  "black": "#000000",
+  "red": "#cd3131",
+  "green": "#05bc79",
+  "yellow": "#e5e512",
+  "blue": "#2472c8",
+  "purple": "#bc3fbc",
+  "cyan": "#0fa8cd",
+  "white": "#e5e5e5",
+  "brightBlack": "#666666",
+  "brightRed": "#cd3131",
+  "brightGreen": "#05bc79",
+  "brightYellow": "#e5e512",
+  "brightBlue": "#2472c8",
+  "brightPurple": "#bc3fbc",
+  "brightCyan": "#0fa8cd",
+  "brightWhite": "#e5e5e5",
+  "background": "#262a33",
+  "foreground": "#e5e5e5"
+}

--- a/windowsterminal/Argonaut.json
+++ b/windowsterminal/Argonaut.json
@@ -1,0 +1,21 @@
+{
+  "name": "Argonaut",
+  "black": "#232323",
+  "red": "#ff000f",
+  "green": "#8ce10b",
+  "yellow": "#ffb900",
+  "blue": "#008df8",
+  "purple": "#6d43a6",
+  "cyan": "#00d8eb",
+  "white": "#ffffff",
+  "brightBlack": "#444444",
+  "brightRed": "#ff2740",
+  "brightGreen": "#abe15b",
+  "brightYellow": "#ffd242",
+  "brightBlue": "#0092ff",
+  "brightPurple": "#9a5feb",
+  "brightCyan": "#67fff0",
+  "brightWhite": "#ffffff",
+  "background": "#0e1019",
+  "foreground": "#fffaf4"
+}

--- a/windowsterminal/Arthur.json
+++ b/windowsterminal/Arthur.json
@@ -1,0 +1,21 @@
+{
+  "name": "Arthur",
+  "black": "#3d352a",
+  "red": "#cd5c5c",
+  "green": "#86af80",
+  "yellow": "#e8ae5b",
+  "blue": "#6495ed",
+  "purple": "#deb887",
+  "cyan": "#b0c4de",
+  "white": "#bbaa99",
+  "brightBlack": "#554444",
+  "brightRed": "#cc5533",
+  "brightGreen": "#88aa22",
+  "brightYellow": "#ffa75d",
+  "brightBlue": "#87ceeb",
+  "brightPurple": "#996600",
+  "brightCyan": "#b0c4de",
+  "brightWhite": "#ddccbb",
+  "background": "#1c1c1c",
+  "foreground": "#ddeedd"
+}

--- a/windowsterminal/AtelierSulphurpool.json
+++ b/windowsterminal/AtelierSulphurpool.json
@@ -1,0 +1,21 @@
+{
+  "name": "AtelierSulphurpool",
+  "black": "#202746",
+  "red": "#c94922",
+  "green": "#ac9739",
+  "yellow": "#c08b30",
+  "blue": "#3d8fd1",
+  "purple": "#6679cc",
+  "cyan": "#22a2c9",
+  "white": "#979db4",
+  "brightBlack": "#6b7394",
+  "brightRed": "#c76b29",
+  "brightGreen": "#293256",
+  "brightYellow": "#5e6687",
+  "brightBlue": "#898ea4",
+  "brightPurple": "#dfe2f1",
+  "brightCyan": "#9c637a",
+  "brightWhite": "#f5f7ff",
+  "background": "#202746",
+  "foreground": "#979db4"
+}

--- a/windowsterminal/Atom.json
+++ b/windowsterminal/Atom.json
@@ -1,0 +1,21 @@
+{
+  "name": "Atom",
+  "black": "#000000",
+  "red": "#fd5ff1",
+  "green": "#87c38a",
+  "yellow": "#ffd7b1",
+  "blue": "#85befd",
+  "purple": "#b9b6fc",
+  "cyan": "#85befd",
+  "white": "#e0e0e0",
+  "brightBlack": "#000000",
+  "brightRed": "#fd5ff1",
+  "brightGreen": "#94fa36",
+  "brightYellow": "#f5ffa8",
+  "brightBlue": "#96cbfe",
+  "brightPurple": "#b9b6fc",
+  "brightCyan": "#85befd",
+  "brightWhite": "#e0e0e0",
+  "background": "#161719",
+  "foreground": "#c5c8c6"
+}

--- a/windowsterminal/AtomOneLight.json
+++ b/windowsterminal/AtomOneLight.json
@@ -1,0 +1,21 @@
+{
+  "name": "AtomOneLight",
+  "black": "#000000",
+  "red": "#de3e35",
+  "green": "#3f953a",
+  "yellow": "#d2b67c",
+  "blue": "#2f5af3",
+  "purple": "#950095",
+  "cyan": "#3f953a",
+  "white": "#bbbbbb",
+  "brightBlack": "#000000",
+  "brightRed": "#de3e35",
+  "brightGreen": "#3f953a",
+  "brightYellow": "#d2b67c",
+  "brightBlue": "#2f5af3",
+  "brightPurple": "#a00095",
+  "brightCyan": "#3f953a",
+  "brightWhite": "#ffffff",
+  "background": "#f9f9f9",
+  "foreground": "#2a2c33"
+}

--- a/windowsterminal/Batman.json
+++ b/windowsterminal/Batman.json
@@ -1,0 +1,21 @@
+{
+  "name": "Batman",
+  "black": "#1b1d1e",
+  "red": "#e6dc44",
+  "green": "#c8be46",
+  "yellow": "#f4fd22",
+  "blue": "#737174",
+  "purple": "#747271",
+  "cyan": "#62605f",
+  "white": "#c6c5bf",
+  "brightBlack": "#505354",
+  "brightRed": "#fff78e",
+  "brightGreen": "#fff27d",
+  "brightYellow": "#feed6c",
+  "brightBlue": "#919495",
+  "brightPurple": "#9a9a9d",
+  "brightCyan": "#a3a3a6",
+  "brightWhite": "#dadbd6",
+  "background": "#1b1d1e",
+  "foreground": "#6f6f6f"
+}

--- a/windowsterminal/Belafonte Day.json
+++ b/windowsterminal/Belafonte Day.json
@@ -1,0 +1,21 @@
+{
+  "name": "Belafonte Day",
+  "black": "#20111b",
+  "red": "#be100e",
+  "green": "#858162",
+  "yellow": "#eaa549",
+  "blue": "#426a79",
+  "purple": "#97522c",
+  "cyan": "#989a9c",
+  "white": "#968c83",
+  "brightBlack": "#5e5252",
+  "brightRed": "#be100e",
+  "brightGreen": "#858162",
+  "brightYellow": "#eaa549",
+  "brightBlue": "#426a79",
+  "brightPurple": "#97522c",
+  "brightCyan": "#989a9c",
+  "brightWhite": "#d5ccba",
+  "background": "#d5ccba",
+  "foreground": "#45373c"
+}

--- a/windowsterminal/Belafonte Night.json
+++ b/windowsterminal/Belafonte Night.json
@@ -1,0 +1,21 @@
+{
+  "name": "Belafonte Night",
+  "black": "#20111b",
+  "red": "#be100e",
+  "green": "#858162",
+  "yellow": "#eaa549",
+  "blue": "#426a79",
+  "purple": "#97522c",
+  "cyan": "#989a9c",
+  "white": "#968c83",
+  "brightBlack": "#5e5252",
+  "brightRed": "#be100e",
+  "brightGreen": "#858162",
+  "brightYellow": "#eaa549",
+  "brightBlue": "#426a79",
+  "brightPurple": "#97522c",
+  "brightCyan": "#989a9c",
+  "brightWhite": "#d5ccba",
+  "background": "#20111b",
+  "foreground": "#968c83"
+}

--- a/windowsterminal/BirdsOfParadise.json
+++ b/windowsterminal/BirdsOfParadise.json
@@ -1,0 +1,21 @@
+{
+  "name": "BirdsOfParadise",
+  "black": "#573d26",
+  "red": "#be2d26",
+  "green": "#6ba18a",
+  "yellow": "#e99d2a",
+  "blue": "#5a86ad",
+  "purple": "#ac80a6",
+  "cyan": "#74a6ad",
+  "white": "#e0dbb7",
+  "brightBlack": "#9b6c4a",
+  "brightRed": "#e84627",
+  "brightGreen": "#95d8ba",
+  "brightYellow": "#d0d150",
+  "brightBlue": "#b8d3ed",
+  "brightPurple": "#d19ecb",
+  "brightCyan": "#93cfd7",
+  "brightWhite": "#fff9d5",
+  "background": "#2a1f1d",
+  "foreground": "#e0dbb7"
+}

--- a/windowsterminal/Blazer.json
+++ b/windowsterminal/Blazer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Blazer",
+  "black": "#000000",
+  "red": "#b87a7a",
+  "green": "#7ab87a",
+  "yellow": "#b8b87a",
+  "blue": "#7a7ab8",
+  "purple": "#b87ab8",
+  "cyan": "#7ab8b8",
+  "white": "#d9d9d9",
+  "brightBlack": "#262626",
+  "brightRed": "#dbbdbd",
+  "brightGreen": "#bddbbd",
+  "brightYellow": "#dbdbbd",
+  "brightBlue": "#bdbddb",
+  "brightPurple": "#dbbddb",
+  "brightCyan": "#bddbdb",
+  "brightWhite": "#ffffff",
+  "background": "#0d1926",
+  "foreground": "#d9e6f2"
+}

--- a/windowsterminal/BlulocoDark.json
+++ b/windowsterminal/BlulocoDark.json
@@ -1,0 +1,21 @@
+{
+  "name": "BlulocoDark",
+  "black": "#4a505d",
+  "red": "#f81141",
+  "green": "#23974a",
+  "yellow": "#fd7e57",
+  "blue": "#285bff",
+  "purple": "#8c62fd",
+  "cyan": "#366f9a",
+  "white": "#ccd5e5",
+  "brightBlack": "#61697a",
+  "brightRed": "#fc4a6d",
+  "brightGreen": "#37bd58",
+  "brightYellow": "#f6be48",
+  "brightBlue": "#199ffd",
+  "brightPurple": "#fc58f6",
+  "brightCyan": "#50acae",
+  "brightWhite": "#ffffff",
+  "background": "#1e2127",
+  "foreground": "#abb2bf"
+}

--- a/windowsterminal/BlulocoLight.json
+++ b/windowsterminal/BlulocoLight.json
@@ -1,0 +1,21 @@
+{
+  "name": "BlulocoLight",
+  "black": "#cbccd5",
+  "red": "#c90e42",
+  "green": "#21883a",
+  "yellow": "#d54d17",
+  "blue": "#1e44dd",
+  "purple": "#6d1bed",
+  "cyan": "#1f4d7a",
+  "white": "#000000",
+  "brightBlack": "#dedfe8",
+  "brightRed": "#fc4a6d",
+  "brightGreen": "#34b354",
+  "brightYellow": "#b89427",
+  "brightBlue": "#1085d9",
+  "brightPurple": "#c00db3",
+  "brightCyan": "#5b80ad",
+  "brightWhite": "#1d1d22",
+  "background": "#f7f7f7",
+  "foreground": "#2a2c33"
+}

--- a/windowsterminal/Borland.json
+++ b/windowsterminal/Borland.json
@@ -1,0 +1,21 @@
+{
+  "name": "Borland",
+  "black": "#4f4f4f",
+  "red": "#ff6c60",
+  "green": "#a8ff60",
+  "yellow": "#ffffb6",
+  "blue": "#96cbfe",
+  "purple": "#ff73fd",
+  "cyan": "#c6c5fe",
+  "white": "#eeeeee",
+  "brightBlack": "#7c7c7c",
+  "brightRed": "#ffb6b0",
+  "brightGreen": "#ceffac",
+  "brightYellow": "#ffffcc",
+  "brightBlue": "#b5dcff",
+  "brightPurple": "#ff9cfe",
+  "brightCyan": "#dfdffe",
+  "brightWhite": "#ffffff",
+  "background": "#0000a4",
+  "foreground": "#ffff4e"
+}

--- a/windowsterminal/Bright Lights.json
+++ b/windowsterminal/Bright Lights.json
@@ -1,0 +1,21 @@
+{
+  "name": "Bright Lights",
+  "black": "#191919",
+  "red": "#ff355b",
+  "green": "#b7e876",
+  "yellow": "#ffc251",
+  "blue": "#76d4ff",
+  "purple": "#ba76e7",
+  "cyan": "#6cbfb5",
+  "white": "#c2c8d7",
+  "brightBlack": "#191919",
+  "brightRed": "#ff355b",
+  "brightGreen": "#b7e876",
+  "brightYellow": "#ffc251",
+  "brightBlue": "#76d5ff",
+  "brightPurple": "#ba76e7",
+  "brightCyan": "#6cbfb5",
+  "brightWhite": "#c2c8d7",
+  "background": "#191919",
+  "foreground": "#b3c9d7"
+}

--- a/windowsterminal/Broadcast.json
+++ b/windowsterminal/Broadcast.json
@@ -1,0 +1,21 @@
+{
+  "name": "Broadcast",
+  "black": "#000000",
+  "red": "#da4939",
+  "green": "#519f50",
+  "yellow": "#ffd24a",
+  "blue": "#6d9cbe",
+  "purple": "#d0d0ff",
+  "cyan": "#6e9cbe",
+  "white": "#ffffff",
+  "brightBlack": "#323232",
+  "brightRed": "#ff7b6b",
+  "brightGreen": "#83d182",
+  "brightYellow": "#ffff7c",
+  "brightBlue": "#9fcef0",
+  "brightPurple": "#ffffff",
+  "brightCyan": "#a0cef0",
+  "brightWhite": "#ffffff",
+  "background": "#2b2b2b",
+  "foreground": "#e6e1dc"
+}

--- a/windowsterminal/Brogrammer.json
+++ b/windowsterminal/Brogrammer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Brogrammer",
+  "black": "#1f1f1f",
+  "red": "#f81118",
+  "green": "#2dc55e",
+  "yellow": "#ecba0f",
+  "blue": "#2a84d2",
+  "purple": "#4e5ab7",
+  "cyan": "#1081d6",
+  "white": "#d6dbe5",
+  "brightBlack": "#d6dbe5",
+  "brightRed": "#de352e",
+  "brightGreen": "#1dd361",
+  "brightYellow": "#f3bd09",
+  "brightBlue": "#1081d6",
+  "brightPurple": "#5350b9",
+  "brightCyan": "#0f7ddb",
+  "brightWhite": "#ffffff",
+  "background": "#131313",
+  "foreground": "#d6dbe5"
+}

--- a/windowsterminal/Builtin Dark.json
+++ b/windowsterminal/Builtin Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Dark",
+  "black": "#000000",
+  "red": "#bb0000",
+  "green": "#00bb00",
+  "yellow": "#bbbb00",
+  "blue": "#0000bb",
+  "purple": "#bb00bb",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/Builtin Light.json
+++ b/windowsterminal/Builtin Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Light",
+  "black": "#000000",
+  "red": "#bb0000",
+  "green": "#00bb00",
+  "yellow": "#bbbb00",
+  "blue": "#0000bb",
+  "purple": "#bb00bb",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/Builtin Pastel Dark.json
+++ b/windowsterminal/Builtin Pastel Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Pastel Dark",
+  "black": "#4f4f4f",
+  "red": "#ff6c60",
+  "green": "#a8ff60",
+  "yellow": "#ffffb6",
+  "blue": "#96cbfe",
+  "purple": "#ff73fd",
+  "cyan": "#c6c5fe",
+  "white": "#eeeeee",
+  "brightBlack": "#7c7c7c",
+  "brightRed": "#ffb6b0",
+  "brightGreen": "#ceffac",
+  "brightYellow": "#ffffcc",
+  "brightBlue": "#b5dcff",
+  "brightPurple": "#ff9cfe",
+  "brightCyan": "#dfdffe",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/Builtin Solarized Dark.json
+++ b/windowsterminal/Builtin Solarized Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Solarized Dark",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#738a05",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#001e27",
+  "brightRed": "#bd3613",
+  "brightGreen": "#475b62",
+  "brightYellow": "#536870",
+  "brightBlue": "#708284",
+  "brightPurple": "#5956ba",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4dc",
+  "background": "#001e27",
+  "foreground": "#708284"
+}

--- a/windowsterminal/Builtin Solarized Light.json
+++ b/windowsterminal/Builtin Solarized Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Solarized Light",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#738a05",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#001e27",
+  "brightRed": "#bd3613",
+  "brightGreen": "#475b62",
+  "brightYellow": "#536870",
+  "brightBlue": "#708284",
+  "brightPurple": "#5956ba",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4dc",
+  "background": "#fcf4dc",
+  "foreground": "#536870"
+}

--- a/windowsterminal/Builtin Tango Dark.json
+++ b/windowsterminal/Builtin Tango Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Tango Dark",
+  "black": "#000000",
+  "red": "#cc0000",
+  "green": "#4e9a06",
+  "yellow": "#c4a000",
+  "blue": "#3465a4",
+  "purple": "#75507b",
+  "cyan": "#06989a",
+  "white": "#d3d7cf",
+  "brightBlack": "#555753",
+  "brightRed": "#ef2929",
+  "brightGreen": "#8ae234",
+  "brightYellow": "#fce94f",
+  "brightBlue": "#729fcf",
+  "brightPurple": "#ad7fa8",
+  "brightCyan": "#34e2e2",
+  "brightWhite": "#eeeeec",
+  "background": "#000000",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Builtin Tango Light.json
+++ b/windowsterminal/Builtin Tango Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Builtin Tango Light",
+  "black": "#000000",
+  "red": "#cc0000",
+  "green": "#4e9a06",
+  "yellow": "#c4a000",
+  "blue": "#3465a4",
+  "purple": "#75507b",
+  "cyan": "#06989a",
+  "white": "#d3d7cf",
+  "brightBlack": "#555753",
+  "brightRed": "#ef2929",
+  "brightGreen": "#8ae234",
+  "brightYellow": "#fce94f",
+  "brightBlue": "#729fcf",
+  "brightPurple": "#ad7fa8",
+  "brightCyan": "#34e2e2",
+  "brightWhite": "#eeeeec",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/C64.json
+++ b/windowsterminal/C64.json
@@ -1,0 +1,21 @@
+{
+  "name": "C64",
+  "black": "#090300",
+  "red": "#883932",
+  "green": "#55a049",
+  "yellow": "#bfce72",
+  "blue": "#40318d",
+  "purple": "#8b3f96",
+  "cyan": "#67b6bd",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#883932",
+  "brightGreen": "#55a049",
+  "brightYellow": "#bfce72",
+  "brightBlue": "#40318d",
+  "brightPurple": "#8b3f96",
+  "brightCyan": "#67b6bd",
+  "brightWhite": "#f7f7f7",
+  "background": "#40318d",
+  "foreground": "#7869c4"
+}

--- a/windowsterminal/CLRS.json
+++ b/windowsterminal/CLRS.json
@@ -1,0 +1,21 @@
+{
+  "name": "CLRS",
+  "black": "#000000",
+  "red": "#f8282a",
+  "green": "#328a5d",
+  "yellow": "#fa701d",
+  "blue": "#135cd0",
+  "purple": "#9f00bd",
+  "cyan": "#33c3c1",
+  "white": "#b3b3b3",
+  "brightBlack": "#555753",
+  "brightRed": "#fb0416",
+  "brightGreen": "#2cc631",
+  "brightYellow": "#fdd727",
+  "brightBlue": "#1670ff",
+  "brightPurple": "#e900b0",
+  "brightCyan": "#3ad5ce",
+  "brightWhite": "#eeeeec",
+  "background": "#ffffff",
+  "foreground": "#262626"
+}

--- a/windowsterminal/Calamity.json
+++ b/windowsterminal/Calamity.json
@@ -1,0 +1,21 @@
+{
+  "name": "Calamity",
+  "black": "#2f2833",
+  "red": "#fc644d",
+  "green": "#a5f69c",
+  "yellow": "#e9d7a5",
+  "blue": "#3b79c7",
+  "purple": "#f92672",
+  "cyan": "#74d3de",
+  "white": "#d5ced9",
+  "brightBlack": "#7e6c88",
+  "brightRed": "#fc644d",
+  "brightGreen": "#a5f69c",
+  "brightYellow": "#e9d7a5",
+  "brightBlue": "#3b79c7",
+  "brightPurple": "#f92672",
+  "brightCyan": "#74d3de",
+  "brightWhite": "#ffffff",
+  "background": "#2f2833",
+  "foreground": "#d5ced9"
+}

--- a/windowsterminal/Chalk.json
+++ b/windowsterminal/Chalk.json
@@ -1,0 +1,21 @@
+{
+  "name": "Chalk",
+  "black": "#7d8b8f",
+  "red": "#b23a52",
+  "green": "#789b6a",
+  "yellow": "#b9ac4a",
+  "blue": "#2a7fac",
+  "purple": "#bd4f5a",
+  "cyan": "#44a799",
+  "white": "#d2d8d9",
+  "brightBlack": "#888888",
+  "brightRed": "#f24840",
+  "brightGreen": "#80c470",
+  "brightYellow": "#ffeb62",
+  "brightBlue": "#4196ff",
+  "brightPurple": "#fc5275",
+  "brightCyan": "#53cdbd",
+  "brightWhite": "#d2d8d9",
+  "background": "#2b2d2e",
+  "foreground": "#d2d8d9"
+}

--- a/windowsterminal/Chalkboard.json
+++ b/windowsterminal/Chalkboard.json
@@ -1,0 +1,21 @@
+{
+  "name": "Chalkboard",
+  "black": "#000000",
+  "red": "#c37372",
+  "green": "#72c373",
+  "yellow": "#c2c372",
+  "blue": "#7372c3",
+  "purple": "#c372c2",
+  "cyan": "#72c2c3",
+  "white": "#d9d9d9",
+  "brightBlack": "#323232",
+  "brightRed": "#dbaaaa",
+  "brightGreen": "#aadbaa",
+  "brightYellow": "#dadbaa",
+  "brightBlue": "#aaaadb",
+  "brightPurple": "#dbaada",
+  "brightCyan": "#aadadb",
+  "brightWhite": "#ffffff",
+  "background": "#29262f",
+  "foreground": "#d9e6f2"
+}

--- a/windowsterminal/ChallengerDeep.json
+++ b/windowsterminal/ChallengerDeep.json
@@ -1,0 +1,21 @@
+{
+  "name": "ChallengerDeep",
+  "black": "#141228",
+  "red": "#ff5458",
+  "green": "#62d196",
+  "yellow": "#ffb378",
+  "blue": "#65b2ff",
+  "purple": "#906cff",
+  "cyan": "#63f2f1",
+  "white": "#a6b3cc",
+  "brightBlack": "#565575",
+  "brightRed": "#ff8080",
+  "brightGreen": "#95ffa4",
+  "brightYellow": "#ffe9aa",
+  "brightBlue": "#91ddff",
+  "brightPurple": "#c991e1",
+  "brightCyan": "#aaffe4",
+  "brightWhite": "#cbe3e7",
+  "background": "#1e1c31",
+  "foreground": "#cbe1e7"
+}

--- a/windowsterminal/Chester.json
+++ b/windowsterminal/Chester.json
@@ -1,0 +1,21 @@
+{
+  "name": "Chester",
+  "black": "#080200",
+  "red": "#fa5e5b",
+  "green": "#16c98d",
+  "yellow": "#ffc83f",
+  "blue": "#288ad6",
+  "purple": "#d34590",
+  "cyan": "#28ddde",
+  "white": "#e7e7e7",
+  "brightBlack": "#6f6b68",
+  "brightRed": "#fa5e5b",
+  "brightGreen": "#16c98d",
+  "brightYellow": "#feef6d",
+  "brightBlue": "#278ad6",
+  "brightPurple": "#d34590",
+  "brightCyan": "#27dede",
+  "brightWhite": "#ffffff",
+  "background": "#2c3643",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Ciapre.json
+++ b/windowsterminal/Ciapre.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ciapre",
+  "black": "#181818",
+  "red": "#810009",
+  "green": "#48513b",
+  "yellow": "#cc8b3f",
+  "blue": "#576d8c",
+  "purple": "#724d7c",
+  "cyan": "#5c4f4b",
+  "white": "#aea47f",
+  "brightBlack": "#555555",
+  "brightRed": "#ac3835",
+  "brightGreen": "#a6a75d",
+  "brightYellow": "#dcdf7c",
+  "brightBlue": "#3097c6",
+  "brightPurple": "#d33061",
+  "brightCyan": "#f3dbb2",
+  "brightWhite": "#f4f4f4",
+  "background": "#191c27",
+  "foreground": "#aea47a"
+}

--- a/windowsterminal/Cobalt Neon.json
+++ b/windowsterminal/Cobalt Neon.json
@@ -1,0 +1,21 @@
+{
+  "name": "Cobalt Neon",
+  "black": "#142631",
+  "red": "#ff2320",
+  "green": "#3ba5ff",
+  "yellow": "#e9e75c",
+  "blue": "#8ff586",
+  "purple": "#781aa0",
+  "cyan": "#8ff586",
+  "white": "#ba46b2",
+  "brightBlack": "#fff688",
+  "brightRed": "#d4312e",
+  "brightGreen": "#8ff586",
+  "brightYellow": "#e9f06d",
+  "brightBlue": "#3c7dd2",
+  "brightPurple": "#8230a7",
+  "brightCyan": "#6cbc67",
+  "brightWhite": "#8ff586",
+  "background": "#142838",
+  "foreground": "#8ff586"
+}

--- a/windowsterminal/Cobalt2.json
+++ b/windowsterminal/Cobalt2.json
@@ -1,0 +1,21 @@
+{
+  "name": "Cobalt2",
+  "black": "#000000",
+  "red": "#ff0000",
+  "green": "#38de21",
+  "yellow": "#ffe50a",
+  "blue": "#1460d2",
+  "purple": "#ff005d",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#f40e17",
+  "brightGreen": "#3bd01d",
+  "brightYellow": "#edc809",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#6ae3fa",
+  "brightWhite": "#ffffff",
+  "background": "#132738",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/CrayonPonyFish.json
+++ b/windowsterminal/CrayonPonyFish.json
@@ -1,0 +1,21 @@
+{
+  "name": "CrayonPonyFish",
+  "black": "#2b1b1d",
+  "red": "#91002b",
+  "green": "#579524",
+  "yellow": "#ab311b",
+  "blue": "#8c87b0",
+  "purple": "#692f50",
+  "cyan": "#e8a866",
+  "white": "#68525a",
+  "brightBlack": "#3d2b2e",
+  "brightRed": "#c5255d",
+  "brightGreen": "#8dff57",
+  "brightYellow": "#c8381d",
+  "brightBlue": "#cfc9ff",
+  "brightPurple": "#fc6cba",
+  "brightCyan": "#ffceaf",
+  "brightWhite": "#b0949d",
+  "background": "#150707",
+  "foreground": "#68525a"
+}

--- a/windowsterminal/Dark Pastel.json
+++ b/windowsterminal/Dark Pastel.json
@@ -1,0 +1,21 @@
+{
+  "name": "Dark Pastel",
+  "black": "#000000",
+  "red": "#ff5555",
+  "green": "#55ff55",
+  "yellow": "#ffff55",
+  "blue": "#5555ff",
+  "purple": "#ff55ff",
+  "cyan": "#55ffff",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Dark+.json
+++ b/windowsterminal/Dark+.json
@@ -1,0 +1,21 @@
+{
+  "name": "Dark+",
+  "black": "#000000",
+  "red": "#cd3131",
+  "green": "#0dbc79",
+  "yellow": "#e5e510",
+  "blue": "#2472c8",
+  "purple": "#bc3fbc",
+  "cyan": "#11a8cd",
+  "white": "#e5e5e5",
+  "brightBlack": "#666666",
+  "brightRed": "#f14c4c",
+  "brightGreen": "#23d18b",
+  "brightYellow": "#f5f543",
+  "brightBlue": "#3b8eea",
+  "brightPurple": "#d670d6",
+  "brightCyan": "#29b8db",
+  "brightWhite": "#e5e5e5",
+  "background": "#0e0e0e",
+  "foreground": "#cccccc"
+}

--- a/windowsterminal/Darkside.json
+++ b/windowsterminal/Darkside.json
@@ -1,0 +1,21 @@
+{
+  "name": "Darkside",
+  "black": "#000000",
+  "red": "#e8341c",
+  "green": "#68c256",
+  "yellow": "#f2d42c",
+  "blue": "#1c98e8",
+  "purple": "#8e69c9",
+  "cyan": "#1c98e8",
+  "white": "#bababa",
+  "brightBlack": "#000000",
+  "brightRed": "#e05a4f",
+  "brightGreen": "#77b869",
+  "brightYellow": "#efd64b",
+  "brightBlue": "#387cd3",
+  "brightPurple": "#957bbe",
+  "brightCyan": "#3d97e2",
+  "brightWhite": "#bababa",
+  "background": "#222324",
+  "foreground": "#bababa"
+}

--- a/windowsterminal/Desert.json
+++ b/windowsterminal/Desert.json
@@ -1,0 +1,21 @@
+{
+  "name": "Desert",
+  "black": "#4d4d4d",
+  "red": "#ff2b2b",
+  "green": "#98fb98",
+  "yellow": "#f0e68c",
+  "blue": "#cd853f",
+  "purple": "#ffdead",
+  "cyan": "#ffa0a0",
+  "white": "#f5deb3",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#87ceff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#ffd700",
+  "brightWhite": "#ffffff",
+  "background": "#333333",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/DimmedMonokai.json
+++ b/windowsterminal/DimmedMonokai.json
@@ -1,0 +1,21 @@
+{
+  "name": "DimmedMonokai",
+  "black": "#3a3d43",
+  "red": "#be3f48",
+  "green": "#879a3b",
+  "yellow": "#c5a635",
+  "blue": "#4f76a1",
+  "purple": "#855c8d",
+  "cyan": "#578fa4",
+  "white": "#b9bcba",
+  "brightBlack": "#888987",
+  "brightRed": "#fb001f",
+  "brightGreen": "#0f722f",
+  "brightYellow": "#c47033",
+  "brightBlue": "#186de3",
+  "brightPurple": "#fb0067",
+  "brightCyan": "#2e706d",
+  "brightWhite": "#fdffb9",
+  "background": "#1f1f1f",
+  "foreground": "#b9bcba"
+}

--- a/windowsterminal/DotGov.json
+++ b/windowsterminal/DotGov.json
@@ -1,0 +1,21 @@
+{
+  "name": "DotGov",
+  "black": "#191919",
+  "red": "#bf091d",
+  "green": "#3d9751",
+  "yellow": "#f6bb34",
+  "blue": "#17b2e0",
+  "purple": "#7830b0",
+  "cyan": "#8bd2ed",
+  "white": "#ffffff",
+  "brightBlack": "#191919",
+  "brightRed": "#bf091d",
+  "brightGreen": "#3d9751",
+  "brightYellow": "#f6bb34",
+  "brightBlue": "#17b2e0",
+  "brightPurple": "#7830b0",
+  "brightCyan": "#8bd2ed",
+  "brightWhite": "#ffffff",
+  "background": "#262c35",
+  "foreground": "#ebebeb"
+}

--- a/windowsterminal/Dracula.json
+++ b/windowsterminal/Dracula.json
@@ -1,0 +1,21 @@
+{
+  "name": "Dracula",
+  "black": "#000000",
+  "red": "#ff5555",
+  "green": "#50fa7b",
+  "yellow": "#f1fa8c",
+  "blue": "#bd93f9",
+  "purple": "#ff79c6",
+  "cyan": "#8be9fd",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#50fa7b",
+  "brightYellow": "#f1fa8c",
+  "brightBlue": "#bd93f9",
+  "brightPurple": "#ff79c6",
+  "brightCyan": "#8be9fd",
+  "brightWhite": "#ffffff",
+  "background": "#1e1f29",
+  "foreground": "#f8f8f2"
+}

--- a/windowsterminal/Duotone Dark.json
+++ b/windowsterminal/Duotone Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Duotone Dark",
+  "black": "#1f1d27",
+  "red": "#d9393e",
+  "green": "#2dcd73",
+  "yellow": "#d9b76e",
+  "blue": "#ffc284",
+  "purple": "#de8d40",
+  "cyan": "#2488ff",
+  "white": "#b7a1ff",
+  "brightBlack": "#353147",
+  "brightRed": "#d9393e",
+  "brightGreen": "#2dcd73",
+  "brightYellow": "#d9b76e",
+  "brightBlue": "#ffc284",
+  "brightPurple": "#de8d40",
+  "brightCyan": "#2488ff",
+  "brightWhite": "#eae5ff",
+  "background": "#1f1d27",
+  "foreground": "#b7a1ff"
+}

--- a/windowsterminal/ENCOM.json
+++ b/windowsterminal/ENCOM.json
@@ -1,0 +1,21 @@
+{
+  "name": "ENCOM",
+  "black": "#000000",
+  "red": "#9f0000",
+  "green": "#008b00",
+  "yellow": "#ffd000",
+  "blue": "#0081ff",
+  "purple": "#bc00ca",
+  "cyan": "#008b8b",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff0000",
+  "brightGreen": "#00ee00",
+  "brightYellow": "#ffff00",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#ff00ff",
+  "brightCyan": "#00cdcd",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#00a595"
+}

--- a/windowsterminal/Earthsong.json
+++ b/windowsterminal/Earthsong.json
@@ -1,0 +1,21 @@
+{
+  "name": "Earthsong",
+  "black": "#121418",
+  "red": "#c94234",
+  "green": "#85c54c",
+  "yellow": "#f5ae2e",
+  "blue": "#1398b9",
+  "purple": "#d0633d",
+  "cyan": "#509552",
+  "white": "#e5c6aa",
+  "brightBlack": "#675f54",
+  "brightRed": "#ff645a",
+  "brightGreen": "#98e036",
+  "brightYellow": "#e0d561",
+  "brightBlue": "#5fdaff",
+  "brightPurple": "#ff9269",
+  "brightCyan": "#84f088",
+  "brightWhite": "#f6f7ec",
+  "background": "#292520",
+  "foreground": "#e5c7a9"
+}

--- a/windowsterminal/Elemental.json
+++ b/windowsterminal/Elemental.json
@@ -1,0 +1,21 @@
+{
+  "name": "Elemental",
+  "black": "#3c3c30",
+  "red": "#98290f",
+  "green": "#479a43",
+  "yellow": "#7f7111",
+  "blue": "#497f7d",
+  "purple": "#7f4e2f",
+  "cyan": "#387f58",
+  "white": "#807974",
+  "brightBlack": "#555445",
+  "brightRed": "#e0502a",
+  "brightGreen": "#61e070",
+  "brightYellow": "#d69927",
+  "brightBlue": "#79d9d9",
+  "brightPurple": "#cd7c54",
+  "brightCyan": "#59d599",
+  "brightWhite": "#fff1e9",
+  "background": "#22211d",
+  "foreground": "#807a74"
+}

--- a/windowsterminal/Elementary.json
+++ b/windowsterminal/Elementary.json
@@ -1,0 +1,21 @@
+{
+  "name": "Elementary",
+  "black": "#242424",
+  "red": "#d71c15",
+  "green": "#5aa513",
+  "yellow": "#fdb40c",
+  "blue": "#063b8c",
+  "purple": "#e40038",
+  "cyan": "#2595e1",
+  "white": "#efefef",
+  "brightBlack": "#4b4b4b",
+  "brightRed": "#fc1c18",
+  "brightGreen": "#6bc219",
+  "brightYellow": "#fec80e",
+  "brightBlue": "#0955ff",
+  "brightPurple": "#fb0050",
+  "brightCyan": "#3ea8fc",
+  "brightWhite": "#8c00ec",
+  "background": "#181818",
+  "foreground": "#efefef"
+}

--- a/windowsterminal/Espresso Libre.json
+++ b/windowsterminal/Espresso Libre.json
@@ -1,0 +1,21 @@
+{
+  "name": "Espresso Libre",
+  "black": "#000000",
+  "red": "#cc0000",
+  "green": "#1a921c",
+  "yellow": "#f0e53a",
+  "blue": "#0066ff",
+  "purple": "#c5656b",
+  "cyan": "#06989a",
+  "white": "#d3d7cf",
+  "brightBlack": "#555753",
+  "brightRed": "#ef2929",
+  "brightGreen": "#9aff87",
+  "brightYellow": "#fffb5c",
+  "brightBlue": "#43a8ed",
+  "brightPurple": "#ff818a",
+  "brightCyan": "#34e2e2",
+  "brightWhite": "#eeeeec",
+  "background": "#2a211c",
+  "foreground": "#b8a898"
+}

--- a/windowsterminal/Espresso.json
+++ b/windowsterminal/Espresso.json
@@ -1,0 +1,21 @@
+{
+  "name": "Espresso",
+  "black": "#353535",
+  "red": "#d25252",
+  "green": "#a5c261",
+  "yellow": "#ffc66d",
+  "blue": "#6c99bb",
+  "purple": "#d197d9",
+  "cyan": "#bed6ff",
+  "white": "#eeeeec",
+  "brightBlack": "#535353",
+  "brightRed": "#f00c0c",
+  "brightGreen": "#c2e075",
+  "brightYellow": "#e1e48b",
+  "brightBlue": "#8ab7d9",
+  "brightPurple": "#efb5f7",
+  "brightCyan": "#dcf4ff",
+  "brightWhite": "#ffffff",
+  "background": "#323232",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Fahrenheit.json
+++ b/windowsterminal/Fahrenheit.json
@@ -1,0 +1,21 @@
+{
+  "name": "Fahrenheit",
+  "black": "#1d1d1d",
+  "red": "#cda074",
+  "green": "#9e744d",
+  "yellow": "#fecf75",
+  "blue": "#720102",
+  "purple": "#734c4d",
+  "cyan": "#979797",
+  "white": "#ffffce",
+  "brightBlack": "#000000",
+  "brightRed": "#fecea0",
+  "brightGreen": "#cc734d",
+  "brightYellow": "#fd9f4d",
+  "brightBlue": "#cb4a05",
+  "brightPurple": "#4e739f",
+  "brightCyan": "#fed04d",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#ffffce"
+}

--- a/windowsterminal/Fideloper.json
+++ b/windowsterminal/Fideloper.json
@@ -1,0 +1,21 @@
+{
+  "name": "Fideloper",
+  "black": "#292f33",
+  "red": "#cb1e2d",
+  "green": "#edb8ac",
+  "yellow": "#b7ab9b",
+  "blue": "#2e78c2",
+  "purple": "#c0236f",
+  "cyan": "#309186",
+  "white": "#eae3ce",
+  "brightBlack": "#092028",
+  "brightRed": "#d4605a",
+  "brightGreen": "#d4605a",
+  "brightYellow": "#a86671",
+  "brightBlue": "#7c85c4",
+  "brightPurple": "#5c5db2",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4df",
+  "background": "#292f33",
+  "foreground": "#dbdae0"
+}

--- a/windowsterminal/FirefoxDev.json
+++ b/windowsterminal/FirefoxDev.json
@@ -1,0 +1,21 @@
+{
+  "name": "FirefoxDev",
+  "black": "#002831",
+  "red": "#e63853",
+  "green": "#5eb83c",
+  "yellow": "#a57706",
+  "blue": "#359ddf",
+  "purple": "#d75cff",
+  "cyan": "#4b73a2",
+  "white": "#dcdcdc",
+  "brightBlack": "#001e27",
+  "brightRed": "#e1003f",
+  "brightGreen": "#1d9000",
+  "brightYellow": "#cd9409",
+  "brightBlue": "#006fc0",
+  "brightPurple": "#a200da",
+  "brightCyan": "#005794",
+  "brightWhite": "#e2e2e2",
+  "background": "#0e1011",
+  "foreground": "#7c8fa4"
+}

--- a/windowsterminal/Firewatch.json
+++ b/windowsterminal/Firewatch.json
@@ -1,0 +1,21 @@
+{
+  "name": "Firewatch",
+  "black": "#585f6d",
+  "red": "#d95360",
+  "green": "#5ab977",
+  "yellow": "#dfb563",
+  "blue": "#4d89c4",
+  "purple": "#d55119",
+  "cyan": "#44a8b6",
+  "white": "#e6e5ff",
+  "brightBlack": "#585f6d",
+  "brightRed": "#d95360",
+  "brightGreen": "#5ab977",
+  "brightYellow": "#dfb563",
+  "brightBlue": "#4c89c5",
+  "brightPurple": "#d55119",
+  "brightCyan": "#44a8b6",
+  "brightWhite": "#e6e5ff",
+  "background": "#1e2027",
+  "foreground": "#9ba2b2"
+}

--- a/windowsterminal/FishTank.json
+++ b/windowsterminal/FishTank.json
@@ -1,0 +1,21 @@
+{
+  "name": "FishTank",
+  "black": "#03073c",
+  "red": "#c6004a",
+  "green": "#acf157",
+  "yellow": "#fecd5e",
+  "blue": "#525fb8",
+  "purple": "#986f82",
+  "cyan": "#968763",
+  "white": "#ecf0fc",
+  "brightBlack": "#6c5b30",
+  "brightRed": "#da4b8a",
+  "brightGreen": "#dbffa9",
+  "brightYellow": "#fee6a9",
+  "brightBlue": "#b2befa",
+  "brightPurple": "#fda5cd",
+  "brightCyan": "#a5bd86",
+  "brightWhite": "#f6ffec",
+  "background": "#232537",
+  "foreground": "#ecf0fe"
+}

--- a/windowsterminal/Flat.json
+++ b/windowsterminal/Flat.json
@@ -1,0 +1,21 @@
+{
+  "name": "Flat",
+  "black": "#222d3f",
+  "red": "#a82320",
+  "green": "#32a548",
+  "yellow": "#e58d11",
+  "blue": "#3167ac",
+  "purple": "#781aa0",
+  "cyan": "#2c9370",
+  "white": "#b0b6ba",
+  "brightBlack": "#212c3c",
+  "brightRed": "#d4312e",
+  "brightGreen": "#2d9440",
+  "brightYellow": "#e5be0c",
+  "brightBlue": "#3c7dd2",
+  "brightPurple": "#8230a7",
+  "brightCyan": "#35b387",
+  "brightWhite": "#e7eced",
+  "background": "#002240",
+  "foreground": "#2cc55d"
+}

--- a/windowsterminal/Flatland.json
+++ b/windowsterminal/Flatland.json
@@ -1,0 +1,21 @@
+{
+  "name": "Flatland",
+  "black": "#1d1d19",
+  "red": "#f18339",
+  "green": "#9fd364",
+  "yellow": "#f4ef6d",
+  "blue": "#5096be",
+  "purple": "#695abc",
+  "cyan": "#d63865",
+  "white": "#ffffff",
+  "brightBlack": "#1d1d19",
+  "brightRed": "#d22a24",
+  "brightGreen": "#a7d42c",
+  "brightYellow": "#ff8949",
+  "brightBlue": "#61b9d0",
+  "brightPurple": "#695abc",
+  "brightCyan": "#d63865",
+  "brightWhite": "#ffffff",
+  "background": "#1d1f21",
+  "foreground": "#b8dbef"
+}

--- a/windowsterminal/Floraverse.json
+++ b/windowsterminal/Floraverse.json
@@ -1,0 +1,21 @@
+{
+  "name": "Floraverse",
+  "black": "#08002e",
+  "red": "#64002c",
+  "green": "#5d731a",
+  "yellow": "#cd751c",
+  "blue": "#1d6da1",
+  "purple": "#b7077e",
+  "cyan": "#42a38c",
+  "white": "#f3e0b8",
+  "brightBlack": "#331e4d",
+  "brightRed": "#d02063",
+  "brightGreen": "#b4ce59",
+  "brightYellow": "#fac357",
+  "brightBlue": "#40a4cf",
+  "brightPurple": "#f12aae",
+  "brightCyan": "#62caa8",
+  "brightWhite": "#fff5db",
+  "background": "#0e0d15",
+  "foreground": "#dbd1b9"
+}

--- a/windowsterminal/ForestBlue.json
+++ b/windowsterminal/ForestBlue.json
@@ -1,0 +1,21 @@
+{
+  "name": "ForestBlue",
+  "black": "#333333",
+  "red": "#f8818e",
+  "green": "#92d3a2",
+  "yellow": "#1a8e63",
+  "blue": "#8ed0ce",
+  "purple": "#5e468c",
+  "cyan": "#31658c",
+  "white": "#e2d8cd",
+  "brightBlack": "#3d3d3d",
+  "brightRed": "#fb3d66",
+  "brightGreen": "#6bb48d",
+  "brightYellow": "#30c85a",
+  "brightBlue": "#39a7a2",
+  "brightPurple": "#7e62b3",
+  "brightCyan": "#6096bf",
+  "brightWhite": "#e2d8cd",
+  "background": "#051519",
+  "foreground": "#e2d8cd"
+}

--- a/windowsterminal/Framer.json
+++ b/windowsterminal/Framer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Framer",
+  "black": "#141414",
+  "red": "#ff5555",
+  "green": "#98ec65",
+  "yellow": "#ffcc33",
+  "blue": "#00aaff",
+  "purple": "#aa88ff",
+  "cyan": "#88ddff",
+  "white": "#cccccc",
+  "brightBlack": "#414141",
+  "brightRed": "#ff8888",
+  "brightGreen": "#b6f292",
+  "brightYellow": "#ffd966",
+  "brightBlue": "#33bbff",
+  "brightPurple": "#cebbff",
+  "brightCyan": "#bbecff",
+  "brightWhite": "#ffffff",
+  "background": "#111111",
+  "foreground": "#777777"
+}

--- a/windowsterminal/FrontEndDelight.json
+++ b/windowsterminal/FrontEndDelight.json
@@ -1,0 +1,21 @@
+{
+  "name": "FrontEndDelight",
+  "black": "#242526",
+  "red": "#f8511b",
+  "green": "#565747",
+  "yellow": "#fa771d",
+  "blue": "#2c70b7",
+  "purple": "#f02e4f",
+  "cyan": "#3ca1a6",
+  "white": "#adadad",
+  "brightBlack": "#5fac6d",
+  "brightRed": "#f74319",
+  "brightGreen": "#74ec4c",
+  "brightYellow": "#fdc325",
+  "brightBlue": "#3393ca",
+  "brightPurple": "#e75e4f",
+  "brightCyan": "#4fbce6",
+  "brightWhite": "#8c735b",
+  "background": "#1b1c1d",
+  "foreground": "#adadad"
+}

--- a/windowsterminal/FunForrest.json
+++ b/windowsterminal/FunForrest.json
@@ -1,0 +1,21 @@
+{
+  "name": "FunForrest",
+  "black": "#000000",
+  "red": "#d6262b",
+  "green": "#919c00",
+  "yellow": "#be8a13",
+  "blue": "#4699a3",
+  "purple": "#8d4331",
+  "cyan": "#da8213",
+  "white": "#ddc265",
+  "brightBlack": "#7f6a55",
+  "brightRed": "#e55a1c",
+  "brightGreen": "#bfc65a",
+  "brightYellow": "#ffcb1b",
+  "brightBlue": "#7cc9cf",
+  "brightPurple": "#d26349",
+  "brightCyan": "#e6a96b",
+  "brightWhite": "#ffeaa3",
+  "background": "#251200",
+  "foreground": "#dec165"
+}

--- a/windowsterminal/Galaxy.json
+++ b/windowsterminal/Galaxy.json
@@ -1,0 +1,21 @@
+{
+  "name": "Galaxy",
+  "black": "#000000",
+  "red": "#f9555f",
+  "green": "#21b089",
+  "yellow": "#fef02a",
+  "blue": "#589df6",
+  "purple": "#944d95",
+  "cyan": "#1f9ee7",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#fa8c8f",
+  "brightGreen": "#35bb9a",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#589df6",
+  "brightPurple": "#e75699",
+  "brightCyan": "#3979bc",
+  "brightWhite": "#ffffff",
+  "background": "#1d2837",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Github.json
+++ b/windowsterminal/Github.json
@@ -1,0 +1,21 @@
+{
+  "name": "Github",
+  "black": "#3e3e3e",
+  "red": "#970b16",
+  "green": "#07962a",
+  "yellow": "#f8eec7",
+  "blue": "#003e8a",
+  "purple": "#e94691",
+  "cyan": "#89d1ec",
+  "white": "#ffffff",
+  "brightBlack": "#666666",
+  "brightRed": "#de0000",
+  "brightGreen": "#87d5a2",
+  "brightYellow": "#f1d007",
+  "brightBlue": "#2e6cba",
+  "brightPurple": "#ffa29f",
+  "brightCyan": "#1cfafe",
+  "brightWhite": "#ffffff",
+  "background": "#f4f4f4",
+  "foreground": "#3e3e3e"
+}

--- a/windowsterminal/Glacier.json
+++ b/windowsterminal/Glacier.json
@@ -1,0 +1,21 @@
+{
+  "name": "Glacier",
+  "black": "#2e343c",
+  "red": "#bd0f2f",
+  "green": "#35a770",
+  "yellow": "#fb9435",
+  "blue": "#1f5872",
+  "purple": "#bd2523",
+  "cyan": "#778397",
+  "white": "#ffffff",
+  "brightBlack": "#404a55",
+  "brightRed": "#bd0f2f",
+  "brightGreen": "#49e998",
+  "brightYellow": "#fddf6e",
+  "brightBlue": "#2a8bc1",
+  "brightPurple": "#ea4727",
+  "brightCyan": "#a0b6d3",
+  "brightWhite": "#ffffff",
+  "background": "#0c1115",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Grape.json
+++ b/windowsterminal/Grape.json
@@ -1,0 +1,21 @@
+{
+  "name": "Grape",
+  "black": "#2d283f",
+  "red": "#ed2261",
+  "green": "#1fa91b",
+  "yellow": "#8ddc20",
+  "blue": "#487df4",
+  "purple": "#8d35c9",
+  "cyan": "#3bdeed",
+  "white": "#9e9ea0",
+  "brightBlack": "#59516a",
+  "brightRed": "#f0729a",
+  "brightGreen": "#53aa5e",
+  "brightYellow": "#b2dc87",
+  "brightBlue": "#a9bcec",
+  "brightPurple": "#ad81c2",
+  "brightCyan": "#9de3eb",
+  "brightWhite": "#a288f7",
+  "background": "#171423",
+  "foreground": "#9f9fa1"
+}

--- a/windowsterminal/Grass.json
+++ b/windowsterminal/Grass.json
@@ -1,0 +1,21 @@
+{
+  "name": "Grass",
+  "black": "#000000",
+  "red": "#bb0000",
+  "green": "#00bb00",
+  "yellow": "#e7b000",
+  "blue": "#0000a3",
+  "purple": "#950062",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#bb0000",
+  "brightGreen": "#00bb00",
+  "brightYellow": "#e7b000",
+  "brightBlue": "#0000bb",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#13773d",
+  "foreground": "#fff0a5"
+}

--- a/windowsterminal/Gruvbox Dark.json
+++ b/windowsterminal/Gruvbox Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Gruvbox Dark",
+  "black": "#161819",
+  "red": "#f73028",
+  "green": "#aab01e",
+  "yellow": "#f7b125",
+  "blue": "#719586",
+  "purple": "#c77089",
+  "cyan": "#7db669",
+  "white": "#faefbb",
+  "brightBlack": "#7f7061",
+  "brightRed": "#be0f17",
+  "brightGreen": "#868715",
+  "brightYellow": "#cc881a",
+  "brightBlue": "#377375",
+  "brightPurple": "#a04b73",
+  "brightCyan": "#578e57",
+  "brightWhite": "#e6d4a3",
+  "background": "#1e1e1e",
+  "foreground": "#e6d4a3"
+}

--- a/windowsterminal/Hacktober.json
+++ b/windowsterminal/Hacktober.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hacktober",
+  "black": "#191918",
+  "red": "#b34538",
+  "green": "#587744",
+  "yellow": "#d08949",
+  "blue": "#206ec5",
+  "purple": "#864651",
+  "cyan": "#ac9166",
+  "white": "#f1eee7",
+  "brightBlack": "#2c2b2a",
+  "brightRed": "#b33323",
+  "brightGreen": "#42824a",
+  "brightYellow": "#c75a22",
+  "brightBlue": "#5389c5",
+  "brightPurple": "#e795a5",
+  "brightCyan": "#ebc587",
+  "brightWhite": "#ffffff",
+  "background": "#141414",
+  "foreground": "#c9c9c9"
+}

--- a/windowsterminal/Hardcore.json
+++ b/windowsterminal/Hardcore.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hardcore",
+  "black": "#1b1d1e",
+  "red": "#f92672",
+  "green": "#a6e22e",
+  "yellow": "#fd971f",
+  "blue": "#66d9ef",
+  "purple": "#9e6ffe",
+  "cyan": "#5e7175",
+  "white": "#ccccc6",
+  "brightBlack": "#505354",
+  "brightRed": "#ff669d",
+  "brightGreen": "#beed5f",
+  "brightYellow": "#e6db74",
+  "brightBlue": "#66d9ef",
+  "brightPurple": "#9e6ffe",
+  "brightCyan": "#a3babf",
+  "brightWhite": "#f8f8f2",
+  "background": "#121212",
+  "foreground": "#a0a0a0"
+}

--- a/windowsterminal/Harper.json
+++ b/windowsterminal/Harper.json
@@ -1,0 +1,21 @@
+{
+  "name": "Harper",
+  "black": "#010101",
+  "red": "#f8b63f",
+  "green": "#7fb5e1",
+  "yellow": "#d6da25",
+  "blue": "#489e48",
+  "purple": "#b296c6",
+  "cyan": "#f5bfd7",
+  "white": "#a8a49d",
+  "brightBlack": "#726e6a",
+  "brightRed": "#f8b63f",
+  "brightGreen": "#7fb5e1",
+  "brightYellow": "#d6da25",
+  "brightBlue": "#489e48",
+  "brightPurple": "#b296c6",
+  "brightCyan": "#f5bfd7",
+  "brightWhite": "#fefbea",
+  "background": "#010101",
+  "foreground": "#a8a49d"
+}

--- a/windowsterminal/Highway.json
+++ b/windowsterminal/Highway.json
@@ -1,0 +1,21 @@
+{
+  "name": "Highway",
+  "black": "#000000",
+  "red": "#d00e18",
+  "green": "#138034",
+  "yellow": "#ffcb3e",
+  "blue": "#006bb3",
+  "purple": "#6b2775",
+  "cyan": "#384564",
+  "white": "#ededed",
+  "brightBlack": "#5d504a",
+  "brightRed": "#f07e18",
+  "brightGreen": "#b1d130",
+  "brightYellow": "#fff120",
+  "brightBlue": "#4fc2fd",
+  "brightPurple": "#de0071",
+  "brightCyan": "#5d504a",
+  "brightWhite": "#ffffff",
+  "background": "#222225",
+  "foreground": "#ededed"
+}

--- a/windowsterminal/Hipster Green.json
+++ b/windowsterminal/Hipster Green.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hipster Green",
+  "black": "#000000",
+  "red": "#b6214a",
+  "green": "#00a600",
+  "yellow": "#bfbf00",
+  "blue": "#246eb2",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#86a93e",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#100b05",
+  "foreground": "#84c138"
+}

--- a/windowsterminal/Homebrew.json
+++ b/windowsterminal/Homebrew.json
@@ -1,0 +1,21 @@
+{
+  "name": "Homebrew",
+  "black": "#000000",
+  "red": "#990000",
+  "green": "#00a600",
+  "yellow": "#999900",
+  "blue": "#0000b2",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#00d900",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#000000",
+  "foreground": "#00ff00"
+}

--- a/windowsterminal/Hopscotch.256.json
+++ b/windowsterminal/Hopscotch.256.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hopscotch.256",
+  "black": "#322931",
+  "red": "#dd464c",
+  "green": "#8fc13e",
+  "yellow": "#fdcc59",
+  "blue": "#1290bf",
+  "purple": "#c85e7c",
+  "cyan": "#149b93",
+  "white": "#b9b5b8",
+  "brightBlack": "#797379",
+  "brightRed": "#dd464c",
+  "brightGreen": "#8fc13e",
+  "brightYellow": "#fdcc59",
+  "brightBlue": "#1290bf",
+  "brightPurple": "#c85e7c",
+  "brightCyan": "#149b93",
+  "brightWhite": "#ffffff",
+  "background": "#322931",
+  "foreground": "#b9b5b8"
+}

--- a/windowsterminal/Hopscotch.json
+++ b/windowsterminal/Hopscotch.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hopscotch",
+  "black": "#322931",
+  "red": "#dd464c",
+  "green": "#8fc13e",
+  "yellow": "#fdcc59",
+  "blue": "#1290bf",
+  "purple": "#c85e7c",
+  "cyan": "#149b93",
+  "white": "#b9b5b8",
+  "brightBlack": "#797379",
+  "brightRed": "#fd8b19",
+  "brightGreen": "#433b42",
+  "brightYellow": "#5c545b",
+  "brightBlue": "#989498",
+  "brightPurple": "#d5d3d5",
+  "brightCyan": "#b33508",
+  "brightWhite": "#ffffff",
+  "background": "#322931",
+  "foreground": "#b9b5b8"
+}

--- a/windowsterminal/Hurtado.json
+++ b/windowsterminal/Hurtado.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hurtado",
+  "black": "#575757",
+  "red": "#ff1b00",
+  "green": "#a5e055",
+  "yellow": "#fbe74a",
+  "blue": "#496487",
+  "purple": "#fd5ff1",
+  "cyan": "#86e9fe",
+  "white": "#cbcccb",
+  "brightBlack": "#262626",
+  "brightRed": "#d51d00",
+  "brightGreen": "#a5df55",
+  "brightYellow": "#fbe84a",
+  "brightBlue": "#89beff",
+  "brightPurple": "#c001c1",
+  "brightCyan": "#86eafe",
+  "brightWhite": "#dbdbdb",
+  "background": "#000000",
+  "foreground": "#dbdbdb"
+}

--- a/windowsterminal/Hybrid.json
+++ b/windowsterminal/Hybrid.json
@@ -1,0 +1,21 @@
+{
+  "name": "Hybrid",
+  "black": "#2a2e33",
+  "red": "#b84d51",
+  "green": "#b3bf5a",
+  "yellow": "#e4b55e",
+  "blue": "#6e90b0",
+  "purple": "#a17eac",
+  "cyan": "#7fbfb4",
+  "white": "#b5b9b6",
+  "brightBlack": "#1d1f22",
+  "brightRed": "#8d2e32",
+  "brightGreen": "#798431",
+  "brightYellow": "#e58a50",
+  "brightBlue": "#4b6b88",
+  "brightPurple": "#6e5079",
+  "brightCyan": "#4d7b74",
+  "brightWhite": "#5a626a",
+  "background": "#161719",
+  "foreground": "#b7bcba"
+}

--- a/windowsterminal/IC_Green_PPL.json
+++ b/windowsterminal/IC_Green_PPL.json
@@ -1,0 +1,21 @@
+{
+  "name": "IC_Green_PPL",
+  "black": "#1f1f1f",
+  "red": "#fb002a",
+  "green": "#339c24",
+  "yellow": "#659b25",
+  "blue": "#149b45",
+  "purple": "#53b82c",
+  "cyan": "#2cb868",
+  "white": "#e0ffef",
+  "brightBlack": "#032710",
+  "brightRed": "#a7ff3f",
+  "brightGreen": "#9fff6d",
+  "brightYellow": "#d2ff6d",
+  "brightBlue": "#72ffb5",
+  "brightPurple": "#50ff3e",
+  "brightCyan": "#22ff71",
+  "brightWhite": "#daefd0",
+  "background": "#3a3d3f",
+  "foreground": "#d9efd3"
+}

--- a/windowsterminal/IC_Orange_PPL.json
+++ b/windowsterminal/IC_Orange_PPL.json
@@ -1,0 +1,21 @@
+{
+  "name": "IC_Orange_PPL",
+  "black": "#000000",
+  "red": "#c13900",
+  "green": "#a4a900",
+  "yellow": "#caaf00",
+  "blue": "#bd6d00",
+  "purple": "#fc5e00",
+  "cyan": "#f79500",
+  "white": "#ffc88a",
+  "brightBlack": "#6a4f2a",
+  "brightRed": "#ff8c68",
+  "brightGreen": "#f6ff40",
+  "brightYellow": "#ffe36e",
+  "brightBlue": "#ffbe55",
+  "brightPurple": "#fc874f",
+  "brightCyan": "#c69752",
+  "brightWhite": "#fafaff",
+  "background": "#262626",
+  "foreground": "#ffcb83"
+}

--- a/windowsterminal/IR_Black.json
+++ b/windowsterminal/IR_Black.json
@@ -1,0 +1,21 @@
+{
+  "name": "IR_Black",
+  "black": "#4f4f4f",
+  "red": "#fa6c60",
+  "green": "#a8ff60",
+  "yellow": "#fffeb7",
+  "blue": "#96cafe",
+  "purple": "#fa73fd",
+  "cyan": "#c6c5fe",
+  "white": "#efedef",
+  "brightBlack": "#7b7b7b",
+  "brightRed": "#fcb6b0",
+  "brightGreen": "#cfffab",
+  "brightYellow": "#ffffcc",
+  "brightBlue": "#b5dcff",
+  "brightPurple": "#fb9cfe",
+  "brightCyan": "#e0e0fe",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#f1f1f1"
+}

--- a/windowsterminal/Jackie Brown.json
+++ b/windowsterminal/Jackie Brown.json
@@ -1,0 +1,21 @@
+{
+  "name": "Jackie Brown",
+  "black": "#2c1d16",
+  "red": "#ef5734",
+  "green": "#2baf2b",
+  "yellow": "#bebf00",
+  "blue": "#246eb2",
+  "purple": "#d05ec1",
+  "cyan": "#00acee",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#86a93e",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#2c1d16",
+  "foreground": "#ffcc2f"
+}

--- a/windowsterminal/Japanesque.json
+++ b/windowsterminal/Japanesque.json
@@ -1,0 +1,21 @@
+{
+  "name": "Japanesque",
+  "black": "#343935",
+  "red": "#cf3f61",
+  "green": "#7bb75b",
+  "yellow": "#e9b32a",
+  "blue": "#4c9ad4",
+  "purple": "#a57fc4",
+  "cyan": "#389aad",
+  "white": "#fafaf6",
+  "brightBlack": "#595b59",
+  "brightRed": "#d18fa6",
+  "brightGreen": "#767f2c",
+  "brightYellow": "#78592f",
+  "brightBlue": "#135979",
+  "brightPurple": "#604291",
+  "brightCyan": "#76bbca",
+  "brightWhite": "#b2b5ae",
+  "background": "#1e1e1e",
+  "foreground": "#f7f6ec"
+}

--- a/windowsterminal/Jellybeans.json
+++ b/windowsterminal/Jellybeans.json
@@ -1,0 +1,21 @@
+{
+  "name": "Jellybeans",
+  "black": "#929292",
+  "red": "#e27373",
+  "green": "#94b979",
+  "yellow": "#ffba7b",
+  "blue": "#97bedc",
+  "purple": "#e1c0fa",
+  "cyan": "#00988e",
+  "white": "#dedede",
+  "brightBlack": "#bdbdbd",
+  "brightRed": "#ffa1a1",
+  "brightGreen": "#bddeab",
+  "brightYellow": "#ffdca0",
+  "brightBlue": "#b1d8f6",
+  "brightPurple": "#fbdaff",
+  "brightCyan": "#1ab2a8",
+  "brightWhite": "#ffffff",
+  "background": "#121212",
+  "foreground": "#dedede"
+}

--- a/windowsterminal/JetBrains Darcula.json
+++ b/windowsterminal/JetBrains Darcula.json
@@ -1,0 +1,21 @@
+{
+  "name": "JetBrains Darcula",
+  "black": "#000000",
+  "red": "#fa5355",
+  "green": "#126e00",
+  "yellow": "#c2c300",
+  "blue": "#4581eb",
+  "purple": "#fa54ff",
+  "cyan": "#33c2c1",
+  "white": "#adadad",
+  "brightBlack": "#555555",
+  "brightRed": "#fb7172",
+  "brightGreen": "#67ff4f",
+  "brightYellow": "#ffff00",
+  "brightBlue": "#6d9df1",
+  "brightPurple": "#fb82ff",
+  "brightCyan": "#60d3d1",
+  "brightWhite": "#eeeeee",
+  "background": "#202020",
+  "foreground": "#adadad"
+}

--- a/windowsterminal/Kibble.json
+++ b/windowsterminal/Kibble.json
@@ -1,0 +1,21 @@
+{
+  "name": "Kibble",
+  "black": "#4d4d4d",
+  "red": "#c70031",
+  "green": "#29cf13",
+  "yellow": "#d8e30e",
+  "blue": "#3449d1",
+  "purple": "#8400ff",
+  "cyan": "#0798ab",
+  "white": "#e2d1e3",
+  "brightBlack": "#5a5a5a",
+  "brightRed": "#f01578",
+  "brightGreen": "#6ce05c",
+  "brightYellow": "#f3f79e",
+  "brightBlue": "#97a4f7",
+  "brightPurple": "#c495f0",
+  "brightCyan": "#68f2e0",
+  "brightWhite": "#ffffff",
+  "background": "#0e100a",
+  "foreground": "#f7f7f7"
+}

--- a/windowsterminal/Kolorit.json
+++ b/windowsterminal/Kolorit.json
@@ -1,0 +1,21 @@
+{
+  "name": "Kolorit",
+  "black": "#1d1a1e",
+  "red": "#ff5b82",
+  "green": "#47d7a1",
+  "yellow": "#e8e562",
+  "blue": "#5db4ee",
+  "purple": "#da6cda",
+  "cyan": "#57e9eb",
+  "white": "#ededed",
+  "brightBlack": "#1d1a1e",
+  "brightRed": "#ff5b82",
+  "brightGreen": "#47d7a1",
+  "brightYellow": "#e8e562",
+  "brightBlue": "#5db4ee",
+  "brightPurple": "#da6cda",
+  "brightCyan": "#57e9eb",
+  "brightWhite": "#ededed",
+  "background": "#1d1a1e",
+  "foreground": "#efecec"
+}

--- a/windowsterminal/Lab Fox.json
+++ b/windowsterminal/Lab Fox.json
@@ -1,0 +1,21 @@
+{
+  "name": "Lab Fox",
+  "black": "#2e2e2e",
+  "red": "#fc6d26",
+  "green": "#3eb383",
+  "yellow": "#fca121",
+  "blue": "#db3b21",
+  "purple": "#380d75",
+  "cyan": "#6e49cb",
+  "white": "#ffffff",
+  "brightBlack": "#464646",
+  "brightRed": "#ff6517",
+  "brightGreen": "#53eaa8",
+  "brightYellow": "#fca013",
+  "brightBlue": "#db501f",
+  "brightPurple": "#441090",
+  "brightCyan": "#7d53e7",
+  "brightWhite": "#ffffff",
+  "background": "#2e2e2e",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Later This Evening.json
+++ b/windowsterminal/Later This Evening.json
@@ -1,0 +1,21 @@
+{
+  "name": "Later This Evening",
+  "black": "#2b2b2b",
+  "red": "#d45a60",
+  "green": "#afba67",
+  "yellow": "#e5d289",
+  "blue": "#a0bad6",
+  "purple": "#c092d6",
+  "cyan": "#91bfb7",
+  "white": "#3c3d3d",
+  "brightBlack": "#454747",
+  "brightRed": "#d3232f",
+  "brightGreen": "#aabb39",
+  "brightYellow": "#e5be39",
+  "brightBlue": "#6699d6",
+  "brightPurple": "#ab53d6",
+  "brightCyan": "#5fc0ae",
+  "brightWhite": "#c1c2c2",
+  "background": "#222222",
+  "foreground": "#959595"
+}

--- a/windowsterminal/Lavandula.json
+++ b/windowsterminal/Lavandula.json
@@ -1,0 +1,21 @@
+{
+  "name": "Lavandula",
+  "black": "#230046",
+  "red": "#7d1625",
+  "green": "#337e6f",
+  "yellow": "#7f6f49",
+  "blue": "#4f4a7f",
+  "purple": "#5a3f7f",
+  "cyan": "#58777f",
+  "white": "#736e7d",
+  "brightBlack": "#372d46",
+  "brightRed": "#e05167",
+  "brightGreen": "#52e0c4",
+  "brightYellow": "#e0c386",
+  "brightBlue": "#8e87e0",
+  "brightPurple": "#a776e0",
+  "brightCyan": "#9ad4e0",
+  "brightWhite": "#8c91fa",
+  "background": "#050014",
+  "foreground": "#736e7d"
+}

--- a/windowsterminal/LiquidCarbon.json
+++ b/windowsterminal/LiquidCarbon.json
@@ -1,0 +1,21 @@
+{
+  "name": "LiquidCarbon",
+  "black": "#000000",
+  "red": "#ff3030",
+  "green": "#559a70",
+  "yellow": "#ccac00",
+  "blue": "#0099cc",
+  "purple": "#cc69c8",
+  "cyan": "#7ac4cc",
+  "white": "#bccccc",
+  "brightBlack": "#000000",
+  "brightRed": "#ff3030",
+  "brightGreen": "#559a70",
+  "brightYellow": "#ccac00",
+  "brightBlue": "#0099cc",
+  "brightPurple": "#cc69c8",
+  "brightCyan": "#7ac4cc",
+  "brightWhite": "#bccccc",
+  "background": "#303030",
+  "foreground": "#afc2c2"
+}

--- a/windowsterminal/LiquidCarbonTransparent.json
+++ b/windowsterminal/LiquidCarbonTransparent.json
@@ -1,0 +1,21 @@
+{
+  "name": "LiquidCarbonTransparent",
+  "black": "#000000",
+  "red": "#ff3030",
+  "green": "#559a70",
+  "yellow": "#ccac00",
+  "blue": "#0099cc",
+  "purple": "#cc69c8",
+  "cyan": "#7ac4cc",
+  "white": "#bccccc",
+  "brightBlack": "#000000",
+  "brightRed": "#ff3030",
+  "brightGreen": "#559a70",
+  "brightYellow": "#ccac00",
+  "brightBlue": "#0099cc",
+  "brightPurple": "#cc69c8",
+  "brightCyan": "#7ac4cc",
+  "brightWhite": "#bccccc",
+  "background": "#000000",
+  "foreground": "#afc2c2"
+}

--- a/windowsterminal/LiquidCarbonTransparentInverse.json
+++ b/windowsterminal/LiquidCarbonTransparentInverse.json
@@ -1,0 +1,21 @@
+{
+  "name": "LiquidCarbonTransparentInverse",
+  "black": "#bccccd",
+  "red": "#ff3030",
+  "green": "#559a70",
+  "yellow": "#ccac00",
+  "blue": "#0099cc",
+  "purple": "#cc69c8",
+  "cyan": "#7ac4cc",
+  "white": "#000000",
+  "brightBlack": "#ffffff",
+  "brightRed": "#ff3030",
+  "brightGreen": "#559a70",
+  "brightYellow": "#ccac00",
+  "brightBlue": "#0099cc",
+  "brightPurple": "#cc69c8",
+  "brightCyan": "#7ac4cc",
+  "brightWhite": "#000000",
+  "background": "#000000",
+  "foreground": "#afc2c2"
+}

--- a/windowsterminal/Man Page.json
+++ b/windowsterminal/Man Page.json
@@ -1,0 +1,21 @@
+{
+  "name": "Man Page",
+  "black": "#000000",
+  "red": "#cc0000",
+  "green": "#00a600",
+  "yellow": "#999900",
+  "blue": "#0000b2",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#cccccc",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#00d900",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#fef49c",
+  "foreground": "#000000"
+}

--- a/windowsterminal/Material.json
+++ b/windowsterminal/Material.json
@@ -1,0 +1,21 @@
+{
+  "name": "Material",
+  "black": "#212121",
+  "red": "#b7141f",
+  "green": "#457b24",
+  "yellow": "#f6981e",
+  "blue": "#134eb2",
+  "purple": "#560088",
+  "cyan": "#0e717c",
+  "white": "#efefef",
+  "brightBlack": "#424242",
+  "brightRed": "#e83b3f",
+  "brightGreen": "#7aba3a",
+  "brightYellow": "#ffea2e",
+  "brightBlue": "#54a4f3",
+  "brightPurple": "#aa4dbc",
+  "brightCyan": "#26bbd1",
+  "brightWhite": "#d9d9d9",
+  "background": "#eaeaea",
+  "foreground": "#232322"
+}

--- a/windowsterminal/MaterialDark.json
+++ b/windowsterminal/MaterialDark.json
@@ -1,0 +1,21 @@
+{
+  "name": "MaterialDark",
+  "black": "#212121",
+  "red": "#b7141f",
+  "green": "#457b24",
+  "yellow": "#f6981e",
+  "blue": "#134eb2",
+  "purple": "#560088",
+  "cyan": "#0e717c",
+  "white": "#efefef",
+  "brightBlack": "#424242",
+  "brightRed": "#e83b3f",
+  "brightGreen": "#7aba3a",
+  "brightYellow": "#ffea2e",
+  "brightBlue": "#54a4f3",
+  "brightPurple": "#aa4dbc",
+  "brightCyan": "#26bbd1",
+  "brightWhite": "#d9d9d9",
+  "background": "#232322",
+  "foreground": "#e5e5e5"
+}

--- a/windowsterminal/Mathias.json
+++ b/windowsterminal/Mathias.json
@@ -1,0 +1,21 @@
+{
+  "name": "Mathias",
+  "black": "#000000",
+  "red": "#e52222",
+  "green": "#a6e32d",
+  "yellow": "#fc951e",
+  "blue": "#c48dff",
+  "purple": "#fa2573",
+  "cyan": "#67d9f0",
+  "white": "#f2f2f2",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/Medallion.json
+++ b/windowsterminal/Medallion.json
@@ -1,0 +1,21 @@
+{
+  "name": "Medallion",
+  "black": "#000000",
+  "red": "#b64c00",
+  "green": "#7c8b16",
+  "yellow": "#d3bd26",
+  "blue": "#616bb0",
+  "purple": "#8c5a90",
+  "cyan": "#916c25",
+  "white": "#cac29a",
+  "brightBlack": "#5e5219",
+  "brightRed": "#ff9149",
+  "brightGreen": "#b2ca3b",
+  "brightYellow": "#ffe54a",
+  "brightBlue": "#acb8ff",
+  "brightPurple": "#ffa0ff",
+  "brightCyan": "#ffbc51",
+  "brightWhite": "#fed698",
+  "background": "#1d1908",
+  "foreground": "#cac296"
+}

--- a/windowsterminal/Misterioso.json
+++ b/windowsterminal/Misterioso.json
@@ -1,0 +1,21 @@
+{
+  "name": "Misterioso",
+  "black": "#000000",
+  "red": "#ff4242",
+  "green": "#74af68",
+  "yellow": "#ffad29",
+  "blue": "#338f86",
+  "purple": "#9414e6",
+  "cyan": "#23d7d7",
+  "white": "#e1e1e0",
+  "brightBlack": "#555555",
+  "brightRed": "#ff3242",
+  "brightGreen": "#74cd68",
+  "brightYellow": "#ffb929",
+  "brightBlue": "#23d7d7",
+  "brightPurple": "#ff37ff",
+  "brightCyan": "#00ede1",
+  "brightWhite": "#ffffff",
+  "background": "#2d3743",
+  "foreground": "#e1e1e0"
+}

--- a/windowsterminal/Molokai.json
+++ b/windowsterminal/Molokai.json
@@ -1,0 +1,21 @@
+{
+  "name": "Molokai",
+  "black": "#121212",
+  "red": "#fa2573",
+  "green": "#98e123",
+  "yellow": "#dfd460",
+  "blue": "#1080d0",
+  "purple": "#8700ff",
+  "cyan": "#43a8d0",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#f6669d",
+  "brightGreen": "#b1e05f",
+  "brightYellow": "#fff26d",
+  "brightBlue": "#00afff",
+  "brightPurple": "#af87ff",
+  "brightCyan": "#51ceff",
+  "brightWhite": "#ffffff",
+  "background": "#121212",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/MonaLisa.json
+++ b/windowsterminal/MonaLisa.json
@@ -1,0 +1,21 @@
+{
+  "name": "MonaLisa",
+  "black": "#351b0e",
+  "red": "#9b291c",
+  "green": "#636232",
+  "yellow": "#c36e28",
+  "blue": "#515c5d",
+  "purple": "#9b1d29",
+  "cyan": "#588056",
+  "white": "#f7d75c",
+  "brightBlack": "#874228",
+  "brightRed": "#ff4331",
+  "brightGreen": "#b4b264",
+  "brightYellow": "#ff9566",
+  "brightBlue": "#9eb2b4",
+  "brightPurple": "#ff5b6a",
+  "brightCyan": "#8acd8f",
+  "brightWhite": "#ffe598",
+  "background": "#120b0d",
+  "foreground": "#f7d66a"
+}

--- a/windowsterminal/Monokai Remastered.json
+++ b/windowsterminal/Monokai Remastered.json
@@ -1,0 +1,21 @@
+{
+  "name": "Monokai Remastered",
+  "black": "#1a1a1a",
+  "red": "#f4005f",
+  "green": "#98e024",
+  "yellow": "#fd971f",
+  "blue": "#9d65ff",
+  "purple": "#f4005f",
+  "cyan": "#58d1eb",
+  "white": "#c4c5b5",
+  "brightBlack": "#625e4c",
+  "brightRed": "#f4005f",
+  "brightGreen": "#98e024",
+  "brightYellow": "#e0d561",
+  "brightBlue": "#9d65ff",
+  "brightPurple": "#f4005f",
+  "brightCyan": "#58d1eb",
+  "brightWhite": "#f6f6ef",
+  "background": "#0c0c0c",
+  "foreground": "#d9d9d9"
+}

--- a/windowsterminal/Monokai Soda.json
+++ b/windowsterminal/Monokai Soda.json
@@ -1,0 +1,21 @@
+{
+  "name": "Monokai Soda",
+  "black": "#1a1a1a",
+  "red": "#f4005f",
+  "green": "#98e024",
+  "yellow": "#fa8419",
+  "blue": "#9d65ff",
+  "purple": "#f4005f",
+  "cyan": "#58d1eb",
+  "white": "#c4c5b5",
+  "brightBlack": "#625e4c",
+  "brightRed": "#f4005f",
+  "brightGreen": "#98e024",
+  "brightYellow": "#e0d561",
+  "brightBlue": "#9d65ff",
+  "brightPurple": "#f4005f",
+  "brightCyan": "#58d1eb",
+  "brightWhite": "#f6f6ef",
+  "background": "#1a1a1a",
+  "foreground": "#c4c5b5"
+}

--- a/windowsterminal/Monokai Vivid.json
+++ b/windowsterminal/Monokai Vivid.json
@@ -1,0 +1,21 @@
+{
+  "name": "Monokai Vivid",
+  "black": "#121212",
+  "red": "#fa2934",
+  "green": "#98e123",
+  "yellow": "#fff30a",
+  "blue": "#0443ff",
+  "purple": "#f800f8",
+  "cyan": "#01b6ed",
+  "white": "#ffffff",
+  "brightBlack": "#838383",
+  "brightRed": "#f6669d",
+  "brightGreen": "#b1e05f",
+  "brightYellow": "#fff26d",
+  "brightBlue": "#0443ff",
+  "brightPurple": "#f200f6",
+  "brightCyan": "#51ceff",
+  "brightWhite": "#ffffff",
+  "background": "#121212",
+  "foreground": "#f9f9f9"
+}

--- a/windowsterminal/N0tch2k.json
+++ b/windowsterminal/N0tch2k.json
@@ -1,0 +1,21 @@
+{
+  "name": "N0tch2k",
+  "black": "#383838",
+  "red": "#a95551",
+  "green": "#666666",
+  "yellow": "#a98051",
+  "blue": "#657d3e",
+  "purple": "#767676",
+  "cyan": "#c9c9c9",
+  "white": "#d0b8a3",
+  "brightBlack": "#474747",
+  "brightRed": "#a97775",
+  "brightGreen": "#8c8c8c",
+  "brightYellow": "#a99175",
+  "brightBlue": "#98bd5e",
+  "brightPurple": "#a3a3a3",
+  "brightCyan": "#dcdcdc",
+  "brightWhite": "#d8c8bb",
+  "background": "#222222",
+  "foreground": "#a0a0a0"
+}

--- a/windowsterminal/Neopolitan.json
+++ b/windowsterminal/Neopolitan.json
@@ -1,0 +1,21 @@
+{
+  "name": "Neopolitan",
+  "black": "#000000",
+  "red": "#800000",
+  "green": "#61ce3c",
+  "yellow": "#fbde2d",
+  "blue": "#253b76",
+  "purple": "#ff0080",
+  "cyan": "#8da6ce",
+  "white": "#f8f8f8",
+  "brightBlack": "#000000",
+  "brightRed": "#800000",
+  "brightGreen": "#61ce3c",
+  "brightYellow": "#fbde2d",
+  "brightBlue": "#253b76",
+  "brightPurple": "#ff0080",
+  "brightCyan": "#8da6ce",
+  "brightWhite": "#f8f8f8",
+  "background": "#271f19",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Neutron.json
+++ b/windowsterminal/Neutron.json
@@ -1,0 +1,21 @@
+{
+  "name": "Neutron",
+  "black": "#23252b",
+  "red": "#b54036",
+  "green": "#5ab977",
+  "yellow": "#deb566",
+  "blue": "#6a7c93",
+  "purple": "#a4799d",
+  "cyan": "#3f94a8",
+  "white": "#e6e8ef",
+  "brightBlack": "#23252b",
+  "brightRed": "#b54036",
+  "brightGreen": "#5ab977",
+  "brightYellow": "#deb566",
+  "brightBlue": "#6a7c93",
+  "brightPurple": "#a4799d",
+  "brightCyan": "#3f94a8",
+  "brightWhite": "#ebedf2",
+  "background": "#1c1e22",
+  "foreground": "#e6e8ef"
+}

--- a/windowsterminal/Night Owlish Light.json
+++ b/windowsterminal/Night Owlish Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Night Owlish Light",
+  "black": "#011627",
+  "red": "#d3423e",
+  "green": "#2aa298",
+  "yellow": "#daaa01",
+  "blue": "#4876d6",
+  "purple": "#403f53",
+  "cyan": "#08916a",
+  "white": "#7a8181",
+  "brightBlack": "#7a8181",
+  "brightRed": "#f76e6e",
+  "brightGreen": "#49d0c5",
+  "brightYellow": "#dac26b",
+  "brightBlue": "#5ca7e4",
+  "brightPurple": "#697098",
+  "brightCyan": "#00c990",
+  "brightWhite": "#989fb1",
+  "background": "#ffffff",
+  "foreground": "#403f53"
+}

--- a/windowsterminal/NightLion v1.json
+++ b/windowsterminal/NightLion v1.json
@@ -1,0 +1,21 @@
+{
+  "name": "NightLion v1",
+  "black": "#4c4c4c",
+  "red": "#bb0000",
+  "green": "#5fde8f",
+  "yellow": "#f3f167",
+  "blue": "#276bd8",
+  "purple": "#bb00bb",
+  "cyan": "#00dadf",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/NightLion v2.json
+++ b/windowsterminal/NightLion v2.json
@@ -1,0 +1,21 @@
+{
+  "name": "NightLion v2",
+  "black": "#4c4c4c",
+  "red": "#bb0000",
+  "green": "#04f623",
+  "yellow": "#f3f167",
+  "blue": "#64d0f0",
+  "purple": "#ce6fdb",
+  "cyan": "#00dadf",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#7df71d",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#62cbe8",
+  "brightPurple": "#ff9bf5",
+  "brightCyan": "#00ccd8",
+  "brightWhite": "#ffffff",
+  "background": "#171717",
+  "foreground": "#bbbbbb"
+}

--- a/windowsterminal/Nocturnal Winter.json
+++ b/windowsterminal/Nocturnal Winter.json
@@ -1,0 +1,21 @@
+{
+  "name": "Nocturnal Winter",
+  "black": "#4d4d4d",
+  "red": "#f12d52",
+  "green": "#09cd7e",
+  "yellow": "#f5f17a",
+  "blue": "#3182e0",
+  "purple": "#ff2b6d",
+  "cyan": "#09c87a",
+  "white": "#fcfcfc",
+  "brightBlack": "#808080",
+  "brightRed": "#f16d86",
+  "brightGreen": "#0ae78d",
+  "brightYellow": "#fffc67",
+  "brightBlue": "#6096ff",
+  "brightPurple": "#ff78a2",
+  "brightCyan": "#0ae78d",
+  "brightWhite": "#ffffff",
+  "background": "#0d0d17",
+  "foreground": "#e6e5e5"
+}

--- a/windowsterminal/Novel.json
+++ b/windowsterminal/Novel.json
@@ -1,0 +1,21 @@
+{
+  "name": "Novel",
+  "black": "#000000",
+  "red": "#cc0000",
+  "green": "#009600",
+  "yellow": "#d06b00",
+  "blue": "#0000cc",
+  "purple": "#cc00cc",
+  "cyan": "#0087cc",
+  "white": "#cccccc",
+  "brightBlack": "#808080",
+  "brightRed": "#cc0000",
+  "brightGreen": "#009600",
+  "brightYellow": "#d06b00",
+  "brightBlue": "#0000cc",
+  "brightPurple": "#cc00cc",
+  "brightCyan": "#0087cc",
+  "brightWhite": "#ffffff",
+  "background": "#dfdbc3",
+  "foreground": "#3b2322"
+}

--- a/windowsterminal/Obsidian.json
+++ b/windowsterminal/Obsidian.json
@@ -1,0 +1,21 @@
+{
+  "name": "Obsidian",
+  "black": "#000000",
+  "red": "#a60001",
+  "green": "#00bb00",
+  "yellow": "#fecd22",
+  "blue": "#3a9bdb",
+  "purple": "#bb00bb",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#ff0003",
+  "brightGreen": "#93c863",
+  "brightYellow": "#fef874",
+  "brightBlue": "#a1d7ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#283033",
+  "foreground": "#cdcdcd"
+}

--- a/windowsterminal/Ocean.json
+++ b/windowsterminal/Ocean.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ocean",
+  "black": "#000000",
+  "red": "#990000",
+  "green": "#00a600",
+  "yellow": "#999900",
+  "blue": "#0000b2",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#00d900",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#224fbc",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/OceanicMaterial.json
+++ b/windowsterminal/OceanicMaterial.json
@@ -1,0 +1,21 @@
+{
+  "name": "OceanicMaterial",
+  "black": "#000000",
+  "red": "#ee2b2a",
+  "green": "#40a33f",
+  "yellow": "#ffea2e",
+  "blue": "#1e80f0",
+  "purple": "#8800a0",
+  "cyan": "#16afca",
+  "white": "#a4a4a4",
+  "brightBlack": "#777777",
+  "brightRed": "#dc5c60",
+  "brightGreen": "#70be71",
+  "brightYellow": "#fff163",
+  "brightBlue": "#54a4f3",
+  "brightPurple": "#aa4dbc",
+  "brightCyan": "#42c7da",
+  "brightWhite": "#ffffff",
+  "background": "#1c262b",
+  "foreground": "#c2c8d7"
+}

--- a/windowsterminal/Ollie.json
+++ b/windowsterminal/Ollie.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ollie",
+  "black": "#000000",
+  "red": "#ac2e31",
+  "green": "#31ac61",
+  "yellow": "#ac4300",
+  "blue": "#2d57ac",
+  "purple": "#b08528",
+  "cyan": "#1fa6ac",
+  "white": "#8a8eac",
+  "brightBlack": "#5b3725",
+  "brightRed": "#ff3d48",
+  "brightGreen": "#3bff99",
+  "brightYellow": "#ff5e1e",
+  "brightBlue": "#4488ff",
+  "brightPurple": "#ffc21d",
+  "brightCyan": "#1ffaff",
+  "brightWhite": "#5b6ea7",
+  "background": "#222125",
+  "foreground": "#8a8dae"
+}

--- a/windowsterminal/OneHalfDark.json
+++ b/windowsterminal/OneHalfDark.json
@@ -1,0 +1,21 @@
+{
+  "name": "OneHalfDark",
+  "black": "#282c34",
+  "red": "#e06c75",
+  "green": "#98c379",
+  "yellow": "#e5c07b",
+  "blue": "#61afef",
+  "purple": "#c678dd",
+  "cyan": "#56b6c2",
+  "white": "#dcdfe4",
+  "brightBlack": "#282c34",
+  "brightRed": "#e06c75",
+  "brightGreen": "#98c379",
+  "brightYellow": "#e5c07b",
+  "brightBlue": "#61afef",
+  "brightPurple": "#c678dd",
+  "brightCyan": "#56b6c2",
+  "brightWhite": "#dcdfe4",
+  "background": "#282c34",
+  "foreground": "#dcdfe4"
+}

--- a/windowsterminal/OneHalfLight.json
+++ b/windowsterminal/OneHalfLight.json
@@ -1,0 +1,21 @@
+{
+  "name": "OneHalfLight",
+  "black": "#383a42",
+  "red": "#e45649",
+  "green": "#50a14f",
+  "yellow": "#c18401",
+  "blue": "#0184bc",
+  "purple": "#a626a4",
+  "cyan": "#0997b3",
+  "white": "#fafafa",
+  "brightBlack": "#4f525e",
+  "brightRed": "#e06c75",
+  "brightGreen": "#98c379",
+  "brightYellow": "#e5c07b",
+  "brightBlue": "#61afef",
+  "brightPurple": "#c678dd",
+  "brightCyan": "#56b6c2",
+  "brightWhite": "#ffffff",
+  "background": "#fafafa",
+  "foreground": "#383a42"
+}

--- a/windowsterminal/Operator Mono Dark.json
+++ b/windowsterminal/Operator Mono Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Operator Mono Dark",
+  "black": "#5a5a5a",
+  "red": "#ca372d",
+  "green": "#4d7b3a",
+  "yellow": "#d4d697",
+  "blue": "#4387cf",
+  "purple": "#b86cb4",
+  "cyan": "#72d5c6",
+  "white": "#ced4cd",
+  "brightBlack": "#9a9b99",
+  "brightRed": "#c37d62",
+  "brightGreen": "#83d0a2",
+  "brightYellow": "#fdfdc5",
+  "brightBlue": "#89d3f6",
+  "brightPurple": "#ff2c7a",
+  "brightCyan": "#82eada",
+  "brightWhite": "#fdfdf6",
+  "background": "#191919",
+  "foreground": "#c3cac2"
+}

--- a/windowsterminal/Pandora.json
+++ b/windowsterminal/Pandora.json
@@ -1,0 +1,21 @@
+{
+  "name": "Pandora",
+  "black": "#000000",
+  "red": "#ff4242",
+  "green": "#74af68",
+  "yellow": "#ffad29",
+  "blue": "#338f86",
+  "purple": "#9414e6",
+  "cyan": "#23d7d7",
+  "white": "#e2e2e2",
+  "brightBlack": "#3f5648",
+  "brightRed": "#ff3242",
+  "brightGreen": "#74cd68",
+  "brightYellow": "#ffb929",
+  "brightBlue": "#23d7d7",
+  "brightPurple": "#ff37ff",
+  "brightCyan": "#00ede1",
+  "brightWhite": "#ffffff",
+  "background": "#141e43",
+  "foreground": "#e1e1e1"
+}

--- a/windowsterminal/Paraiso Dark.json
+++ b/windowsterminal/Paraiso Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Paraiso Dark",
+  "black": "#2f1e2e",
+  "red": "#ef6155",
+  "green": "#48b685",
+  "yellow": "#fec418",
+  "blue": "#06b6ef",
+  "purple": "#815ba4",
+  "cyan": "#5bc4bf",
+  "white": "#a39e9b",
+  "brightBlack": "#776e71",
+  "brightRed": "#ef6155",
+  "brightGreen": "#48b685",
+  "brightYellow": "#fec418",
+  "brightBlue": "#06b6ef",
+  "brightPurple": "#815ba4",
+  "brightCyan": "#5bc4bf",
+  "brightWhite": "#e7e9db",
+  "background": "#2f1e2e",
+  "foreground": "#a39e9b"
+}

--- a/windowsterminal/Parasio Dark.json
+++ b/windowsterminal/Parasio Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Parasio Dark",
+  "black": "#2f1e2e",
+  "red": "#ef6155",
+  "green": "#48b685",
+  "yellow": "#fec418",
+  "blue": "#06b6ef",
+  "purple": "#815ba4",
+  "cyan": "#5bc4bf",
+  "white": "#a39e9b",
+  "brightBlack": "#776e71",
+  "brightRed": "#ef6155",
+  "brightGreen": "#48b685",
+  "brightYellow": "#fec418",
+  "brightBlue": "#06b6ef",
+  "brightPurple": "#815ba4",
+  "brightCyan": "#5bc4bf",
+  "brightWhite": "#e7e9db",
+  "background": "#2f1e2e",
+  "foreground": "#a39e9b"
+}

--- a/windowsterminal/PaulMillr.json
+++ b/windowsterminal/PaulMillr.json
@@ -1,0 +1,21 @@
+{
+  "name": "PaulMillr",
+  "black": "#2a2a2a",
+  "red": "#ff0000",
+  "green": "#79ff0f",
+  "yellow": "#e7bf00",
+  "blue": "#396bd7",
+  "purple": "#b449be",
+  "cyan": "#66ccff",
+  "white": "#bbbbbb",
+  "brightBlack": "#666666",
+  "brightRed": "#ff0080",
+  "brightGreen": "#66ff66",
+  "brightYellow": "#f3d64e",
+  "brightBlue": "#709aed",
+  "brightPurple": "#db67e6",
+  "brightCyan": "#7adff2",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#f2f2f2"
+}

--- a/windowsterminal/PencilDark.json
+++ b/windowsterminal/PencilDark.json
@@ -1,0 +1,21 @@
+{
+  "name": "PencilDark",
+  "black": "#212121",
+  "red": "#c30771",
+  "green": "#10a778",
+  "yellow": "#a89c14",
+  "blue": "#008ec4",
+  "purple": "#523c79",
+  "cyan": "#20a5ba",
+  "white": "#d9d9d9",
+  "brightBlack": "#424242",
+  "brightRed": "#fb007a",
+  "brightGreen": "#5fd7af",
+  "brightYellow": "#f3e430",
+  "brightBlue": "#20bbfc",
+  "brightPurple": "#6855de",
+  "brightCyan": "#4fb8cc",
+  "brightWhite": "#f1f1f1",
+  "background": "#212121",
+  "foreground": "#f1f1f1"
+}

--- a/windowsterminal/PencilLight.json
+++ b/windowsterminal/PencilLight.json
@@ -1,0 +1,21 @@
+{
+  "name": "PencilLight",
+  "black": "#212121",
+  "red": "#c30771",
+  "green": "#10a778",
+  "yellow": "#a89c14",
+  "blue": "#008ec4",
+  "purple": "#523c79",
+  "cyan": "#20a5ba",
+  "white": "#d9d9d9",
+  "brightBlack": "#424242",
+  "brightRed": "#fb007a",
+  "brightGreen": "#5fd7af",
+  "brightYellow": "#f3e430",
+  "brightBlue": "#20bbfc",
+  "brightPurple": "#6855de",
+  "brightCyan": "#4fb8cc",
+  "brightWhite": "#f1f1f1",
+  "background": "#f1f1f1",
+  "foreground": "#424242"
+}

--- a/windowsterminal/Piatto Light.json
+++ b/windowsterminal/Piatto Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Piatto Light",
+  "black": "#414141",
+  "red": "#b23771",
+  "green": "#66781e",
+  "yellow": "#cd6f34",
+  "blue": "#3c5ea8",
+  "purple": "#a454b2",
+  "cyan": "#66781e",
+  "white": "#ffffff",
+  "brightBlack": "#3f3f3f",
+  "brightRed": "#db3365",
+  "brightGreen": "#829429",
+  "brightYellow": "#cd6f34",
+  "brightBlue": "#3c5ea8",
+  "brightPurple": "#a454b2",
+  "brightCyan": "#829429",
+  "brightWhite": "#f2f2f2",
+  "background": "#ffffff",
+  "foreground": "#414141"
+}

--- a/windowsterminal/Pnevma.json
+++ b/windowsterminal/Pnevma.json
@@ -1,0 +1,21 @@
+{
+  "name": "Pnevma",
+  "black": "#2f2e2d",
+  "red": "#a36666",
+  "green": "#90a57d",
+  "yellow": "#d7af87",
+  "blue": "#7fa5bd",
+  "purple": "#c79ec4",
+  "cyan": "#8adbb4",
+  "white": "#d0d0d0",
+  "brightBlack": "#4a4845",
+  "brightRed": "#d78787",
+  "brightGreen": "#afbea2",
+  "brightYellow": "#e4c9af",
+  "brightBlue": "#a1bdce",
+  "brightPurple": "#d7beda",
+  "brightCyan": "#b1e7dd",
+  "brightWhite": "#efefef",
+  "background": "#1c1c1c",
+  "foreground": "#d0d0d0"
+}

--- a/windowsterminal/Pro Light.json
+++ b/windowsterminal/Pro Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Pro Light",
+  "black": "#000000",
+  "red": "#e5492b",
+  "green": "#50d148",
+  "yellow": "#c6c440",
+  "blue": "#3b75ff",
+  "purple": "#ed66e8",
+  "cyan": "#4ed2de",
+  "white": "#dcdcdc",
+  "brightBlack": "#9f9f9f",
+  "brightRed": "#ff6640",
+  "brightGreen": "#61ef57",
+  "brightYellow": "#f2f156",
+  "brightBlue": "#0082ff",
+  "brightPurple": "#ff7eff",
+  "brightCyan": "#61f7f8",
+  "brightWhite": "#f2f2f2",
+  "background": "#ffffff",
+  "foreground": "#191919"
+}

--- a/windowsterminal/Pro.json
+++ b/windowsterminal/Pro.json
@@ -1,0 +1,21 @@
+{
+  "name": "Pro",
+  "black": "#000000",
+  "red": "#990000",
+  "green": "#00a600",
+  "yellow": "#999900",
+  "blue": "#2009db",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#00d900",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#000000",
+  "foreground": "#f2f2f2"
+}

--- a/windowsterminal/Purple Rain.json
+++ b/windowsterminal/Purple Rain.json
@@ -1,0 +1,21 @@
+{
+  "name": "Purple Rain",
+  "black": "#000000",
+  "red": "#ff260e",
+  "green": "#9be205",
+  "yellow": "#ffc400",
+  "blue": "#00a2fa",
+  "purple": "#815bb5",
+  "cyan": "#00deef",
+  "white": "#ffffff",
+  "brightBlack": "#565656",
+  "brightRed": "#ff4250",
+  "brightGreen": "#b8e36e",
+  "brightYellow": "#ffd852",
+  "brightBlue": "#00a6ff",
+  "brightPurple": "#ac7bf0",
+  "brightCyan": "#74fdf3",
+  "brightWhite": "#ffffff",
+  "background": "#21084a",
+  "foreground": "#fffbf6"
+}

--- a/windowsterminal/Red Alert.json
+++ b/windowsterminal/Red Alert.json
@@ -1,0 +1,21 @@
+{
+  "name": "Red Alert",
+  "black": "#000000",
+  "red": "#d62e4e",
+  "green": "#71be6b",
+  "yellow": "#beb86b",
+  "blue": "#489bee",
+  "purple": "#e979d7",
+  "cyan": "#6bbeb8",
+  "white": "#d6d6d6",
+  "brightBlack": "#262626",
+  "brightRed": "#e02553",
+  "brightGreen": "#aff08c",
+  "brightYellow": "#dfddb7",
+  "brightBlue": "#65aaf1",
+  "brightPurple": "#ddb7df",
+  "brightCyan": "#b7dfdd",
+  "brightWhite": "#ffffff",
+  "background": "#762423",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Red Planet.json
+++ b/windowsterminal/Red Planet.json
@@ -1,0 +1,21 @@
+{
+  "name": "Red Planet",
+  "black": "#202020",
+  "red": "#8c3432",
+  "green": "#728271",
+  "yellow": "#e8bf6a",
+  "blue": "#69819e",
+  "purple": "#896492",
+  "cyan": "#5b8390",
+  "white": "#b9aa99",
+  "brightBlack": "#676767",
+  "brightRed": "#b55242",
+  "brightGreen": "#869985",
+  "brightYellow": "#ebeb91",
+  "brightBlue": "#60827e",
+  "brightPurple": "#de4974",
+  "brightCyan": "#38add8",
+  "brightWhite": "#d6bfb8",
+  "background": "#222222",
+  "foreground": "#c2b790"
+}

--- a/windowsterminal/Red Sands.json
+++ b/windowsterminal/Red Sands.json
@@ -1,0 +1,21 @@
+{
+  "name": "Red Sands",
+  "black": "#000000",
+  "red": "#ff3f00",
+  "green": "#00bb00",
+  "yellow": "#e7b000",
+  "blue": "#0072ff",
+  "purple": "#bb00bb",
+  "cyan": "#00bbbb",
+  "white": "#bbbbbb",
+  "brightBlack": "#555555",
+  "brightRed": "#bb0000",
+  "brightGreen": "#00bb00",
+  "brightYellow": "#e7b000",
+  "brightBlue": "#0072ae",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#7a251e",
+  "foreground": "#d7c9a7"
+}

--- a/windowsterminal/Relaxed.json
+++ b/windowsterminal/Relaxed.json
@@ -1,0 +1,21 @@
+{
+  "name": "Relaxed",
+  "black": "#151515",
+  "red": "#bc5653",
+  "green": "#909d63",
+  "yellow": "#ebc17a",
+  "blue": "#6a8799",
+  "purple": "#b06698",
+  "cyan": "#c9dfff",
+  "white": "#d9d9d9",
+  "brightBlack": "#636363",
+  "brightRed": "#bc5653",
+  "brightGreen": "#a0ac77",
+  "brightYellow": "#ebc17a",
+  "brightBlue": "#7eaac7",
+  "brightPurple": "#b06698",
+  "brightCyan": "#acbbd0",
+  "brightWhite": "#f7f7f7",
+  "background": "#353a44",
+  "foreground": "#d9d9d9"
+}

--- a/windowsterminal/Rippedcasts.json
+++ b/windowsterminal/Rippedcasts.json
@@ -1,0 +1,21 @@
+{
+  "name": "Rippedcasts",
+  "black": "#000000",
+  "red": "#cdaf95",
+  "green": "#a8ff60",
+  "yellow": "#bfbb1f",
+  "blue": "#75a5b0",
+  "purple": "#ff73fd",
+  "cyan": "#5a647e",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#eecbad",
+  "brightGreen": "#bcee68",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#86bdc9",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#8c9bc4",
+  "brightWhite": "#e5e5e5",
+  "background": "#2b2b2b",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Royal.json
+++ b/windowsterminal/Royal.json
@@ -1,0 +1,21 @@
+{
+  "name": "Royal",
+  "black": "#241f2b",
+  "red": "#91284c",
+  "green": "#23801c",
+  "yellow": "#b49d27",
+  "blue": "#6580b0",
+  "purple": "#674d96",
+  "cyan": "#8aaabe",
+  "white": "#524966",
+  "brightBlack": "#312d3d",
+  "brightRed": "#d5356c",
+  "brightGreen": "#2cd946",
+  "brightYellow": "#fde83b",
+  "brightBlue": "#90baf9",
+  "brightPurple": "#a479e3",
+  "brightCyan": "#acd4eb",
+  "brightWhite": "#9e8cbd",
+  "background": "#100815",
+  "foreground": "#514968"
+}

--- a/windowsterminal/Ryuuko.json
+++ b/windowsterminal/Ryuuko.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ryuuko",
+  "black": "#2c3941",
+  "red": "#865f5b",
+  "green": "#66907d",
+  "yellow": "#b1a990",
+  "blue": "#6a8e95",
+  "purple": "#b18a73",
+  "cyan": "#88b2ac",
+  "white": "#ececec",
+  "brightBlack": "#5d7079",
+  "brightRed": "#865f5b",
+  "brightGreen": "#66907d",
+  "brightYellow": "#b1a990",
+  "brightBlue": "#6a8e95",
+  "brightPurple": "#b18a73",
+  "brightCyan": "#88b2ac",
+  "brightWhite": "#ececec",
+  "background": "#2c3941",
+  "foreground": "#ececec"
+}

--- a/windowsterminal/SeaShells.json
+++ b/windowsterminal/SeaShells.json
@@ -1,0 +1,21 @@
+{
+  "name": "SeaShells",
+  "black": "#17384c",
+  "red": "#d15123",
+  "green": "#027c9b",
+  "yellow": "#fca02f",
+  "blue": "#1e4950",
+  "purple": "#68d4f1",
+  "cyan": "#50a3b5",
+  "white": "#deb88d",
+  "brightBlack": "#434b53",
+  "brightRed": "#d48678",
+  "brightGreen": "#628d98",
+  "brightYellow": "#fdd39f",
+  "brightBlue": "#1bbcdd",
+  "brightPurple": "#bbe3ee",
+  "brightCyan": "#87acb4",
+  "brightWhite": "#fee4ce",
+  "background": "#09141b",
+  "foreground": "#deb88d"
+}

--- a/windowsterminal/Seafoam Pastel.json
+++ b/windowsterminal/Seafoam Pastel.json
@@ -1,0 +1,21 @@
+{
+  "name": "Seafoam Pastel",
+  "black": "#757575",
+  "red": "#825d4d",
+  "green": "#728c62",
+  "yellow": "#ada16d",
+  "blue": "#4d7b82",
+  "purple": "#8a7267",
+  "cyan": "#729494",
+  "white": "#e0e0e0",
+  "brightBlack": "#8a8a8a",
+  "brightRed": "#cf937a",
+  "brightGreen": "#98d9aa",
+  "brightYellow": "#fae79d",
+  "brightBlue": "#7ac3cf",
+  "brightPurple": "#d6b2a1",
+  "brightCyan": "#ade0e0",
+  "brightWhite": "#e0e0e0",
+  "background": "#243435",
+  "foreground": "#d4e7d4"
+}

--- a/windowsterminal/Seti.json
+++ b/windowsterminal/Seti.json
@@ -1,0 +1,21 @@
+{
+  "name": "Seti",
+  "black": "#323232",
+  "red": "#c22832",
+  "green": "#8ec43d",
+  "yellow": "#e0c64f",
+  "blue": "#43a5d5",
+  "purple": "#8b57b5",
+  "cyan": "#8ec43d",
+  "white": "#eeeeee",
+  "brightBlack": "#323232",
+  "brightRed": "#c22832",
+  "brightGreen": "#8ec43d",
+  "brightYellow": "#e0c64f",
+  "brightBlue": "#43a5d5",
+  "brightPurple": "#8b57b5",
+  "brightCyan": "#8ec43d",
+  "brightWhite": "#ffffff",
+  "background": "#111213",
+  "foreground": "#cacecd"
+}

--- a/windowsterminal/Shaman.json
+++ b/windowsterminal/Shaman.json
@@ -1,0 +1,21 @@
+{
+  "name": "Shaman",
+  "black": "#012026",
+  "red": "#b2302d",
+  "green": "#00a941",
+  "yellow": "#5e8baa",
+  "blue": "#449a86",
+  "purple": "#00599d",
+  "cyan": "#5d7e19",
+  "white": "#405555",
+  "brightBlack": "#384451",
+  "brightRed": "#ff4242",
+  "brightGreen": "#2aea5e",
+  "brightYellow": "#8ed4fd",
+  "brightBlue": "#61d5ba",
+  "brightPurple": "#1298ff",
+  "brightCyan": "#98d028",
+  "brightWhite": "#58fbd6",
+  "background": "#001015",
+  "foreground": "#405555"
+}

--- a/windowsterminal/Slate.json
+++ b/windowsterminal/Slate.json
@@ -1,0 +1,21 @@
+{
+  "name": "Slate",
+  "black": "#222222",
+  "red": "#e2a8bf",
+  "green": "#81d778",
+  "yellow": "#c4c9c0",
+  "blue": "#264b49",
+  "purple": "#a481d3",
+  "cyan": "#15ab9c",
+  "white": "#02c5e0",
+  "brightBlack": "#ffffff",
+  "brightRed": "#ffcdd9",
+  "brightGreen": "#beffa8",
+  "brightYellow": "#d0ccca",
+  "brightBlue": "#7ab0d2",
+  "brightPurple": "#c5a7d9",
+  "brightCyan": "#8cdfe0",
+  "brightWhite": "#e0e0e0",
+  "background": "#222222",
+  "foreground": "#35b1d2"
+}

--- a/windowsterminal/Smyck.json
+++ b/windowsterminal/Smyck.json
@@ -1,0 +1,21 @@
+{
+  "name": "Smyck",
+  "black": "#000000",
+  "red": "#b84131",
+  "green": "#7da900",
+  "yellow": "#c4a500",
+  "blue": "#62a3c4",
+  "purple": "#ba8acc",
+  "cyan": "#207383",
+  "white": "#a1a1a1",
+  "brightBlack": "#7a7a7a",
+  "brightRed": "#d6837c",
+  "brightGreen": "#c4f137",
+  "brightYellow": "#fee14d",
+  "brightBlue": "#8dcff0",
+  "brightPurple": "#f79aff",
+  "brightCyan": "#6ad9cf",
+  "brightWhite": "#f7f7f7",
+  "background": "#1b1b1b",
+  "foreground": "#f7f7f7"
+}

--- a/windowsterminal/Snazzy.json
+++ b/windowsterminal/Snazzy.json
@@ -1,0 +1,21 @@
+{
+  "name": "Snazzy",
+  "black": "#000000",
+  "red": "#fc4346",
+  "green": "#50fb7c",
+  "yellow": "#f0fb8c",
+  "blue": "#49baff",
+  "purple": "#fc4cb4",
+  "cyan": "#8be9fe",
+  "white": "#ededec",
+  "brightBlack": "#555555",
+  "brightRed": "#fc4346",
+  "brightGreen": "#50fb7c",
+  "brightYellow": "#f0fb8c",
+  "brightBlue": "#49baff",
+  "brightPurple": "#fc4cb4",
+  "brightCyan": "#8be9fe",
+  "brightWhite": "#ededec",
+  "background": "#1e1f29",
+  "foreground": "#ebece6"
+}

--- a/windowsterminal/SoftServer.json
+++ b/windowsterminal/SoftServer.json
@@ -1,0 +1,21 @@
+{
+  "name": "SoftServer",
+  "black": "#000000",
+  "red": "#a2686a",
+  "green": "#9aa56a",
+  "yellow": "#a3906a",
+  "blue": "#6b8fa3",
+  "purple": "#6a71a3",
+  "cyan": "#6ba58f",
+  "white": "#99a3a2",
+  "brightBlack": "#666c6c",
+  "brightRed": "#dd5c60",
+  "brightGreen": "#bfdf55",
+  "brightYellow": "#deb360",
+  "brightBlue": "#62b1df",
+  "brightPurple": "#606edf",
+  "brightCyan": "#64e39c",
+  "brightWhite": "#d2e0de",
+  "background": "#242626",
+  "foreground": "#99a3a2"
+}

--- a/windowsterminal/Solarized Darcula.json
+++ b/windowsterminal/Solarized Darcula.json
@@ -1,0 +1,21 @@
+{
+  "name": "Solarized Darcula",
+  "black": "#25292a",
+  "red": "#f24840",
+  "green": "#629655",
+  "yellow": "#b68800",
+  "blue": "#2075c7",
+  "purple": "#797fd4",
+  "cyan": "#15968d",
+  "white": "#d2d8d9",
+  "brightBlack": "#25292a",
+  "brightRed": "#f24840",
+  "brightGreen": "#629655",
+  "brightYellow": "#b68800",
+  "brightBlue": "#2075c7",
+  "brightPurple": "#797fd4",
+  "brightCyan": "#15968d",
+  "brightWhite": "#d2d8d9",
+  "background": "#3d3f41",
+  "foreground": "#d2d8d9"
+}

--- a/windowsterminal/Solarized Dark - Patched.json
+++ b/windowsterminal/Solarized Dark - Patched.json
@@ -1,0 +1,21 @@
+{
+  "name": "Solarized Dark - Patched",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#738a05",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#475b62",
+  "brightRed": "#bd3613",
+  "brightGreen": "#475b62",
+  "brightYellow": "#536870",
+  "brightBlue": "#708284",
+  "brightPurple": "#5956ba",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4dc",
+  "background": "#001e27",
+  "foreground": "#708284"
+}

--- a/windowsterminal/Solarized Dark Higher Contrast.json
+++ b/windowsterminal/Solarized Dark Higher Contrast.json
@@ -1,0 +1,21 @@
+{
+  "name": "Solarized Dark Higher Contrast",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#6cbe6c",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#006488",
+  "brightRed": "#f5163b",
+  "brightGreen": "#51ef84",
+  "brightYellow": "#b27e28",
+  "brightBlue": "#178ec8",
+  "brightPurple": "#e24d8e",
+  "brightCyan": "#00b39e",
+  "brightWhite": "#fcf4dc",
+  "background": "#001e27",
+  "foreground": "#9cc2c3"
+}

--- a/windowsterminal/Solarized Dark.json
+++ b/windowsterminal/Solarized Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Solarized Dark",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#738a05",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#001e27",
+  "brightRed": "#bd3613",
+  "brightGreen": "#475b62",
+  "brightYellow": "#536870",
+  "brightBlue": "#708284",
+  "brightPurple": "#5956ba",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4dc",
+  "background": "#001e27",
+  "foreground": "#708284"
+}

--- a/windowsterminal/Solarized Light.json
+++ b/windowsterminal/Solarized Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Solarized Light",
+  "black": "#002831",
+  "red": "#d11c24",
+  "green": "#738a05",
+  "yellow": "#a57706",
+  "blue": "#2176c7",
+  "purple": "#c61c6f",
+  "cyan": "#259286",
+  "white": "#eae3cb",
+  "brightBlack": "#001e27",
+  "brightRed": "#bd3613",
+  "brightGreen": "#475b62",
+  "brightYellow": "#536870",
+  "brightBlue": "#708284",
+  "brightPurple": "#5956ba",
+  "brightCyan": "#819090",
+  "brightWhite": "#fcf4dc",
+  "background": "#fcf4dc",
+  "foreground": "#536870"
+}

--- a/windowsterminal/SpaceGray Eighties Dull.json
+++ b/windowsterminal/SpaceGray Eighties Dull.json
@@ -1,0 +1,21 @@
+{
+  "name": "SpaceGray Eighties Dull",
+  "black": "#15171c",
+  "red": "#b24a56",
+  "green": "#92b477",
+  "yellow": "#c6735a",
+  "blue": "#7c8fa5",
+  "purple": "#a5789e",
+  "cyan": "#80cdcb",
+  "white": "#b3b8c3",
+  "brightBlack": "#555555",
+  "brightRed": "#ec5f67",
+  "brightGreen": "#89e986",
+  "brightYellow": "#fec254",
+  "brightBlue": "#5486c0",
+  "brightPurple": "#bf83c1",
+  "brightCyan": "#58c2c1",
+  "brightWhite": "#ffffff",
+  "background": "#222222",
+  "foreground": "#c9c6bc"
+}

--- a/windowsterminal/SpaceGray Eighties.json
+++ b/windowsterminal/SpaceGray Eighties.json
@@ -1,0 +1,21 @@
+{
+  "name": "SpaceGray Eighties",
+  "black": "#15171c",
+  "red": "#ec5f67",
+  "green": "#81a764",
+  "yellow": "#fec254",
+  "blue": "#5486c0",
+  "purple": "#bf83c1",
+  "cyan": "#57c2c1",
+  "white": "#efece7",
+  "brightBlack": "#555555",
+  "brightRed": "#ff6973",
+  "brightGreen": "#93d493",
+  "brightYellow": "#ffd256",
+  "brightBlue": "#4d84d1",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#83e9e4",
+  "brightWhite": "#ffffff",
+  "background": "#222222",
+  "foreground": "#bdbaae"
+}

--- a/windowsterminal/SpaceGray.json
+++ b/windowsterminal/SpaceGray.json
@@ -1,0 +1,21 @@
+{
+  "name": "SpaceGray",
+  "black": "#000000",
+  "red": "#b04b57",
+  "green": "#87b379",
+  "yellow": "#e5c179",
+  "blue": "#7d8fa4",
+  "purple": "#a47996",
+  "cyan": "#85a7a5",
+  "white": "#b3b8c3",
+  "brightBlack": "#000000",
+  "brightRed": "#b04b57",
+  "brightGreen": "#87b379",
+  "brightYellow": "#e5c179",
+  "brightBlue": "#7d8fa4",
+  "brightPurple": "#a47996",
+  "brightCyan": "#85a7a5",
+  "brightWhite": "#ffffff",
+  "background": "#20242d",
+  "foreground": "#b3b8c3"
+}

--- a/windowsterminal/Spacedust.json
+++ b/windowsterminal/Spacedust.json
@@ -1,0 +1,21 @@
+{
+  "name": "Spacedust",
+  "black": "#6e5346",
+  "red": "#e35b00",
+  "green": "#5cab96",
+  "yellow": "#e3cd7b",
+  "blue": "#0f548b",
+  "purple": "#e35b00",
+  "cyan": "#06afc7",
+  "white": "#f0f1ce",
+  "brightBlack": "#684c31",
+  "brightRed": "#ff8a3a",
+  "brightGreen": "#aecab8",
+  "brightYellow": "#ffc878",
+  "brightBlue": "#67a0ce",
+  "brightPurple": "#ff8a3a",
+  "brightCyan": "#83a7b4",
+  "brightWhite": "#fefff1",
+  "background": "#0a1e24",
+  "foreground": "#ecf0c1"
+}

--- a/windowsterminal/Spiderman.json
+++ b/windowsterminal/Spiderman.json
@@ -1,0 +1,21 @@
+{
+  "name": "Spiderman",
+  "black": "#1b1d1e",
+  "red": "#e60813",
+  "green": "#e22928",
+  "yellow": "#e24756",
+  "blue": "#2c3fff",
+  "purple": "#2435db",
+  "cyan": "#3256ff",
+  "white": "#fffef6",
+  "brightBlack": "#505354",
+  "brightRed": "#ff0325",
+  "brightGreen": "#ff3338",
+  "brightYellow": "#fe3a35",
+  "brightBlue": "#1d50ff",
+  "brightPurple": "#747cff",
+  "brightCyan": "#6184ff",
+  "brightWhite": "#fffff9",
+  "background": "#1b1d1e",
+  "foreground": "#e3e3e3"
+}

--- a/windowsterminal/Spring.json
+++ b/windowsterminal/Spring.json
@@ -1,0 +1,21 @@
+{
+  "name": "Spring",
+  "black": "#000000",
+  "red": "#ff4d83",
+  "green": "#1f8c3b",
+  "yellow": "#1fc95b",
+  "blue": "#1dd3ee",
+  "purple": "#8959a8",
+  "cyan": "#3e999f",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#ff0021",
+  "brightGreen": "#1fc231",
+  "brightYellow": "#d5b807",
+  "brightBlue": "#15a9fd",
+  "brightPurple": "#8959a8",
+  "brightCyan": "#3e999f",
+  "brightWhite": "#ffffff",
+  "background": "#ffffff",
+  "foreground": "#4d4d4c"
+}

--- a/windowsterminal/Square.json
+++ b/windowsterminal/Square.json
@@ -1,0 +1,21 @@
+{
+  "name": "Square",
+  "black": "#050505",
+  "red": "#e9897c",
+  "green": "#b6377d",
+  "yellow": "#ecebbe",
+  "blue": "#a9cdeb",
+  "purple": "#75507b",
+  "cyan": "#c9caec",
+  "white": "#f2f2f2",
+  "brightBlack": "#141414",
+  "brightRed": "#f99286",
+  "brightGreen": "#c3f786",
+  "brightYellow": "#fcfbcc",
+  "brightBlue": "#b6defb",
+  "brightPurple": "#ad7fa8",
+  "brightCyan": "#d7d9fc",
+  "brightWhite": "#e2e2e2",
+  "background": "#1a1a1a",
+  "foreground": "#acacab"
+}

--- a/windowsterminal/Subliminal.json
+++ b/windowsterminal/Subliminal.json
@@ -1,0 +1,21 @@
+{
+  "name": "Subliminal",
+  "black": "#7f7f7f",
+  "red": "#e15a60",
+  "green": "#a9cfa4",
+  "yellow": "#ffe2a9",
+  "blue": "#6699cc",
+  "purple": "#f1a5ab",
+  "cyan": "#5fb3b3",
+  "white": "#d4d4d4",
+  "brightBlack": "#7f7f7f",
+  "brightRed": "#e15a60",
+  "brightGreen": "#a9cfa4",
+  "brightYellow": "#ffe2a9",
+  "brightBlue": "#6699cc",
+  "brightPurple": "#f1a5ab",
+  "brightCyan": "#5fb3b3",
+  "brightWhite": "#d4d4d4",
+  "background": "#282c35",
+  "foreground": "#d4d4d4"
+}

--- a/windowsterminal/Sundried.json
+++ b/windowsterminal/Sundried.json
@@ -1,0 +1,21 @@
+{
+  "name": "Sundried",
+  "black": "#302b2a",
+  "red": "#a7463d",
+  "green": "#587744",
+  "yellow": "#9d602a",
+  "blue": "#485b98",
+  "purple": "#864651",
+  "cyan": "#9c814f",
+  "white": "#c9c9c9",
+  "brightBlack": "#4d4e48",
+  "brightRed": "#aa000c",
+  "brightGreen": "#128c21",
+  "brightYellow": "#fc6a21",
+  "brightBlue": "#7999f7",
+  "brightPurple": "#fd8aa1",
+  "brightCyan": "#fad484",
+  "brightWhite": "#ffffff",
+  "background": "#1a1818",
+  "foreground": "#c9c9c9"
+}

--- a/windowsterminal/Symfonic.json
+++ b/windowsterminal/Symfonic.json
@@ -1,0 +1,21 @@
+{
+  "name": "Symfonic",
+  "black": "#000000",
+  "red": "#dc322f",
+  "green": "#56db3a",
+  "yellow": "#ff8400",
+  "blue": "#0084d4",
+  "purple": "#b729d9",
+  "cyan": "#ccccff",
+  "white": "#ffffff",
+  "brightBlack": "#1b1d21",
+  "brightRed": "#dc322f",
+  "brightGreen": "#56db3a",
+  "brightYellow": "#ff8400",
+  "brightBlue": "#0084d4",
+  "brightPurple": "#b729d9",
+  "brightCyan": "#ccccff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Tango Adapted.json
+++ b/windowsterminal/Tango Adapted.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tango Adapted",
+  "black": "#000000",
+  "red": "#ff0000",
+  "green": "#59d600",
+  "yellow": "#f0cb00",
+  "blue": "#00a2ff",
+  "purple": "#c17ecc",
+  "cyan": "#00d0d6",
+  "white": "#e6ebe1",
+  "brightBlack": "#8f928b",
+  "brightRed": "#ff0013",
+  "brightGreen": "#93ff00",
+  "brightYellow": "#fff121",
+  "brightBlue": "#88c9ff",
+  "brightPurple": "#e9a7e1",
+  "brightCyan": "#00feff",
+  "brightWhite": "#f6f6f4",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/Tango Half Adapted.json
+++ b/windowsterminal/Tango Half Adapted.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tango Half Adapted",
+  "black": "#000000",
+  "red": "#ff0000",
+  "green": "#4cc300",
+  "yellow": "#e2c000",
+  "blue": "#008ef6",
+  "purple": "#a96cb3",
+  "cyan": "#00bdc3",
+  "white": "#e0e5db",
+  "brightBlack": "#797d76",
+  "brightRed": "#ff0013",
+  "brightGreen": "#8af600",
+  "brightYellow": "#ffec00",
+  "brightBlue": "#76bfff",
+  "brightPurple": "#d898d1",
+  "brightCyan": "#00f6fa",
+  "brightWhite": "#f4f4f2",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/Teerb.json
+++ b/windowsterminal/Teerb.json
@@ -1,0 +1,21 @@
+{
+  "name": "Teerb",
+  "black": "#1c1c1c",
+  "red": "#d68686",
+  "green": "#aed686",
+  "yellow": "#d7af87",
+  "blue": "#86aed6",
+  "purple": "#d6aed6",
+  "cyan": "#8adbb4",
+  "white": "#d0d0d0",
+  "brightBlack": "#1c1c1c",
+  "brightRed": "#d68686",
+  "brightGreen": "#aed686",
+  "brightYellow": "#e4c9af",
+  "brightBlue": "#86aed6",
+  "brightPurple": "#d6aed6",
+  "brightCyan": "#b1e7dd",
+  "brightWhite": "#efefef",
+  "background": "#262626",
+  "foreground": "#d0d0d0"
+}

--- a/windowsterminal/Terminal Basic.json
+++ b/windowsterminal/Terminal Basic.json
@@ -1,0 +1,21 @@
+{
+  "name": "Terminal Basic",
+  "black": "#000000",
+  "red": "#990000",
+  "green": "#00a600",
+  "yellow": "#999900",
+  "blue": "#0000b2",
+  "purple": "#b200b2",
+  "cyan": "#00a6b2",
+  "white": "#bfbfbf",
+  "brightBlack": "#666666",
+  "brightRed": "#e50000",
+  "brightGreen": "#00d900",
+  "brightYellow": "#e5e500",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#e500e5",
+  "brightCyan": "#00e5e5",
+  "brightWhite": "#e5e5e5",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/Thayer Bright.json
+++ b/windowsterminal/Thayer Bright.json
@@ -1,0 +1,21 @@
+{
+  "name": "Thayer Bright",
+  "black": "#1b1d1e",
+  "red": "#f92672",
+  "green": "#4df840",
+  "yellow": "#f4fd22",
+  "blue": "#2757d6",
+  "purple": "#8c54fe",
+  "cyan": "#38c8b5",
+  "white": "#ccccc6",
+  "brightBlack": "#505354",
+  "brightRed": "#ff5995",
+  "brightGreen": "#b6e354",
+  "brightYellow": "#feed6c",
+  "brightBlue": "#3f78ff",
+  "brightPurple": "#9e6ffe",
+  "brightCyan": "#23cfd5",
+  "brightWhite": "#f8f8f2",
+  "background": "#1b1d1e",
+  "foreground": "#f8f8f8"
+}

--- a/windowsterminal/The Hulk.json
+++ b/windowsterminal/The Hulk.json
@@ -1,0 +1,21 @@
+{
+  "name": "The Hulk",
+  "black": "#1b1d1e",
+  "red": "#269d1b",
+  "green": "#13ce30",
+  "yellow": "#63e457",
+  "blue": "#2525f5",
+  "purple": "#641f74",
+  "cyan": "#378ca9",
+  "white": "#d9d8d1",
+  "brightBlack": "#505354",
+  "brightRed": "#8dff2a",
+  "brightGreen": "#48ff77",
+  "brightYellow": "#3afe16",
+  "brightBlue": "#506b95",
+  "brightPurple": "#72589d",
+  "brightCyan": "#4085a6",
+  "brightWhite": "#e5e6e1",
+  "background": "#1b1d1e",
+  "foreground": "#b5b5b5"
+}

--- a/windowsterminal/Tomorrow Night Blue.json
+++ b/windowsterminal/Tomorrow Night Blue.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow Night Blue",
+  "black": "#000000",
+  "red": "#ff9da4",
+  "green": "#d1f1a9",
+  "yellow": "#ffeead",
+  "blue": "#bbdaff",
+  "purple": "#ebbbff",
+  "cyan": "#99ffff",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#ff9da4",
+  "brightGreen": "#d1f1a9",
+  "brightYellow": "#ffeead",
+  "brightBlue": "#bbdaff",
+  "brightPurple": "#ebbbff",
+  "brightCyan": "#99ffff",
+  "brightWhite": "#ffffff",
+  "background": "#002451",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Tomorrow Night Bright.json
+++ b/windowsterminal/Tomorrow Night Bright.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow Night Bright",
+  "black": "#000000",
+  "red": "#d54e53",
+  "green": "#b9ca4a",
+  "yellow": "#e7c547",
+  "blue": "#7aa6da",
+  "purple": "#c397d8",
+  "cyan": "#70c0b1",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#d54e53",
+  "brightGreen": "#b9ca4a",
+  "brightYellow": "#e7c547",
+  "brightBlue": "#7aa6da",
+  "brightPurple": "#c397d8",
+  "brightCyan": "#70c0b1",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#eaeaea"
+}

--- a/windowsterminal/Tomorrow Night Burns.json
+++ b/windowsterminal/Tomorrow Night Burns.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow Night Burns",
+  "black": "#252525",
+  "red": "#832e31",
+  "green": "#a63c40",
+  "yellow": "#d3494e",
+  "blue": "#fc595f",
+  "purple": "#df9395",
+  "cyan": "#ba8586",
+  "white": "#f5f5f5",
+  "brightBlack": "#5d6f71",
+  "brightRed": "#832e31",
+  "brightGreen": "#a63c40",
+  "brightYellow": "#d2494e",
+  "brightBlue": "#fc595f",
+  "brightPurple": "#df9395",
+  "brightCyan": "#ba8586",
+  "brightWhite": "#f5f5f5",
+  "background": "#151515",
+  "foreground": "#a1b0b8"
+}

--- a/windowsterminal/Tomorrow Night Eighties.json
+++ b/windowsterminal/Tomorrow Night Eighties.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow Night Eighties",
+  "black": "#000000",
+  "red": "#f2777a",
+  "green": "#99cc99",
+  "yellow": "#ffcc66",
+  "blue": "#6699cc",
+  "purple": "#cc99cc",
+  "cyan": "#66cccc",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#f2777a",
+  "brightGreen": "#99cc99",
+  "brightYellow": "#ffcc66",
+  "brightBlue": "#6699cc",
+  "brightPurple": "#cc99cc",
+  "brightCyan": "#66cccc",
+  "brightWhite": "#ffffff",
+  "background": "#2d2d2d",
+  "foreground": "#cccccc"
+}

--- a/windowsterminal/Tomorrow Night.json
+++ b/windowsterminal/Tomorrow Night.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow Night",
+  "black": "#000000",
+  "red": "#cc6666",
+  "green": "#b5bd68",
+  "yellow": "#f0c674",
+  "blue": "#81a2be",
+  "purple": "#b294bb",
+  "cyan": "#8abeb7",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#cc6666",
+  "brightGreen": "#b5bd68",
+  "brightYellow": "#f0c674",
+  "brightBlue": "#81a2be",
+  "brightPurple": "#b294bb",
+  "brightCyan": "#8abeb7",
+  "brightWhite": "#ffffff",
+  "background": "#1d1f21",
+  "foreground": "#c5c8c6"
+}

--- a/windowsterminal/Tomorrow.json
+++ b/windowsterminal/Tomorrow.json
@@ -1,0 +1,21 @@
+{
+  "name": "Tomorrow",
+  "black": "#000000",
+  "red": "#c82829",
+  "green": "#718c00",
+  "yellow": "#eab700",
+  "blue": "#4271ae",
+  "purple": "#8959a8",
+  "cyan": "#3e999f",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#c82829",
+  "brightGreen": "#718c00",
+  "brightYellow": "#eab700",
+  "brightBlue": "#4271ae",
+  "brightPurple": "#8959a8",
+  "brightCyan": "#3e999f",
+  "brightWhite": "#ffffff",
+  "background": "#ffffff",
+  "foreground": "#4d4d4c"
+}

--- a/windowsterminal/ToyChest.json
+++ b/windowsterminal/ToyChest.json
@@ -1,0 +1,21 @@
+{
+  "name": "ToyChest",
+  "black": "#2c3f58",
+  "red": "#be2d26",
+  "green": "#1a9172",
+  "yellow": "#db8e27",
+  "blue": "#325d96",
+  "purple": "#8a5edc",
+  "cyan": "#35a08f",
+  "white": "#23d183",
+  "brightBlack": "#336889",
+  "brightRed": "#dd5944",
+  "brightGreen": "#31d07b",
+  "brightYellow": "#e7d84b",
+  "brightBlue": "#34a6da",
+  "brightPurple": "#ae6bdc",
+  "brightCyan": "#42c3ae",
+  "brightWhite": "#d5d5d5",
+  "background": "#24364b",
+  "foreground": "#31d07b"
+}

--- a/windowsterminal/Treehouse.json
+++ b/windowsterminal/Treehouse.json
@@ -1,0 +1,21 @@
+{
+  "name": "Treehouse",
+  "black": "#321300",
+  "red": "#b2270e",
+  "green": "#44a900",
+  "yellow": "#aa820c",
+  "blue": "#58859a",
+  "purple": "#97363d",
+  "cyan": "#b25a1e",
+  "white": "#786b53",
+  "brightBlack": "#433626",
+  "brightRed": "#ed5d20",
+  "brightGreen": "#55f238",
+  "brightYellow": "#f2b732",
+  "brightBlue": "#85cfed",
+  "brightPurple": "#e14c5a",
+  "brightCyan": "#f07d14",
+  "brightWhite": "#ffc800",
+  "background": "#191919",
+  "foreground": "#786b53"
+}

--- a/windowsterminal/Twilight.json
+++ b/windowsterminal/Twilight.json
@@ -1,0 +1,21 @@
+{
+  "name": "Twilight",
+  "black": "#141414",
+  "red": "#c06d44",
+  "green": "#afb97a",
+  "yellow": "#c2a86c",
+  "blue": "#44474a",
+  "purple": "#b4be7c",
+  "cyan": "#778385",
+  "white": "#ffffd4",
+  "brightBlack": "#262626",
+  "brightRed": "#de7c4c",
+  "brightGreen": "#ccd88c",
+  "brightYellow": "#e2c47e",
+  "brightBlue": "#5a5e62",
+  "brightPurple": "#d0dc8e",
+  "brightCyan": "#8a989b",
+  "brightWhite": "#ffffd4",
+  "background": "#141414",
+  "foreground": "#ffffd4"
+}

--- a/windowsterminal/Ubuntu.json
+++ b/windowsterminal/Ubuntu.json
@@ -1,0 +1,21 @@
+{
+  "name": "Ubuntu",
+  "black": "#2e3436",
+  "red": "#cc0000",
+  "green": "#4e9a06",
+  "yellow": "#c4a000",
+  "blue": "#3465a4",
+  "purple": "#75507b",
+  "cyan": "#06989a",
+  "white": "#d3d7cf",
+  "brightBlack": "#555753",
+  "brightRed": "#ef2929",
+  "brightGreen": "#8ae234",
+  "brightYellow": "#fce94f",
+  "brightBlue": "#729fcf",
+  "brightPurple": "#ad7fa8",
+  "brightCyan": "#34e2e2",
+  "brightWhite": "#eeeeec",
+  "background": "#300a24",
+  "foreground": "#eeeeec"
+}

--- a/windowsterminal/UltraViolent.json
+++ b/windowsterminal/UltraViolent.json
@@ -1,0 +1,21 @@
+{
+  "name": "UltraViolent",
+  "black": "#242728",
+  "red": "#ff0090",
+  "green": "#b6ff00",
+  "yellow": "#fff727",
+  "blue": "#47e0fb",
+  "purple": "#d731ff",
+  "cyan": "#0effbb",
+  "white": "#e1e1e1",
+  "brightBlack": "#636667",
+  "brightRed": "#fb58b4",
+  "brightGreen": "#deff8c",
+  "brightYellow": "#ebe087",
+  "brightBlue": "#7fecff",
+  "brightPurple": "#e681ff",
+  "brightCyan": "#69fcd3",
+  "brightWhite": "#f9f9f5",
+  "background": "#242728",
+  "foreground": "#c1c1c1"
+}

--- a/windowsterminal/UnderTheSea.json
+++ b/windowsterminal/UnderTheSea.json
@@ -1,0 +1,21 @@
+{
+  "name": "UnderTheSea",
+  "black": "#022026",
+  "red": "#b2302d",
+  "green": "#00a941",
+  "yellow": "#59819c",
+  "blue": "#459a86",
+  "purple": "#00599d",
+  "cyan": "#5d7e19",
+  "white": "#405555",
+  "brightBlack": "#384451",
+  "brightRed": "#ff4242",
+  "brightGreen": "#2aea5e",
+  "brightYellow": "#8ed4fd",
+  "brightBlue": "#61d5ba",
+  "brightPurple": "#1298ff",
+  "brightCyan": "#98d028",
+  "brightWhite": "#58fbd6",
+  "background": "#011116",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Unikitty.json
+++ b/windowsterminal/Unikitty.json
@@ -1,0 +1,21 @@
+{
+  "name": "Unikitty",
+  "black": "#0c0c0c",
+  "red": "#a80f20",
+  "green": "#bafc8b",
+  "yellow": "#eedf4b",
+  "blue": "#145fcd",
+  "purple": "#ff36a2",
+  "cyan": "#6bd1bc",
+  "white": "#e2d7e1",
+  "brightBlack": "#434343",
+  "brightRed": "#d91329",
+  "brightGreen": "#d3ffaf",
+  "brightYellow": "#ffef50",
+  "brightBlue": "#0075ea",
+  "brightPurple": "#fdd5e5",
+  "brightCyan": "#79ecd5",
+  "brightWhite": "#fff3fe",
+  "background": "#ff8cd9",
+  "foreground": "#0b0b0b"
+}

--- a/windowsterminal/Urple.json
+++ b/windowsterminal/Urple.json
@@ -1,0 +1,21 @@
+{
+  "name": "Urple",
+  "black": "#000000",
+  "red": "#b0425b",
+  "green": "#37a415",
+  "yellow": "#ad5c42",
+  "blue": "#564d9b",
+  "purple": "#6c3ca1",
+  "cyan": "#808080",
+  "white": "#87799c",
+  "brightBlack": "#5d3225",
+  "brightRed": "#ff6388",
+  "brightGreen": "#29e620",
+  "brightYellow": "#f08161",
+  "brightBlue": "#867aed",
+  "brightPurple": "#a05eee",
+  "brightCyan": "#eaeaea",
+  "brightWhite": "#bfa3ff",
+  "background": "#1b1b23",
+  "foreground": "#877a9b"
+}

--- a/windowsterminal/Vaughn.json
+++ b/windowsterminal/Vaughn.json
@@ -1,0 +1,21 @@
+{
+  "name": "Vaughn",
+  "black": "#25234f",
+  "red": "#705050",
+  "green": "#60b48a",
+  "yellow": "#dfaf8f",
+  "blue": "#5555ff",
+  "purple": "#f08cc3",
+  "cyan": "#8cd0d3",
+  "white": "#709080",
+  "brightBlack": "#709080",
+  "brightRed": "#dca3a3",
+  "brightGreen": "#60b48a",
+  "brightYellow": "#f0dfaf",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ec93d3",
+  "brightCyan": "#93e0e3",
+  "brightWhite": "#ffffff",
+  "background": "#25234f",
+  "foreground": "#dcdccc"
+}

--- a/windowsterminal/VibrantInk.json
+++ b/windowsterminal/VibrantInk.json
@@ -1,0 +1,21 @@
+{
+  "name": "VibrantInk",
+  "black": "#878787",
+  "red": "#ff6600",
+  "green": "#ccff04",
+  "yellow": "#ffcc00",
+  "blue": "#44b4cc",
+  "purple": "#9933cc",
+  "cyan": "#44b4cc",
+  "white": "#f5f5f5",
+  "brightBlack": "#555555",
+  "brightRed": "#ff0000",
+  "brightGreen": "#00ff00",
+  "brightYellow": "#ffff00",
+  "brightBlue": "#0000ff",
+  "brightPurple": "#ff00ff",
+  "brightCyan": "#00ffff",
+  "brightWhite": "#e5e5e5",
+  "background": "#000000",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/Violet Dark.json
+++ b/windowsterminal/Violet Dark.json
@@ -1,0 +1,21 @@
+{
+  "name": "Violet Dark",
+  "black": "#56595c",
+  "red": "#c94c22",
+  "green": "#85981c",
+  "yellow": "#b4881d",
+  "blue": "#2e8bce",
+  "purple": "#d13a82",
+  "cyan": "#32a198",
+  "white": "#c9c6bd",
+  "brightBlack": "#45484b",
+  "brightRed": "#bd3613",
+  "brightGreen": "#738a04",
+  "brightYellow": "#a57705",
+  "brightBlue": "#2176c7",
+  "brightPurple": "#c61c6f",
+  "brightCyan": "#259286",
+  "brightWhite": "#c9c6bd",
+  "background": "#1c1d1f",
+  "foreground": "#708284"
+}

--- a/windowsterminal/Violet Light.json
+++ b/windowsterminal/Violet Light.json
@@ -1,0 +1,21 @@
+{
+  "name": "Violet Light",
+  "black": "#56595c",
+  "red": "#c94c22",
+  "green": "#85981c",
+  "yellow": "#b4881d",
+  "blue": "#2e8bce",
+  "purple": "#d13a82",
+  "cyan": "#32a198",
+  "white": "#d3d0c9",
+  "brightBlack": "#45484b",
+  "brightRed": "#bd3613",
+  "brightGreen": "#738a04",
+  "brightYellow": "#a57705",
+  "brightBlue": "#2176c7",
+  "brightPurple": "#c61c6f",
+  "brightCyan": "#259286",
+  "brightWhite": "#c9c6bd",
+  "background": "#fcf4dc",
+  "foreground": "#536870"
+}

--- a/windowsterminal/WarmNeon.json
+++ b/windowsterminal/WarmNeon.json
@@ -1,0 +1,21 @@
+{
+  "name": "WarmNeon",
+  "black": "#000000",
+  "red": "#e24346",
+  "green": "#39b13a",
+  "yellow": "#dae145",
+  "blue": "#4261c5",
+  "purple": "#f920fb",
+  "cyan": "#2abbd4",
+  "white": "#d0b8a3",
+  "brightBlack": "#fefcfc",
+  "brightRed": "#e97071",
+  "brightGreen": "#9cc090",
+  "brightYellow": "#ddda7a",
+  "brightBlue": "#7b91d6",
+  "brightPurple": "#f674ba",
+  "brightCyan": "#5ed1e5",
+  "brightWhite": "#d8c8bb",
+  "background": "#404040",
+  "foreground": "#afdab6"
+}

--- a/windowsterminal/Wez.json
+++ b/windowsterminal/Wez.json
@@ -1,0 +1,21 @@
+{
+  "name": "Wez",
+  "black": "#000000",
+  "red": "#cc5555",
+  "green": "#55cc55",
+  "yellow": "#cdcd55",
+  "blue": "#5555cc",
+  "purple": "#cc55cc",
+  "cyan": "#7acaca",
+  "white": "#cccccc",
+  "brightBlack": "#555555",
+  "brightRed": "#ff5555",
+  "brightGreen": "#55ff55",
+  "brightYellow": "#ffff55",
+  "brightBlue": "#5555ff",
+  "brightPurple": "#ff55ff",
+  "brightCyan": "#55ffff",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#b3b3b3"
+}

--- a/windowsterminal/Whimsy.json
+++ b/windowsterminal/Whimsy.json
@@ -1,0 +1,21 @@
+{
+  "name": "Whimsy",
+  "black": "#535178",
+  "red": "#ef6487",
+  "green": "#5eca89",
+  "yellow": "#fdd877",
+  "blue": "#65aef7",
+  "purple": "#aa7ff0",
+  "cyan": "#43c1be",
+  "white": "#ffffff",
+  "brightBlack": "#535178",
+  "brightRed": "#ef6487",
+  "brightGreen": "#5eca89",
+  "brightYellow": "#fdd877",
+  "brightBlue": "#65aef7",
+  "brightPurple": "#aa7ff0",
+  "brightCyan": "#43c1be",
+  "brightWhite": "#ffffff",
+  "background": "#29283b",
+  "foreground": "#b3b0d6"
+}

--- a/windowsterminal/WildCherry.json
+++ b/windowsterminal/WildCherry.json
@@ -1,0 +1,21 @@
+{
+  "name": "WildCherry",
+  "black": "#000507",
+  "red": "#d94085",
+  "green": "#2ab250",
+  "yellow": "#ffd16f",
+  "blue": "#883cdc",
+  "purple": "#ececec",
+  "cyan": "#c1b8b7",
+  "white": "#fff8de",
+  "brightBlack": "#009cc9",
+  "brightRed": "#da6bac",
+  "brightGreen": "#f4dca5",
+  "brightYellow": "#eac066",
+  "brightBlue": "#308cba",
+  "brightPurple": "#ae636b",
+  "brightCyan": "#ff919d",
+  "brightWhite": "#e4838d",
+  "background": "#1f1726",
+  "foreground": "#dafaff"
+}

--- a/windowsterminal/Wombat.json
+++ b/windowsterminal/Wombat.json
@@ -1,0 +1,21 @@
+{
+  "name": "Wombat",
+  "black": "#000000",
+  "red": "#ff615a",
+  "green": "#b1e969",
+  "yellow": "#ebd99c",
+  "blue": "#5da9f6",
+  "purple": "#e86aff",
+  "cyan": "#82fff7",
+  "white": "#dedacf",
+  "brightBlack": "#313131",
+  "brightRed": "#f58c80",
+  "brightGreen": "#ddf88f",
+  "brightYellow": "#eee5b2",
+  "brightBlue": "#a5c7ff",
+  "brightPurple": "#ddaaff",
+  "brightCyan": "#b7fff9",
+  "brightWhite": "#ffffff",
+  "background": "#171717",
+  "foreground": "#dedacf"
+}

--- a/windowsterminal/Wryan.json
+++ b/windowsterminal/Wryan.json
@@ -1,0 +1,21 @@
+{
+  "name": "Wryan",
+  "black": "#333333",
+  "red": "#8c4665",
+  "green": "#287373",
+  "yellow": "#7c7c99",
+  "blue": "#395573",
+  "purple": "#5e468c",
+  "cyan": "#31658c",
+  "white": "#899ca1",
+  "brightBlack": "#3d3d3d",
+  "brightRed": "#bf4d80",
+  "brightGreen": "#53a6a6",
+  "brightYellow": "#9e9ecb",
+  "brightBlue": "#477ab3",
+  "brightPurple": "#7e62b3",
+  "brightCyan": "#6096bf",
+  "brightWhite": "#c0c0c0",
+  "background": "#101010",
+  "foreground": "#999993"
+}

--- a/windowsterminal/Zenburn.json
+++ b/windowsterminal/Zenburn.json
@@ -1,0 +1,21 @@
+{
+  "name": "Zenburn",
+  "black": "#4d4d4d",
+  "red": "#705050",
+  "green": "#60b48a",
+  "yellow": "#f0dfaf",
+  "blue": "#506070",
+  "purple": "#dc8cc3",
+  "cyan": "#8cd0d3",
+  "white": "#dcdccc",
+  "brightBlack": "#709080",
+  "brightRed": "#dca3a3",
+  "brightGreen": "#c3bf9f",
+  "brightYellow": "#e0cf9f",
+  "brightBlue": "#94bff3",
+  "brightPurple": "#ec93d3",
+  "brightCyan": "#93e0e3",
+  "brightWhite": "#ffffff",
+  "background": "#3f3f3f",
+  "foreground": "#dcdccc"
+}

--- a/windowsterminal/ayu.json
+++ b/windowsterminal/ayu.json
@@ -1,0 +1,21 @@
+{
+  "name": "ayu",
+  "black": "#000000",
+  "red": "#ff3333",
+  "green": "#b8cc52",
+  "yellow": "#e7c547",
+  "blue": "#36a3d9",
+  "purple": "#f07178",
+  "cyan": "#95e6cb",
+  "white": "#ffffff",
+  "brightBlack": "#323232",
+  "brightRed": "#ff6565",
+  "brightGreen": "#eafe84",
+  "brightYellow": "#fff779",
+  "brightBlue": "#68d5ff",
+  "brightPurple": "#ffa3aa",
+  "brightCyan": "#c7fffd",
+  "brightWhite": "#ffffff",
+  "background": "#0f1419",
+  "foreground": "#e6e1cf"
+}

--- a/windowsterminal/ayu_light.json
+++ b/windowsterminal/ayu_light.json
@@ -1,0 +1,21 @@
+{
+  "name": "ayu_light",
+  "black": "#000000",
+  "red": "#ff3333",
+  "green": "#86b300",
+  "yellow": "#f29718",
+  "blue": "#41a6d9",
+  "purple": "#f07178",
+  "cyan": "#4dbf99",
+  "white": "#ffffff",
+  "brightBlack": "#323232",
+  "brightRed": "#ff6565",
+  "brightGreen": "#b8e532",
+  "brightYellow": "#ffc94a",
+  "brightBlue": "#73d8ff",
+  "brightPurple": "#ffa3aa",
+  "brightCyan": "#7ff1cb",
+  "brightWhite": "#ffffff",
+  "background": "#fafafa",
+  "foreground": "#5c6773"
+}

--- a/windowsterminal/cyberpunk.json
+++ b/windowsterminal/cyberpunk.json
@@ -1,0 +1,21 @@
+{
+  "name": "cyberpunk",
+  "black": "#000000",
+  "red": "#ff7092",
+  "green": "#00fbac",
+  "yellow": "#fffa6a",
+  "blue": "#00bfff",
+  "purple": "#df95ff",
+  "cyan": "#86cbfe",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#ff8aa4",
+  "brightGreen": "#21f6bc",
+  "brightYellow": "#fff787",
+  "brightBlue": "#1bccfd",
+  "brightPurple": "#e6aefe",
+  "brightCyan": "#99d6fc",
+  "brightWhite": "#ffffff",
+  "background": "#332a57",
+  "foreground": "#e5e5e5"
+}

--- a/windowsterminal/deep.json
+++ b/windowsterminal/deep.json
@@ -1,0 +1,21 @@
+{
+  "name": "deep",
+  "black": "#000000",
+  "red": "#d70005",
+  "green": "#1cd915",
+  "yellow": "#d9bd26",
+  "blue": "#5665ff",
+  "purple": "#b052da",
+  "cyan": "#50d2da",
+  "white": "#e0e0e0",
+  "brightBlack": "#535353",
+  "brightRed": "#fb0007",
+  "brightGreen": "#22ff18",
+  "brightYellow": "#fedc2b",
+  "brightBlue": "#9fa9ff",
+  "brightPurple": "#e09aff",
+  "brightCyan": "#8df9ff",
+  "brightWhite": "#ffffff",
+  "background": "#090909",
+  "foreground": "#cdcdcd"
+}

--- a/windowsterminal/idea.json
+++ b/windowsterminal/idea.json
@@ -1,0 +1,21 @@
+{
+  "name": "idea",
+  "black": "#adadad",
+  "red": "#fc5256",
+  "green": "#98b61c",
+  "yellow": "#ccb444",
+  "blue": "#437ee7",
+  "purple": "#9d74b0",
+  "cyan": "#248887",
+  "white": "#181818",
+  "brightBlack": "#ffffff",
+  "brightRed": "#fc7072",
+  "brightGreen": "#98b61c",
+  "brightYellow": "#ffff0b",
+  "brightBlue": "#6c9ced",
+  "brightPurple": "#fc7eff",
+  "brightCyan": "#248887",
+  "brightWhite": "#181818",
+  "background": "#202020",
+  "foreground": "#adadad"
+}

--- a/windowsterminal/idleToes.json
+++ b/windowsterminal/idleToes.json
@@ -1,0 +1,21 @@
+{
+  "name": "idleToes",
+  "black": "#323232",
+  "red": "#d25252",
+  "green": "#7fe173",
+  "yellow": "#ffc66d",
+  "blue": "#4099ff",
+  "purple": "#f680ff",
+  "cyan": "#bed6ff",
+  "white": "#eeeeec",
+  "brightBlack": "#535353",
+  "brightRed": "#f07070",
+  "brightGreen": "#9dff91",
+  "brightYellow": "#ffe48b",
+  "brightBlue": "#5eb7f7",
+  "brightPurple": "#ff9dff",
+  "brightCyan": "#dcf4ff",
+  "brightWhite": "#ffffff",
+  "background": "#323232",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/lovelace.json
+++ b/windowsterminal/lovelace.json
@@ -1,0 +1,21 @@
+{
+  "name": "lovelace",
+  "black": "#282a36",
+  "red": "#f37f97",
+  "green": "#5adecd",
+  "yellow": "#f2a272",
+  "blue": "#8897f4",
+  "purple": "#c574dd",
+  "cyan": "#79e6f3",
+  "white": "#fdfdfd",
+  "brightBlack": "#414458",
+  "brightRed": "#ff4971",
+  "brightGreen": "#18e3c8",
+  "brightYellow": "#ff8037",
+  "brightBlue": "#556fff",
+  "brightPurple": "#b043d1",
+  "brightCyan": "#3fdcee",
+  "brightWhite": "#bebec1",
+  "background": "#1d1f28",
+  "foreground": "#fdfdfd"
+}

--- a/windowsterminal/midnight-in-mojave.json
+++ b/windowsterminal/midnight-in-mojave.json
@@ -1,0 +1,21 @@
+{
+  "name": "midnight-in-mojave",
+  "black": "#1e1e1e",
+  "red": "#ff453a",
+  "green": "#32d74b",
+  "yellow": "#ffd60a",
+  "blue": "#0a84ff",
+  "purple": "#bf5af2",
+  "cyan": "#5ac8fa",
+  "white": "#ffffff",
+  "brightBlack": "#1e1e1e",
+  "brightRed": "#ff453a",
+  "brightGreen": "#32d74b",
+  "brightYellow": "#ffd60a",
+  "brightBlue": "#0a84ff",
+  "brightPurple": "#bf5af2",
+  "brightCyan": "#5ac8fa",
+  "brightWhite": "#ffffff",
+  "background": "#1e1e1e",
+  "foreground": "#ffffff"
+}

--- a/windowsterminal/primary.json
+++ b/windowsterminal/primary.json
@@ -1,0 +1,21 @@
+{
+  "name": "primary",
+  "black": "#000000",
+  "red": "#db4437",
+  "green": "#0f9d58",
+  "yellow": "#f4b400",
+  "blue": "#4285f4",
+  "purple": "#db4437",
+  "cyan": "#4285f4",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#db4437",
+  "brightGreen": "#0f9d58",
+  "brightYellow": "#f4b400",
+  "brightBlue": "#4285f4",
+  "brightPurple": "#4285f4",
+  "brightCyan": "#0f9d58",
+  "brightWhite": "#ffffff",
+  "background": "#ffffff",
+  "foreground": "#000000"
+}

--- a/windowsterminal/purplepeter.json
+++ b/windowsterminal/purplepeter.json
@@ -1,0 +1,21 @@
+{
+  "name": "purplepeter",
+  "black": "#0a0520",
+  "red": "#ff796d",
+  "green": "#99b481",
+  "yellow": "#efdfac",
+  "blue": "#66d9ef",
+  "purple": "#e78fcd",
+  "cyan": "#ba8cff",
+  "white": "#ffba81",
+  "brightBlack": "#100b23",
+  "brightRed": "#f99f92",
+  "brightGreen": "#b4be8f",
+  "brightYellow": "#f2e9bf",
+  "brightBlue": "#79daed",
+  "brightPurple": "#ba91d4",
+  "brightCyan": "#a0a0d6",
+  "brightWhite": "#b9aed3",
+  "background": "#2a1a4a",
+  "foreground": "#ece7fa"
+}

--- a/windowsterminal/rebecca.json
+++ b/windowsterminal/rebecca.json
@@ -1,0 +1,21 @@
+{
+  "name": "rebecca",
+  "black": "#12131e",
+  "red": "#dd7755",
+  "green": "#04dbb5",
+  "yellow": "#f2e7b7",
+  "blue": "#7aa5ff",
+  "purple": "#bf9cf9",
+  "cyan": "#56d3c2",
+  "white": "#e4e3e9",
+  "brightBlack": "#666699",
+  "brightRed": "#ff92cd",
+  "brightGreen": "#01eac0",
+  "brightYellow": "#fffca8",
+  "brightBlue": "#69c0fa",
+  "brightPurple": "#c17ff8",
+  "brightCyan": "#8bfde1",
+  "brightWhite": "#f4f2f9",
+  "background": "#292a44",
+  "foreground": "#e8e6ed"
+}

--- a/windowsterminal/synthwave.json
+++ b/windowsterminal/synthwave.json
@@ -1,0 +1,21 @@
+{
+  "name": "synthwave",
+  "black": "#000000",
+  "red": "#f6188f",
+  "green": "#1ebb2b",
+  "yellow": "#fdf834",
+  "blue": "#2186ec",
+  "purple": "#f85a21",
+  "cyan": "#12c3e2",
+  "white": "#ffffff",
+  "brightBlack": "#000000",
+  "brightRed": "#f841a0",
+  "brightGreen": "#25c141",
+  "brightYellow": "#fdf454",
+  "brightBlue": "#2f9ded",
+  "brightPurple": "#f97137",
+  "brightCyan": "#19cde6",
+  "brightWhite": "#ffffff",
+  "background": "#000000",
+  "foreground": "#dad9c7"
+}


### PR DESCRIPTION
Microsoft have a new open source [Windows Terminal](https://github.com/microsoft/terminal).

While the old Console can use `colortool` to load `.itermcolors` schemes, the new one has its own JSON object scheme format, so **this PR adds support for the new scheme format**.

- Added an `xrdb2windowsterminal.py` conversion script (based on `xrdb2wezterm.py`)
- Added the script to `update_all.py`
- Ran the script and added the output schemes to `windowsterminal/`