### PR TITLE
Feature: Add Visual Studio Code (vscode) Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1296,6 +1296,9 @@ Copy the theme content form `mobaxterm/` and paste the content to your `MobaXter
 ### LXTerminal color schemes
 Copy the theme content form `lxterminal/` and paste the content to your `lxterminal` in the corresponding place. (`[general]`)
 
+### Visual Studio Code (vscode) color schemes
+Copy the theme content into your [UserSettings.json](https://code.visualstudio.com/docs/getstarted/settings)
+
 ### Previewing color schemes
 
 [preview.rb](tools/preview.rb) is a simple script that allows you to preview

--- a/tools/windowsterminal2vscode.ps1
+++ b/tools/windowsterminal2vscode.ps1
@@ -1,0 +1,32 @@
+#requires -version 5
+if (-not (Test-Path ../vscode)) {New-Item -ItemType Directory ../vscode}
+Get-Item ../WindowsTerminal/*.json | Foreach-Object {
+    write-verbose "Generating vscode theme for $($PSItem.name)"
+    $theme = Get-Content -raw $PSItem | ConvertFrom-JSON
+    @"
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "$($theme.foreground)",
+        "terminal.background": "$($theme.background)",
+        "terminal.ansiBlack": "$($theme.black)",
+        "terminal.ansiBlue": "$($theme.blue)",
+        "terminal.ansiCyan": "$($theme.cyan)",
+        "terminal.ansiGreen": "$($theme.green)",
+        "terminal.ansiMagenta": "$($theme.purple)",
+        "terminal.ansiRed": "$($theme.red)",
+        "terminal.ansiWhite": "$($theme.white)",
+        "terminal.ansiYellow": "$($theme.yellow)",
+        "terminal.ansiBrightBlack": "$($theme.brightBlack)",
+        "terminal.ansiBrightBlue": "$($theme.brightBlue)",
+        "terminal.ansiBrightCyan": "$($theme.brightCyan)",
+        "terminal.ansiBrightGreen": "$($theme.brightGreen)",
+        "terminal.ansiBrightMagenta": "$($theme.brightPurple)",
+        "terminal.ansiBrightRed": "$($theme.brightRed)",
+        "terminal.ansiBrightWhite": "$($theme.brightWhite)",
+        "terminal.ansiBrightYellow": "$($theme.brightYellow)"
+    }
+}
+"@ > "../vscode/$($PSItem.Name)"
+}
+
+

--- a/vscode/3024 Day.json
+++ b/vscode/3024 Day.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#4a4543",
+        "terminal.background": "#f7f7f7",
+        "terminal.ansiBlack": "#090300",
+        "terminal.ansiBlue": "#01a0e4",
+        "terminal.ansiCyan": "#b5e4f4",
+        "terminal.ansiGreen": "#01a252",
+        "terminal.ansiMagenta": "#a16a94",
+        "terminal.ansiRed": "#db2d20",
+        "terminal.ansiWhite": "#a5a2a2",
+        "terminal.ansiYellow": "#fded02",
+        "terminal.ansiBrightBlack": "#5c5855",
+        "terminal.ansiBrightBlue": "#807d7c",
+        "terminal.ansiBrightCyan": "#cdab53",
+        "terminal.ansiBrightGreen": "#3a3432",
+        "terminal.ansiBrightMagenta": "#d6d5d4",
+        "terminal.ansiBrightRed": "#e8bbd0",
+        "terminal.ansiBrightWhite": "#f7f7f7",
+        "terminal.ansiBrightYellow": "#4a4543"
+    }
+}

--- a/vscode/3024 Night.json
+++ b/vscode/3024 Night.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a5a2a2",
+        "terminal.background": "#090300",
+        "terminal.ansiBlack": "#090300",
+        "terminal.ansiBlue": "#01a0e4",
+        "terminal.ansiCyan": "#b5e4f4",
+        "terminal.ansiGreen": "#01a252",
+        "terminal.ansiMagenta": "#a16a94",
+        "terminal.ansiRed": "#db2d20",
+        "terminal.ansiWhite": "#a5a2a2",
+        "terminal.ansiYellow": "#fded02",
+        "terminal.ansiBrightBlack": "#5c5855",
+        "terminal.ansiBrightBlue": "#807d7c",
+        "terminal.ansiBrightCyan": "#cdab53",
+        "terminal.ansiBrightGreen": "#3a3432",
+        "terminal.ansiBrightMagenta": "#d6d5d4",
+        "terminal.ansiBrightRed": "#e8bbd0",
+        "terminal.ansiBrightWhite": "#f7f7f7",
+        "terminal.ansiBrightYellow": "#4a4543"
+    }
+}

--- a/vscode/AdventureTime.json
+++ b/vscode/AdventureTime.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f8dcc0",
+        "terminal.background": "#1f1d45",
+        "terminal.ansiBlack": "#050404",
+        "terminal.ansiBlue": "#0f4ac6",
+        "terminal.ansiCyan": "#70a598",
+        "terminal.ansiGreen": "#4ab118",
+        "terminal.ansiMagenta": "#665993",
+        "terminal.ansiRed": "#bd0013",
+        "terminal.ansiWhite": "#f8dcc0",
+        "terminal.ansiYellow": "#e7741e",
+        "terminal.ansiBrightBlack": "#4e7cbf",
+        "terminal.ansiBrightBlue": "#1997c6",
+        "terminal.ansiBrightCyan": "#c8faf4",
+        "terminal.ansiBrightGreen": "#9eff6e",
+        "terminal.ansiBrightMagenta": "#9b5953",
+        "terminal.ansiBrightRed": "#fc5f5a",
+        "terminal.ansiBrightWhite": "#f6f5fb",
+        "terminal.ansiBrightYellow": "#efc11a"
+    }
+}

--- a/vscode/Afterglow.json
+++ b/vscode/Afterglow.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d0d0d0",
+        "terminal.background": "#212121",
+        "terminal.ansiBlack": "#151515",
+        "terminal.ansiBlue": "#6c99bb",
+        "terminal.ansiCyan": "#7dd6cf",
+        "terminal.ansiGreen": "#7e8e50",
+        "terminal.ansiMagenta": "#9f4e85",
+        "terminal.ansiRed": "#ac4142",
+        "terminal.ansiWhite": "#d0d0d0",
+        "terminal.ansiYellow": "#e5b567",
+        "terminal.ansiBrightBlack": "#505050",
+        "terminal.ansiBrightBlue": "#6c99bb",
+        "terminal.ansiBrightCyan": "#7dd6cf",
+        "terminal.ansiBrightGreen": "#7e8e50",
+        "terminal.ansiBrightMagenta": "#9f4e85",
+        "terminal.ansiBrightRed": "#ac4142",
+        "terminal.ansiBrightWhite": "#f5f5f5",
+        "terminal.ansiBrightYellow": "#e5b567"
+    }
+}

--- a/vscode/AlienBlood.json
+++ b/vscode/AlienBlood.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#637d75",
+        "terminal.background": "#0f1610",
+        "terminal.ansiBlack": "#112616",
+        "terminal.ansiBlue": "#2f6a7f",
+        "terminal.ansiCyan": "#327f77",
+        "terminal.ansiGreen": "#2f7e25",
+        "terminal.ansiMagenta": "#47587f",
+        "terminal.ansiRed": "#7f2b27",
+        "terminal.ansiWhite": "#647d75",
+        "terminal.ansiYellow": "#717f24",
+        "terminal.ansiBrightBlack": "#3c4812",
+        "terminal.ansiBrightBlue": "#00aae0",
+        "terminal.ansiBrightCyan": "#00e0c4",
+        "terminal.ansiBrightGreen": "#18e000",
+        "terminal.ansiBrightMagenta": "#0058e0",
+        "terminal.ansiBrightRed": "#e08009",
+        "terminal.ansiBrightWhite": "#73fa91",
+        "terminal.ansiBrightYellow": "#bde000"
+    }
+}

--- a/vscode/Andromeda.json
+++ b/vscode/Andromeda.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e5e5e5",
+        "terminal.background": "#262a33",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2472c8",
+        "terminal.ansiCyan": "#0fa8cd",
+        "terminal.ansiGreen": "#05bc79",
+        "terminal.ansiMagenta": "#bc3fbc",
+        "terminal.ansiRed": "#cd3131",
+        "terminal.ansiWhite": "#e5e5e5",
+        "terminal.ansiYellow": "#e5e512",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#2472c8",
+        "terminal.ansiBrightCyan": "#0fa8cd",
+        "terminal.ansiBrightGreen": "#05bc79",
+        "terminal.ansiBrightMagenta": "#bc3fbc",
+        "terminal.ansiBrightRed": "#cd3131",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e512"
+    }
+}

--- a/vscode/Argonaut.json
+++ b/vscode/Argonaut.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#fffaf4",
+        "terminal.background": "#0e1019",
+        "terminal.ansiBlack": "#232323",
+        "terminal.ansiBlue": "#008df8",
+        "terminal.ansiCyan": "#00d8eb",
+        "terminal.ansiGreen": "#8ce10b",
+        "terminal.ansiMagenta": "#6d43a6",
+        "terminal.ansiRed": "#ff000f",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffb900",
+        "terminal.ansiBrightBlack": "#444444",
+        "terminal.ansiBrightBlue": "#0092ff",
+        "terminal.ansiBrightCyan": "#67fff0",
+        "terminal.ansiBrightGreen": "#abe15b",
+        "terminal.ansiBrightMagenta": "#9a5feb",
+        "terminal.ansiBrightRed": "#ff2740",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffd242"
+    }
+}

--- a/vscode/Arthur.json
+++ b/vscode/Arthur.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ddeedd",
+        "terminal.background": "#1c1c1c",
+        "terminal.ansiBlack": "#3d352a",
+        "terminal.ansiBlue": "#6495ed",
+        "terminal.ansiCyan": "#b0c4de",
+        "terminal.ansiGreen": "#86af80",
+        "terminal.ansiMagenta": "#deb887",
+        "terminal.ansiRed": "#cd5c5c",
+        "terminal.ansiWhite": "#bbaa99",
+        "terminal.ansiYellow": "#e8ae5b",
+        "terminal.ansiBrightBlack": "#554444",
+        "terminal.ansiBrightBlue": "#87ceeb",
+        "terminal.ansiBrightCyan": "#b0c4de",
+        "terminal.ansiBrightGreen": "#88aa22",
+        "terminal.ansiBrightMagenta": "#996600",
+        "terminal.ansiBrightRed": "#cc5533",
+        "terminal.ansiBrightWhite": "#ddccbb",
+        "terminal.ansiBrightYellow": "#ffa75d"
+    }
+}

--- a/vscode/AtelierSulphurpool.json
+++ b/vscode/AtelierSulphurpool.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#979db4",
+        "terminal.background": "#202746",
+        "terminal.ansiBlack": "#202746",
+        "terminal.ansiBlue": "#3d8fd1",
+        "terminal.ansiCyan": "#22a2c9",
+        "terminal.ansiGreen": "#ac9739",
+        "terminal.ansiMagenta": "#6679cc",
+        "terminal.ansiRed": "#c94922",
+        "terminal.ansiWhite": "#979db4",
+        "terminal.ansiYellow": "#c08b30",
+        "terminal.ansiBrightBlack": "#6b7394",
+        "terminal.ansiBrightBlue": "#898ea4",
+        "terminal.ansiBrightCyan": "#9c637a",
+        "terminal.ansiBrightGreen": "#293256",
+        "terminal.ansiBrightMagenta": "#dfe2f1",
+        "terminal.ansiBrightRed": "#c76b29",
+        "terminal.ansiBrightWhite": "#f5f7ff",
+        "terminal.ansiBrightYellow": "#5e6687"
+    }
+}

--- a/vscode/Atom.json
+++ b/vscode/Atom.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c5c8c6",
+        "terminal.background": "#161719",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#85befd",
+        "terminal.ansiCyan": "#85befd",
+        "terminal.ansiGreen": "#87c38a",
+        "terminal.ansiMagenta": "#b9b6fc",
+        "terminal.ansiRed": "#fd5ff1",
+        "terminal.ansiWhite": "#e0e0e0",
+        "terminal.ansiYellow": "#ffd7b1",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#96cbfe",
+        "terminal.ansiBrightCyan": "#85befd",
+        "terminal.ansiBrightGreen": "#94fa36",
+        "terminal.ansiBrightMagenta": "#b9b6fc",
+        "terminal.ansiBrightRed": "#fd5ff1",
+        "terminal.ansiBrightWhite": "#e0e0e0",
+        "terminal.ansiBrightYellow": "#f5ffa8"
+    }
+}

--- a/vscode/AtomOneLight.json
+++ b/vscode/AtomOneLight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#2a2c33",
+        "terminal.background": "#f9f9f9",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2f5af3",
+        "terminal.ansiCyan": "#3f953a",
+        "terminal.ansiGreen": "#3f953a",
+        "terminal.ansiMagenta": "#950095",
+        "terminal.ansiRed": "#de3e35",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#d2b67c",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#2f5af3",
+        "terminal.ansiBrightCyan": "#3f953a",
+        "terminal.ansiBrightGreen": "#3f953a",
+        "terminal.ansiBrightMagenta": "#a00095",
+        "terminal.ansiBrightRed": "#de3e35",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#d2b67c"
+    }
+}

--- a/vscode/Batman.json
+++ b/vscode/Batman.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#6f6f6f",
+        "terminal.background": "#1b1d1e",
+        "terminal.ansiBlack": "#1b1d1e",
+        "terminal.ansiBlue": "#737174",
+        "terminal.ansiCyan": "#62605f",
+        "terminal.ansiGreen": "#c8be46",
+        "terminal.ansiMagenta": "#747271",
+        "terminal.ansiRed": "#e6dc44",
+        "terminal.ansiWhite": "#c6c5bf",
+        "terminal.ansiYellow": "#f4fd22",
+        "terminal.ansiBrightBlack": "#505354",
+        "terminal.ansiBrightBlue": "#919495",
+        "terminal.ansiBrightCyan": "#a3a3a6",
+        "terminal.ansiBrightGreen": "#fff27d",
+        "terminal.ansiBrightMagenta": "#9a9a9d",
+        "terminal.ansiBrightRed": "#fff78e",
+        "terminal.ansiBrightWhite": "#dadbd6",
+        "terminal.ansiBrightYellow": "#feed6c"
+    }
+}

--- a/vscode/Belafonte Day.json
+++ b/vscode/Belafonte Day.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#45373c",
+        "terminal.background": "#d5ccba",
+        "terminal.ansiBlack": "#20111b",
+        "terminal.ansiBlue": "#426a79",
+        "terminal.ansiCyan": "#989a9c",
+        "terminal.ansiGreen": "#858162",
+        "terminal.ansiMagenta": "#97522c",
+        "terminal.ansiRed": "#be100e",
+        "terminal.ansiWhite": "#968c83",
+        "terminal.ansiYellow": "#eaa549",
+        "terminal.ansiBrightBlack": "#5e5252",
+        "terminal.ansiBrightBlue": "#426a79",
+        "terminal.ansiBrightCyan": "#989a9c",
+        "terminal.ansiBrightGreen": "#858162",
+        "terminal.ansiBrightMagenta": "#97522c",
+        "terminal.ansiBrightRed": "#be100e",
+        "terminal.ansiBrightWhite": "#d5ccba",
+        "terminal.ansiBrightYellow": "#eaa549"
+    }
+}

--- a/vscode/Belafonte Night.json
+++ b/vscode/Belafonte Night.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#968c83",
+        "terminal.background": "#20111b",
+        "terminal.ansiBlack": "#20111b",
+        "terminal.ansiBlue": "#426a79",
+        "terminal.ansiCyan": "#989a9c",
+        "terminal.ansiGreen": "#858162",
+        "terminal.ansiMagenta": "#97522c",
+        "terminal.ansiRed": "#be100e",
+        "terminal.ansiWhite": "#968c83",
+        "terminal.ansiYellow": "#eaa549",
+        "terminal.ansiBrightBlack": "#5e5252",
+        "terminal.ansiBrightBlue": "#426a79",
+        "terminal.ansiBrightCyan": "#989a9c",
+        "terminal.ansiBrightGreen": "#858162",
+        "terminal.ansiBrightMagenta": "#97522c",
+        "terminal.ansiBrightRed": "#be100e",
+        "terminal.ansiBrightWhite": "#d5ccba",
+        "terminal.ansiBrightYellow": "#eaa549"
+    }
+}

--- a/vscode/BirdsOfParadise.json
+++ b/vscode/BirdsOfParadise.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e0dbb7",
+        "terminal.background": "#2a1f1d",
+        "terminal.ansiBlack": "#573d26",
+        "terminal.ansiBlue": "#5a86ad",
+        "terminal.ansiCyan": "#74a6ad",
+        "terminal.ansiGreen": "#6ba18a",
+        "terminal.ansiMagenta": "#ac80a6",
+        "terminal.ansiRed": "#be2d26",
+        "terminal.ansiWhite": "#e0dbb7",
+        "terminal.ansiYellow": "#e99d2a",
+        "terminal.ansiBrightBlack": "#9b6c4a",
+        "terminal.ansiBrightBlue": "#b8d3ed",
+        "terminal.ansiBrightCyan": "#93cfd7",
+        "terminal.ansiBrightGreen": "#95d8ba",
+        "terminal.ansiBrightMagenta": "#d19ecb",
+        "terminal.ansiBrightRed": "#e84627",
+        "terminal.ansiBrightWhite": "#fff9d5",
+        "terminal.ansiBrightYellow": "#d0d150"
+    }
+}

--- a/vscode/Blazer.json
+++ b/vscode/Blazer.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d9e6f2",
+        "terminal.background": "#0d1926",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#7a7ab8",
+        "terminal.ansiCyan": "#7ab8b8",
+        "terminal.ansiGreen": "#7ab87a",
+        "terminal.ansiMagenta": "#b87ab8",
+        "terminal.ansiRed": "#b87a7a",
+        "terminal.ansiWhite": "#d9d9d9",
+        "terminal.ansiYellow": "#b8b87a",
+        "terminal.ansiBrightBlack": "#262626",
+        "terminal.ansiBrightBlue": "#bdbddb",
+        "terminal.ansiBrightCyan": "#bddbdb",
+        "terminal.ansiBrightGreen": "#bddbbd",
+        "terminal.ansiBrightMagenta": "#dbbddb",
+        "terminal.ansiBrightRed": "#dbbdbd",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#dbdbbd"
+    }
+}

--- a/vscode/BlulocoDark.json
+++ b/vscode/BlulocoDark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#abb2bf",
+        "terminal.background": "#1e2127",
+        "terminal.ansiBlack": "#4a505d",
+        "terminal.ansiBlue": "#285bff",
+        "terminal.ansiCyan": "#366f9a",
+        "terminal.ansiGreen": "#23974a",
+        "terminal.ansiMagenta": "#8c62fd",
+        "terminal.ansiRed": "#f81141",
+        "terminal.ansiWhite": "#ccd5e5",
+        "terminal.ansiYellow": "#fd7e57",
+        "terminal.ansiBrightBlack": "#61697a",
+        "terminal.ansiBrightBlue": "#199ffd",
+        "terminal.ansiBrightCyan": "#50acae",
+        "terminal.ansiBrightGreen": "#37bd58",
+        "terminal.ansiBrightMagenta": "#fc58f6",
+        "terminal.ansiBrightRed": "#fc4a6d",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f6be48"
+    }
+}

--- a/vscode/BlulocoLight.json
+++ b/vscode/BlulocoLight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#2a2c33",
+        "terminal.background": "#f7f7f7",
+        "terminal.ansiBlack": "#cbccd5",
+        "terminal.ansiBlue": "#1e44dd",
+        "terminal.ansiCyan": "#1f4d7a",
+        "terminal.ansiGreen": "#21883a",
+        "terminal.ansiMagenta": "#6d1bed",
+        "terminal.ansiRed": "#c90e42",
+        "terminal.ansiWhite": "#000000",
+        "terminal.ansiYellow": "#d54d17",
+        "terminal.ansiBrightBlack": "#dedfe8",
+        "terminal.ansiBrightBlue": "#1085d9",
+        "terminal.ansiBrightCyan": "#5b80ad",
+        "terminal.ansiBrightGreen": "#34b354",
+        "terminal.ansiBrightMagenta": "#c00db3",
+        "terminal.ansiBrightRed": "#fc4a6d",
+        "terminal.ansiBrightWhite": "#1d1d22",
+        "terminal.ansiBrightYellow": "#b89427"
+    }
+}

--- a/vscode/Borland.json
+++ b/vscode/Borland.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffff4e",
+        "terminal.background": "#0000a4",
+        "terminal.ansiBlack": "#4f4f4f",
+        "terminal.ansiBlue": "#96cbfe",
+        "terminal.ansiCyan": "#c6c5fe",
+        "terminal.ansiGreen": "#a8ff60",
+        "terminal.ansiMagenta": "#ff73fd",
+        "terminal.ansiRed": "#ff6c60",
+        "terminal.ansiWhite": "#eeeeee",
+        "terminal.ansiYellow": "#ffffb6",
+        "terminal.ansiBrightBlack": "#7c7c7c",
+        "terminal.ansiBrightBlue": "#b5dcff",
+        "terminal.ansiBrightCyan": "#dfdffe",
+        "terminal.ansiBrightGreen": "#ceffac",
+        "terminal.ansiBrightMagenta": "#ff9cfe",
+        "terminal.ansiBrightRed": "#ffb6b0",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffffcc"
+    }
+}

--- a/vscode/Bright Lights.json
+++ b/vscode/Bright Lights.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b3c9d7",
+        "terminal.background": "#191919",
+        "terminal.ansiBlack": "#191919",
+        "terminal.ansiBlue": "#76d4ff",
+        "terminal.ansiCyan": "#6cbfb5",
+        "terminal.ansiGreen": "#b7e876",
+        "terminal.ansiMagenta": "#ba76e7",
+        "terminal.ansiRed": "#ff355b",
+        "terminal.ansiWhite": "#c2c8d7",
+        "terminal.ansiYellow": "#ffc251",
+        "terminal.ansiBrightBlack": "#191919",
+        "terminal.ansiBrightBlue": "#76d5ff",
+        "terminal.ansiBrightCyan": "#6cbfb5",
+        "terminal.ansiBrightGreen": "#b7e876",
+        "terminal.ansiBrightMagenta": "#ba76e7",
+        "terminal.ansiBrightRed": "#ff355b",
+        "terminal.ansiBrightWhite": "#c2c8d7",
+        "terminal.ansiBrightYellow": "#ffc251"
+    }
+}

--- a/vscode/Broadcast.json
+++ b/vscode/Broadcast.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e6e1dc",
+        "terminal.background": "#2b2b2b",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#6d9cbe",
+        "terminal.ansiCyan": "#6e9cbe",
+        "terminal.ansiGreen": "#519f50",
+        "terminal.ansiMagenta": "#d0d0ff",
+        "terminal.ansiRed": "#da4939",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffd24a",
+        "terminal.ansiBrightBlack": "#323232",
+        "terminal.ansiBrightBlue": "#9fcef0",
+        "terminal.ansiBrightCyan": "#a0cef0",
+        "terminal.ansiBrightGreen": "#83d182",
+        "terminal.ansiBrightMagenta": "#ffffff",
+        "terminal.ansiBrightRed": "#ff7b6b",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff7c"
+    }
+}

--- a/vscode/Brogrammer.json
+++ b/vscode/Brogrammer.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d6dbe5",
+        "terminal.background": "#131313",
+        "terminal.ansiBlack": "#1f1f1f",
+        "terminal.ansiBlue": "#2a84d2",
+        "terminal.ansiCyan": "#1081d6",
+        "terminal.ansiGreen": "#2dc55e",
+        "terminal.ansiMagenta": "#4e5ab7",
+        "terminal.ansiRed": "#f81118",
+        "terminal.ansiWhite": "#d6dbe5",
+        "terminal.ansiYellow": "#ecba0f",
+        "terminal.ansiBrightBlack": "#d6dbe5",
+        "terminal.ansiBrightBlue": "#1081d6",
+        "terminal.ansiBrightCyan": "#0f7ddb",
+        "terminal.ansiBrightGreen": "#1dd361",
+        "terminal.ansiBrightMagenta": "#5350b9",
+        "terminal.ansiBrightRed": "#de352e",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f3bd09"
+    }
+}

--- a/vscode/Builtin Dark.json
+++ b/vscode/Builtin Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000bb",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#00bb00",
+        "terminal.ansiMagenta": "#bb00bb",
+        "terminal.ansiRed": "#bb0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#bbbb00",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Builtin Light.json
+++ b/vscode/Builtin Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000bb",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#00bb00",
+        "terminal.ansiMagenta": "#bb00bb",
+        "terminal.ansiRed": "#bb0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#bbbb00",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Builtin Pastel Dark.json
+++ b/vscode/Builtin Pastel Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#4f4f4f",
+        "terminal.ansiBlue": "#96cbfe",
+        "terminal.ansiCyan": "#c6c5fe",
+        "terminal.ansiGreen": "#a8ff60",
+        "terminal.ansiMagenta": "#ff73fd",
+        "terminal.ansiRed": "#ff6c60",
+        "terminal.ansiWhite": "#eeeeee",
+        "terminal.ansiYellow": "#ffffb6",
+        "terminal.ansiBrightBlack": "#7c7c7c",
+        "terminal.ansiBrightBlue": "#b5dcff",
+        "terminal.ansiBrightCyan": "#dfdffe",
+        "terminal.ansiBrightGreen": "#ceffac",
+        "terminal.ansiBrightMagenta": "#ff9cfe",
+        "terminal.ansiBrightRed": "#ffb6b0",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffffcc"
+    }
+}

--- a/vscode/Builtin Solarized Dark.json
+++ b/vscode/Builtin Solarized Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#839496",
+        "terminal.background": "#002b36",
+        "terminal.ansiBlack": "#073642",
+        "terminal.ansiBlue": "#268bd2",
+        "terminal.ansiCyan": "#2aa198",
+        "terminal.ansiGreen": "#859900",
+        "terminal.ansiMagenta": "#d33682",
+        "terminal.ansiRed": "#dc322f",
+        "terminal.ansiWhite": "#eee8d5",
+        "terminal.ansiYellow": "#b58900",
+        "terminal.ansiBrightBlack": "#002b36",
+        "terminal.ansiBrightBlue": "#839496",
+        "terminal.ansiBrightCyan": "#93a1a1",
+        "terminal.ansiBrightGreen": "#586e75",
+        "terminal.ansiBrightMagenta": "#6c71c4",
+        "terminal.ansiBrightRed": "#cb4b16",
+        "terminal.ansiBrightWhite": "#fdf6e3",
+        "terminal.ansiBrightYellow": "#657b83"
+    }
+}

--- a/vscode/Builtin Solarized Light.json
+++ b/vscode/Builtin Solarized Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#657b83",
+        "terminal.background": "#fdf6e3",
+        "terminal.ansiBlack": "#073642",
+        "terminal.ansiBlue": "#268bd2",
+        "terminal.ansiCyan": "#2aa198",
+        "terminal.ansiGreen": "#859900",
+        "terminal.ansiMagenta": "#d33682",
+        "terminal.ansiRed": "#dc322f",
+        "terminal.ansiWhite": "#eee8d5",
+        "terminal.ansiYellow": "#b58900",
+        "terminal.ansiBrightBlack": "#002b36",
+        "terminal.ansiBrightBlue": "#839496",
+        "terminal.ansiBrightCyan": "#93a1a1",
+        "terminal.ansiBrightGreen": "#586e75",
+        "terminal.ansiBrightMagenta": "#6c71c4",
+        "terminal.ansiBrightRed": "#cb4b16",
+        "terminal.ansiBrightWhite": "#fdf6e3",
+        "terminal.ansiBrightYellow": "#657b83"
+    }
+}

--- a/vscode/Builtin Tango Dark.json
+++ b/vscode/Builtin Tango Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#3465a4",
+        "terminal.ansiCyan": "#06989a",
+        "terminal.ansiGreen": "#4e9a06",
+        "terminal.ansiMagenta": "#75507b",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#d3d7cf",
+        "terminal.ansiYellow": "#c4a000",
+        "terminal.ansiBrightBlack": "#555753",
+        "terminal.ansiBrightBlue": "#729fcf",
+        "terminal.ansiBrightCyan": "#34e2e2",
+        "terminal.ansiBrightGreen": "#8ae234",
+        "terminal.ansiBrightMagenta": "#ad7fa8",
+        "terminal.ansiBrightRed": "#ef2929",
+        "terminal.ansiBrightWhite": "#eeeeec",
+        "terminal.ansiBrightYellow": "#fce94f"
+    }
+}

--- a/vscode/Builtin Tango Light.json
+++ b/vscode/Builtin Tango Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#3465a4",
+        "terminal.ansiCyan": "#06989a",
+        "terminal.ansiGreen": "#4e9a06",
+        "terminal.ansiMagenta": "#75507b",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#d3d7cf",
+        "terminal.ansiYellow": "#c4a000",
+        "terminal.ansiBrightBlack": "#555753",
+        "terminal.ansiBrightBlue": "#729fcf",
+        "terminal.ansiBrightCyan": "#34e2e2",
+        "terminal.ansiBrightGreen": "#8ae234",
+        "terminal.ansiBrightMagenta": "#ad7fa8",
+        "terminal.ansiBrightRed": "#ef2929",
+        "terminal.ansiBrightWhite": "#eeeeec",
+        "terminal.ansiBrightYellow": "#fce94f"
+    }
+}

--- a/vscode/C64.json
+++ b/vscode/C64.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#7869c4",
+        "terminal.background": "#40318d",
+        "terminal.ansiBlack": "#090300",
+        "terminal.ansiBlue": "#40318d",
+        "terminal.ansiCyan": "#67b6bd",
+        "terminal.ansiGreen": "#55a049",
+        "terminal.ansiMagenta": "#8b3f96",
+        "terminal.ansiRed": "#883932",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#bfce72",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#40318d",
+        "terminal.ansiBrightCyan": "#67b6bd",
+        "terminal.ansiBrightGreen": "#55a049",
+        "terminal.ansiBrightMagenta": "#8b3f96",
+        "terminal.ansiBrightRed": "#883932",
+        "terminal.ansiBrightWhite": "#f7f7f7",
+        "terminal.ansiBrightYellow": "#bfce72"
+    }
+}

--- a/vscode/CLRS.json
+++ b/vscode/CLRS.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#262626",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#135cd0",
+        "terminal.ansiCyan": "#33c3c1",
+        "terminal.ansiGreen": "#328a5d",
+        "terminal.ansiMagenta": "#9f00bd",
+        "terminal.ansiRed": "#f8282a",
+        "terminal.ansiWhite": "#b3b3b3",
+        "terminal.ansiYellow": "#fa701d",
+        "terminal.ansiBrightBlack": "#555753",
+        "terminal.ansiBrightBlue": "#1670ff",
+        "terminal.ansiBrightCyan": "#3ad5ce",
+        "terminal.ansiBrightGreen": "#2cc631",
+        "terminal.ansiBrightMagenta": "#e900b0",
+        "terminal.ansiBrightRed": "#fb0416",
+        "terminal.ansiBrightWhite": "#eeeeec",
+        "terminal.ansiBrightYellow": "#fdd727"
+    }
+}

--- a/vscode/Calamity.json
+++ b/vscode/Calamity.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d5ced9",
+        "terminal.background": "#2f2833",
+        "terminal.ansiBlack": "#2f2833",
+        "terminal.ansiBlue": "#3b79c7",
+        "terminal.ansiCyan": "#74d3de",
+        "terminal.ansiGreen": "#a5f69c",
+        "terminal.ansiMagenta": "#f92672",
+        "terminal.ansiRed": "#fc644d",
+        "terminal.ansiWhite": "#d5ced9",
+        "terminal.ansiYellow": "#e9d7a5",
+        "terminal.ansiBrightBlack": "#7e6c88",
+        "terminal.ansiBrightBlue": "#3b79c7",
+        "terminal.ansiBrightCyan": "#74d3de",
+        "terminal.ansiBrightGreen": "#a5f69c",
+        "terminal.ansiBrightMagenta": "#f92672",
+        "terminal.ansiBrightRed": "#fc644d",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e9d7a5"
+    }
+}

--- a/vscode/Chalk.json
+++ b/vscode/Chalk.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d2d8d9",
+        "terminal.background": "#2b2d2e",
+        "terminal.ansiBlack": "#7d8b8f",
+        "terminal.ansiBlue": "#2a7fac",
+        "terminal.ansiCyan": "#44a799",
+        "terminal.ansiGreen": "#789b6a",
+        "terminal.ansiMagenta": "#bd4f5a",
+        "terminal.ansiRed": "#b23a52",
+        "terminal.ansiWhite": "#d2d8d9",
+        "terminal.ansiYellow": "#b9ac4a",
+        "terminal.ansiBrightBlack": "#888888",
+        "terminal.ansiBrightBlue": "#4196ff",
+        "terminal.ansiBrightCyan": "#53cdbd",
+        "terminal.ansiBrightGreen": "#80c470",
+        "terminal.ansiBrightMagenta": "#fc5275",
+        "terminal.ansiBrightRed": "#f24840",
+        "terminal.ansiBrightWhite": "#d2d8d9",
+        "terminal.ansiBrightYellow": "#ffeb62"
+    }
+}

--- a/vscode/Chalkboard.json
+++ b/vscode/Chalkboard.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d9e6f2",
+        "terminal.background": "#29262f",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#7372c3",
+        "terminal.ansiCyan": "#72c2c3",
+        "terminal.ansiGreen": "#72c373",
+        "terminal.ansiMagenta": "#c372c2",
+        "terminal.ansiRed": "#c37372",
+        "terminal.ansiWhite": "#d9d9d9",
+        "terminal.ansiYellow": "#c2c372",
+        "terminal.ansiBrightBlack": "#323232",
+        "terminal.ansiBrightBlue": "#aaaadb",
+        "terminal.ansiBrightCyan": "#aadadb",
+        "terminal.ansiBrightGreen": "#aadbaa",
+        "terminal.ansiBrightMagenta": "#dbaada",
+        "terminal.ansiBrightRed": "#dbaaaa",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#dadbaa"
+    }
+}

--- a/vscode/ChallengerDeep.json
+++ b/vscode/ChallengerDeep.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cbe1e7",
+        "terminal.background": "#1e1c31",
+        "terminal.ansiBlack": "#141228",
+        "terminal.ansiBlue": "#65b2ff",
+        "terminal.ansiCyan": "#63f2f1",
+        "terminal.ansiGreen": "#62d196",
+        "terminal.ansiMagenta": "#906cff",
+        "terminal.ansiRed": "#ff5458",
+        "terminal.ansiWhite": "#a6b3cc",
+        "terminal.ansiYellow": "#ffb378",
+        "terminal.ansiBrightBlack": "#565575",
+        "terminal.ansiBrightBlue": "#91ddff",
+        "terminal.ansiBrightCyan": "#aaffe4",
+        "terminal.ansiBrightGreen": "#95ffa4",
+        "terminal.ansiBrightMagenta": "#c991e1",
+        "terminal.ansiBrightRed": "#ff8080",
+        "terminal.ansiBrightWhite": "#cbe3e7",
+        "terminal.ansiBrightYellow": "#ffe9aa"
+    }
+}

--- a/vscode/Chester.json
+++ b/vscode/Chester.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#2c3643",
+        "terminal.ansiBlack": "#080200",
+        "terminal.ansiBlue": "#288ad6",
+        "terminal.ansiCyan": "#28ddde",
+        "terminal.ansiGreen": "#16c98d",
+        "terminal.ansiMagenta": "#d34590",
+        "terminal.ansiRed": "#fa5e5b",
+        "terminal.ansiWhite": "#e7e7e7",
+        "terminal.ansiYellow": "#ffc83f",
+        "terminal.ansiBrightBlack": "#6f6b68",
+        "terminal.ansiBrightBlue": "#278ad6",
+        "terminal.ansiBrightCyan": "#27dede",
+        "terminal.ansiBrightGreen": "#16c98d",
+        "terminal.ansiBrightMagenta": "#d34590",
+        "terminal.ansiBrightRed": "#fa5e5b",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#feef6d"
+    }
+}

--- a/vscode/Ciapre.json
+++ b/vscode/Ciapre.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#aea47a",
+        "terminal.background": "#191c27",
+        "terminal.ansiBlack": "#181818",
+        "terminal.ansiBlue": "#576d8c",
+        "terminal.ansiCyan": "#5c4f4b",
+        "terminal.ansiGreen": "#48513b",
+        "terminal.ansiMagenta": "#724d7c",
+        "terminal.ansiRed": "#810009",
+        "terminal.ansiWhite": "#aea47f",
+        "terminal.ansiYellow": "#cc8b3f",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#3097c6",
+        "terminal.ansiBrightCyan": "#f3dbb2",
+        "terminal.ansiBrightGreen": "#a6a75d",
+        "terminal.ansiBrightMagenta": "#d33061",
+        "terminal.ansiBrightRed": "#ac3835",
+        "terminal.ansiBrightWhite": "#f4f4f4",
+        "terminal.ansiBrightYellow": "#dcdf7c"
+    }
+}

--- a/vscode/Cobalt Neon.json
+++ b/vscode/Cobalt Neon.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#8ff586",
+        "terminal.background": "#142838",
+        "terminal.ansiBlack": "#142631",
+        "terminal.ansiBlue": "#8ff586",
+        "terminal.ansiCyan": "#8ff586",
+        "terminal.ansiGreen": "#3ba5ff",
+        "terminal.ansiMagenta": "#781aa0",
+        "terminal.ansiRed": "#ff2320",
+        "terminal.ansiWhite": "#ba46b2",
+        "terminal.ansiYellow": "#e9e75c",
+        "terminal.ansiBrightBlack": "#fff688",
+        "terminal.ansiBrightBlue": "#3c7dd2",
+        "terminal.ansiBrightCyan": "#6cbc67",
+        "terminal.ansiBrightGreen": "#8ff586",
+        "terminal.ansiBrightMagenta": "#8230a7",
+        "terminal.ansiBrightRed": "#d4312e",
+        "terminal.ansiBrightWhite": "#8ff586",
+        "terminal.ansiBrightYellow": "#e9f06d"
+    }
+}

--- a/vscode/Cobalt2.json
+++ b/vscode/Cobalt2.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#132738",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#1460d2",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#38de21",
+        "terminal.ansiMagenta": "#ff005d",
+        "terminal.ansiRed": "#ff0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#ffe50a",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#6ae3fa",
+        "terminal.ansiBrightGreen": "#3bd01d",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#f40e17",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#edc809"
+    }
+}

--- a/vscode/CrayonPonyFish.json
+++ b/vscode/CrayonPonyFish.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#68525a",
+        "terminal.background": "#150707",
+        "terminal.ansiBlack": "#2b1b1d",
+        "terminal.ansiBlue": "#8c87b0",
+        "terminal.ansiCyan": "#e8a866",
+        "terminal.ansiGreen": "#579524",
+        "terminal.ansiMagenta": "#692f50",
+        "terminal.ansiRed": "#91002b",
+        "terminal.ansiWhite": "#68525a",
+        "terminal.ansiYellow": "#ab311b",
+        "terminal.ansiBrightBlack": "#3d2b2e",
+        "terminal.ansiBrightBlue": "#cfc9ff",
+        "terminal.ansiBrightCyan": "#ffceaf",
+        "terminal.ansiBrightGreen": "#8dff57",
+        "terminal.ansiBrightMagenta": "#fc6cba",
+        "terminal.ansiBrightRed": "#c5255d",
+        "terminal.ansiBrightWhite": "#b0949d",
+        "terminal.ansiBrightYellow": "#c8381d"
+    }
+}

--- a/vscode/Dark Pastel.json
+++ b/vscode/Dark Pastel.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#5555ff",
+        "terminal.ansiCyan": "#55ffff",
+        "terminal.ansiGreen": "#55ff55",
+        "terminal.ansiMagenta": "#ff55ff",
+        "terminal.ansiRed": "#ff5555",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#ffff55",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Dark+.json
+++ b/vscode/Dark+.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cccccc",
+        "terminal.background": "#0e0e0e",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2472c8",
+        "terminal.ansiCyan": "#11a8cd",
+        "terminal.ansiGreen": "#0dbc79",
+        "terminal.ansiMagenta": "#bc3fbc",
+        "terminal.ansiRed": "#cd3131",
+        "terminal.ansiWhite": "#e5e5e5",
+        "terminal.ansiYellow": "#e5e510",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#3b8eea",
+        "terminal.ansiBrightCyan": "#29b8db",
+        "terminal.ansiBrightGreen": "#23d18b",
+        "terminal.ansiBrightMagenta": "#d670d6",
+        "terminal.ansiBrightRed": "#f14c4c",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#f5f543"
+    }
+}

--- a/vscode/Darkside.json
+++ b/vscode/Darkside.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bababa",
+        "terminal.background": "#222324",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#1c98e8",
+        "terminal.ansiCyan": "#1c98e8",
+        "terminal.ansiGreen": "#68c256",
+        "terminal.ansiMagenta": "#8e69c9",
+        "terminal.ansiRed": "#e8341c",
+        "terminal.ansiWhite": "#bababa",
+        "terminal.ansiYellow": "#f2d42c",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#387cd3",
+        "terminal.ansiBrightCyan": "#3d97e2",
+        "terminal.ansiBrightGreen": "#77b869",
+        "terminal.ansiBrightMagenta": "#957bbe",
+        "terminal.ansiBrightRed": "#e05a4f",
+        "terminal.ansiBrightWhite": "#bababa",
+        "terminal.ansiBrightYellow": "#efd64b"
+    }
+}

--- a/vscode/Desert.json
+++ b/vscode/Desert.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#333333",
+        "terminal.ansiBlack": "#4d4d4d",
+        "terminal.ansiBlue": "#cd853f",
+        "terminal.ansiCyan": "#ffa0a0",
+        "terminal.ansiGreen": "#98fb98",
+        "terminal.ansiMagenta": "#ffdead",
+        "terminal.ansiRed": "#ff2b2b",
+        "terminal.ansiWhite": "#f5deb3",
+        "terminal.ansiYellow": "#f0e68c",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#87ceff",
+        "terminal.ansiBrightCyan": "#ffd700",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/DimmedMonokai.json
+++ b/vscode/DimmedMonokai.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b9bcba",
+        "terminal.background": "#1f1f1f",
+        "terminal.ansiBlack": "#3a3d43",
+        "terminal.ansiBlue": "#4f76a1",
+        "terminal.ansiCyan": "#578fa4",
+        "terminal.ansiGreen": "#879a3b",
+        "terminal.ansiMagenta": "#855c8d",
+        "terminal.ansiRed": "#be3f48",
+        "terminal.ansiWhite": "#b9bcba",
+        "terminal.ansiYellow": "#c5a635",
+        "terminal.ansiBrightBlack": "#888987",
+        "terminal.ansiBrightBlue": "#186de3",
+        "terminal.ansiBrightCyan": "#2e706d",
+        "terminal.ansiBrightGreen": "#0f722f",
+        "terminal.ansiBrightMagenta": "#fb0067",
+        "terminal.ansiBrightRed": "#fb001f",
+        "terminal.ansiBrightWhite": "#fdffb9",
+        "terminal.ansiBrightYellow": "#c47033"
+    }
+}

--- a/vscode/DotGov.json
+++ b/vscode/DotGov.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ebebeb",
+        "terminal.background": "#262c35",
+        "terminal.ansiBlack": "#191919",
+        "terminal.ansiBlue": "#17b2e0",
+        "terminal.ansiCyan": "#8bd2ed",
+        "terminal.ansiGreen": "#3d9751",
+        "terminal.ansiMagenta": "#7830b0",
+        "terminal.ansiRed": "#bf091d",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f6bb34",
+        "terminal.ansiBrightBlack": "#191919",
+        "terminal.ansiBrightBlue": "#17b2e0",
+        "terminal.ansiBrightCyan": "#8bd2ed",
+        "terminal.ansiBrightGreen": "#3d9751",
+        "terminal.ansiBrightMagenta": "#7830b0",
+        "terminal.ansiBrightRed": "#bf091d",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f6bb34"
+    }
+}

--- a/vscode/Dracula.json
+++ b/vscode/Dracula.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f8f8f2",
+        "terminal.background": "#1e1f29",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#bd93f9",
+        "terminal.ansiCyan": "#8be9fd",
+        "terminal.ansiGreen": "#50fa7b",
+        "terminal.ansiMagenta": "#ff79c6",
+        "terminal.ansiRed": "#ff5555",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#f1fa8c",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#bd93f9",
+        "terminal.ansiBrightCyan": "#8be9fd",
+        "terminal.ansiBrightGreen": "#50fa7b",
+        "terminal.ansiBrightMagenta": "#ff79c6",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f1fa8c"
+    }
+}

--- a/vscode/Duotone Dark.json
+++ b/vscode/Duotone Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b7a1ff",
+        "terminal.background": "#1f1d27",
+        "terminal.ansiBlack": "#1f1d27",
+        "terminal.ansiBlue": "#ffc284",
+        "terminal.ansiCyan": "#2488ff",
+        "terminal.ansiGreen": "#2dcd73",
+        "terminal.ansiMagenta": "#de8d40",
+        "terminal.ansiRed": "#d9393e",
+        "terminal.ansiWhite": "#b7a1ff",
+        "terminal.ansiYellow": "#d9b76e",
+        "terminal.ansiBrightBlack": "#353147",
+        "terminal.ansiBrightBlue": "#ffc284",
+        "terminal.ansiBrightCyan": "#2488ff",
+        "terminal.ansiBrightGreen": "#2dcd73",
+        "terminal.ansiBrightMagenta": "#de8d40",
+        "terminal.ansiBrightRed": "#d9393e",
+        "terminal.ansiBrightWhite": "#eae5ff",
+        "terminal.ansiBrightYellow": "#d9b76e"
+    }
+}

--- a/vscode/ENCOM.json
+++ b/vscode/ENCOM.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#00a595",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0081ff",
+        "terminal.ansiCyan": "#008b8b",
+        "terminal.ansiGreen": "#008b00",
+        "terminal.ansiMagenta": "#bc00ca",
+        "terminal.ansiRed": "#9f0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#ffd000",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00cdcd",
+        "terminal.ansiBrightGreen": "#00ee00",
+        "terminal.ansiBrightMagenta": "#ff00ff",
+        "terminal.ansiBrightRed": "#ff0000",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff00"
+    }
+}

--- a/vscode/Earthsong.json
+++ b/vscode/Earthsong.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e5c7a9",
+        "terminal.background": "#292520",
+        "terminal.ansiBlack": "#121418",
+        "terminal.ansiBlue": "#1398b9",
+        "terminal.ansiCyan": "#509552",
+        "terminal.ansiGreen": "#85c54c",
+        "terminal.ansiMagenta": "#d0633d",
+        "terminal.ansiRed": "#c94234",
+        "terminal.ansiWhite": "#e5c6aa",
+        "terminal.ansiYellow": "#f5ae2e",
+        "terminal.ansiBrightBlack": "#675f54",
+        "terminal.ansiBrightBlue": "#5fdaff",
+        "terminal.ansiBrightCyan": "#84f088",
+        "terminal.ansiBrightGreen": "#98e036",
+        "terminal.ansiBrightMagenta": "#ff9269",
+        "terminal.ansiBrightRed": "#ff645a",
+        "terminal.ansiBrightWhite": "#f6f7ec",
+        "terminal.ansiBrightYellow": "#e0d561"
+    }
+}

--- a/vscode/Elemental.json
+++ b/vscode/Elemental.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#807a74",
+        "terminal.background": "#22211d",
+        "terminal.ansiBlack": "#3c3c30",
+        "terminal.ansiBlue": "#497f7d",
+        "terminal.ansiCyan": "#387f58",
+        "terminal.ansiGreen": "#479a43",
+        "terminal.ansiMagenta": "#7f4e2f",
+        "terminal.ansiRed": "#98290f",
+        "terminal.ansiWhite": "#807974",
+        "terminal.ansiYellow": "#7f7111",
+        "terminal.ansiBrightBlack": "#555445",
+        "terminal.ansiBrightBlue": "#79d9d9",
+        "terminal.ansiBrightCyan": "#59d599",
+        "terminal.ansiBrightGreen": "#61e070",
+        "terminal.ansiBrightMagenta": "#cd7c54",
+        "terminal.ansiBrightRed": "#e0502a",
+        "terminal.ansiBrightWhite": "#fff1e9",
+        "terminal.ansiBrightYellow": "#d69927"
+    }
+}

--- a/vscode/Elementary.json
+++ b/vscode/Elementary.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#efefef",
+        "terminal.background": "#181818",
+        "terminal.ansiBlack": "#242424",
+        "terminal.ansiBlue": "#063b8c",
+        "terminal.ansiCyan": "#2595e1",
+        "terminal.ansiGreen": "#5aa513",
+        "terminal.ansiMagenta": "#e40038",
+        "terminal.ansiRed": "#d71c15",
+        "terminal.ansiWhite": "#efefef",
+        "terminal.ansiYellow": "#fdb40c",
+        "terminal.ansiBrightBlack": "#4b4b4b",
+        "terminal.ansiBrightBlue": "#0955ff",
+        "terminal.ansiBrightCyan": "#3ea8fc",
+        "terminal.ansiBrightGreen": "#6bc219",
+        "terminal.ansiBrightMagenta": "#fb0050",
+        "terminal.ansiBrightRed": "#fc1c18",
+        "terminal.ansiBrightWhite": "#8c00ec",
+        "terminal.ansiBrightYellow": "#fec80e"
+    }
+}

--- a/vscode/Espresso Libre.json
+++ b/vscode/Espresso Libre.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b8a898",
+        "terminal.background": "#2a211c",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0066ff",
+        "terminal.ansiCyan": "#06989a",
+        "terminal.ansiGreen": "#1a921c",
+        "terminal.ansiMagenta": "#c5656b",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#d3d7cf",
+        "terminal.ansiYellow": "#f0e53a",
+        "terminal.ansiBrightBlack": "#555753",
+        "terminal.ansiBrightBlue": "#43a8ed",
+        "terminal.ansiBrightCyan": "#34e2e2",
+        "terminal.ansiBrightGreen": "#9aff87",
+        "terminal.ansiBrightMagenta": "#ff818a",
+        "terminal.ansiBrightRed": "#ef2929",
+        "terminal.ansiBrightWhite": "#eeeeec",
+        "terminal.ansiBrightYellow": "#fffb5c"
+    }
+}

--- a/vscode/Espresso.json
+++ b/vscode/Espresso.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#323232",
+        "terminal.ansiBlack": "#353535",
+        "terminal.ansiBlue": "#6c99bb",
+        "terminal.ansiCyan": "#bed6ff",
+        "terminal.ansiGreen": "#a5c261",
+        "terminal.ansiMagenta": "#d197d9",
+        "terminal.ansiRed": "#d25252",
+        "terminal.ansiWhite": "#eeeeec",
+        "terminal.ansiYellow": "#ffc66d",
+        "terminal.ansiBrightBlack": "#535353",
+        "terminal.ansiBrightBlue": "#8ab7d9",
+        "terminal.ansiBrightCyan": "#dcf4ff",
+        "terminal.ansiBrightGreen": "#c2e075",
+        "terminal.ansiBrightMagenta": "#efb5f7",
+        "terminal.ansiBrightRed": "#f00c0c",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e1e48b"
+    }
+}

--- a/vscode/Fahrenheit.json
+++ b/vscode/Fahrenheit.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffce",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#1d1d1d",
+        "terminal.ansiBlue": "#720102",
+        "terminal.ansiCyan": "#979797",
+        "terminal.ansiGreen": "#9e744d",
+        "terminal.ansiMagenta": "#734c4d",
+        "terminal.ansiRed": "#cda074",
+        "terminal.ansiWhite": "#ffffce",
+        "terminal.ansiYellow": "#fecf75",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#cb4a05",
+        "terminal.ansiBrightCyan": "#fed04d",
+        "terminal.ansiBrightGreen": "#cc734d",
+        "terminal.ansiBrightMagenta": "#4e739f",
+        "terminal.ansiBrightRed": "#fecea0",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fd9f4d"
+    }
+}

--- a/vscode/Fideloper.json
+++ b/vscode/Fideloper.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dbdae0",
+        "terminal.background": "#292f33",
+        "terminal.ansiBlack": "#292f33",
+        "terminal.ansiBlue": "#2e78c2",
+        "terminal.ansiCyan": "#309186",
+        "terminal.ansiGreen": "#edb8ac",
+        "terminal.ansiMagenta": "#c0236f",
+        "terminal.ansiRed": "#cb1e2d",
+        "terminal.ansiWhite": "#eae3ce",
+        "terminal.ansiYellow": "#b7ab9b",
+        "terminal.ansiBrightBlack": "#092028",
+        "terminal.ansiBrightBlue": "#7c85c4",
+        "terminal.ansiBrightCyan": "#819090",
+        "terminal.ansiBrightGreen": "#d4605a",
+        "terminal.ansiBrightMagenta": "#5c5db2",
+        "terminal.ansiBrightRed": "#d4605a",
+        "terminal.ansiBrightWhite": "#fcf4df",
+        "terminal.ansiBrightYellow": "#a86671"
+    }
+}

--- a/vscode/FirefoxDev.json
+++ b/vscode/FirefoxDev.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#7c8fa4",
+        "terminal.background": "#0e1011",
+        "terminal.ansiBlack": "#002831",
+        "terminal.ansiBlue": "#359ddf",
+        "terminal.ansiCyan": "#4b73a2",
+        "terminal.ansiGreen": "#5eb83c",
+        "terminal.ansiMagenta": "#d75cff",
+        "terminal.ansiRed": "#e63853",
+        "terminal.ansiWhite": "#dcdcdc",
+        "terminal.ansiYellow": "#a57706",
+        "terminal.ansiBrightBlack": "#001e27",
+        "terminal.ansiBrightBlue": "#006fc0",
+        "terminal.ansiBrightCyan": "#005794",
+        "terminal.ansiBrightGreen": "#1d9000",
+        "terminal.ansiBrightMagenta": "#a200da",
+        "terminal.ansiBrightRed": "#e1003f",
+        "terminal.ansiBrightWhite": "#e2e2e2",
+        "terminal.ansiBrightYellow": "#cd9409"
+    }
+}

--- a/vscode/Firewatch.json
+++ b/vscode/Firewatch.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#9ba2b2",
+        "terminal.background": "#1e2027",
+        "terminal.ansiBlack": "#585f6d",
+        "terminal.ansiBlue": "#4d89c4",
+        "terminal.ansiCyan": "#44a8b6",
+        "terminal.ansiGreen": "#5ab977",
+        "terminal.ansiMagenta": "#d55119",
+        "terminal.ansiRed": "#d95360",
+        "terminal.ansiWhite": "#e6e5ff",
+        "terminal.ansiYellow": "#dfb563",
+        "terminal.ansiBrightBlack": "#585f6d",
+        "terminal.ansiBrightBlue": "#4c89c5",
+        "terminal.ansiBrightCyan": "#44a8b6",
+        "terminal.ansiBrightGreen": "#5ab977",
+        "terminal.ansiBrightMagenta": "#d55119",
+        "terminal.ansiBrightRed": "#d95360",
+        "terminal.ansiBrightWhite": "#e6e5ff",
+        "terminal.ansiBrightYellow": "#dfb563"
+    }
+}

--- a/vscode/FishTank.json
+++ b/vscode/FishTank.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ecf0fe",
+        "terminal.background": "#232537",
+        "terminal.ansiBlack": "#03073c",
+        "terminal.ansiBlue": "#525fb8",
+        "terminal.ansiCyan": "#968763",
+        "terminal.ansiGreen": "#acf157",
+        "terminal.ansiMagenta": "#986f82",
+        "terminal.ansiRed": "#c6004a",
+        "terminal.ansiWhite": "#ecf0fc",
+        "terminal.ansiYellow": "#fecd5e",
+        "terminal.ansiBrightBlack": "#6c5b30",
+        "terminal.ansiBrightBlue": "#b2befa",
+        "terminal.ansiBrightCyan": "#a5bd86",
+        "terminal.ansiBrightGreen": "#dbffa9",
+        "terminal.ansiBrightMagenta": "#fda5cd",
+        "terminal.ansiBrightRed": "#da4b8a",
+        "terminal.ansiBrightWhite": "#f6ffec",
+        "terminal.ansiBrightYellow": "#fee6a9"
+    }
+}

--- a/vscode/Flat.json
+++ b/vscode/Flat.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#2cc55d",
+        "terminal.background": "#002240",
+        "terminal.ansiBlack": "#222d3f",
+        "terminal.ansiBlue": "#3167ac",
+        "terminal.ansiCyan": "#2c9370",
+        "terminal.ansiGreen": "#32a548",
+        "terminal.ansiMagenta": "#781aa0",
+        "terminal.ansiRed": "#a82320",
+        "terminal.ansiWhite": "#b0b6ba",
+        "terminal.ansiYellow": "#e58d11",
+        "terminal.ansiBrightBlack": "#212c3c",
+        "terminal.ansiBrightBlue": "#3c7dd2",
+        "terminal.ansiBrightCyan": "#35b387",
+        "terminal.ansiBrightGreen": "#2d9440",
+        "terminal.ansiBrightMagenta": "#8230a7",
+        "terminal.ansiBrightRed": "#d4312e",
+        "terminal.ansiBrightWhite": "#e7eced",
+        "terminal.ansiBrightYellow": "#e5be0c"
+    }
+}

--- a/vscode/Flatland.json
+++ b/vscode/Flatland.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b8dbef",
+        "terminal.background": "#1d1f21",
+        "terminal.ansiBlack": "#1d1d19",
+        "terminal.ansiBlue": "#5096be",
+        "terminal.ansiCyan": "#d63865",
+        "terminal.ansiGreen": "#9fd364",
+        "terminal.ansiMagenta": "#695abc",
+        "terminal.ansiRed": "#f18339",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f4ef6d",
+        "terminal.ansiBrightBlack": "#1d1d19",
+        "terminal.ansiBrightBlue": "#61b9d0",
+        "terminal.ansiBrightCyan": "#d63865",
+        "terminal.ansiBrightGreen": "#a7d42c",
+        "terminal.ansiBrightMagenta": "#695abc",
+        "terminal.ansiBrightRed": "#d22a24",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ff8949"
+    }
+}

--- a/vscode/Floraverse.json
+++ b/vscode/Floraverse.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dbd1b9",
+        "terminal.background": "#0e0d15",
+        "terminal.ansiBlack": "#08002e",
+        "terminal.ansiBlue": "#1d6da1",
+        "terminal.ansiCyan": "#42a38c",
+        "terminal.ansiGreen": "#5d731a",
+        "terminal.ansiMagenta": "#b7077e",
+        "terminal.ansiRed": "#64002c",
+        "terminal.ansiWhite": "#f3e0b8",
+        "terminal.ansiYellow": "#cd751c",
+        "terminal.ansiBrightBlack": "#331e4d",
+        "terminal.ansiBrightBlue": "#40a4cf",
+        "terminal.ansiBrightCyan": "#62caa8",
+        "terminal.ansiBrightGreen": "#b4ce59",
+        "terminal.ansiBrightMagenta": "#f12aae",
+        "terminal.ansiBrightRed": "#d02063",
+        "terminal.ansiBrightWhite": "#fff5db",
+        "terminal.ansiBrightYellow": "#fac357"
+    }
+}

--- a/vscode/ForestBlue.json
+++ b/vscode/ForestBlue.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e2d8cd",
+        "terminal.background": "#051519",
+        "terminal.ansiBlack": "#333333",
+        "terminal.ansiBlue": "#8ed0ce",
+        "terminal.ansiCyan": "#31658c",
+        "terminal.ansiGreen": "#92d3a2",
+        "terminal.ansiMagenta": "#5e468c",
+        "terminal.ansiRed": "#f8818e",
+        "terminal.ansiWhite": "#e2d8cd",
+        "terminal.ansiYellow": "#1a8e63",
+        "terminal.ansiBrightBlack": "#3d3d3d",
+        "terminal.ansiBrightBlue": "#39a7a2",
+        "terminal.ansiBrightCyan": "#6096bf",
+        "terminal.ansiBrightGreen": "#6bb48d",
+        "terminal.ansiBrightMagenta": "#7e62b3",
+        "terminal.ansiBrightRed": "#fb3d66",
+        "terminal.ansiBrightWhite": "#e2d8cd",
+        "terminal.ansiBrightYellow": "#30c85a"
+    }
+}

--- a/vscode/Framer.json
+++ b/vscode/Framer.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#777777",
+        "terminal.background": "#111111",
+        "terminal.ansiBlack": "#141414",
+        "terminal.ansiBlue": "#00aaff",
+        "terminal.ansiCyan": "#88ddff",
+        "terminal.ansiGreen": "#98ec65",
+        "terminal.ansiMagenta": "#aa88ff",
+        "terminal.ansiRed": "#ff5555",
+        "terminal.ansiWhite": "#cccccc",
+        "terminal.ansiYellow": "#ffcc33",
+        "terminal.ansiBrightBlack": "#414141",
+        "terminal.ansiBrightBlue": "#33bbff",
+        "terminal.ansiBrightCyan": "#bbecff",
+        "terminal.ansiBrightGreen": "#b6f292",
+        "terminal.ansiBrightMagenta": "#cebbff",
+        "terminal.ansiBrightRed": "#ff8888",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffd966"
+    }
+}

--- a/vscode/FrontEndDelight.json
+++ b/vscode/FrontEndDelight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#adadad",
+        "terminal.background": "#1b1c1d",
+        "terminal.ansiBlack": "#242526",
+        "terminal.ansiBlue": "#2c70b7",
+        "terminal.ansiCyan": "#3ca1a6",
+        "terminal.ansiGreen": "#565747",
+        "terminal.ansiMagenta": "#f02e4f",
+        "terminal.ansiRed": "#f8511b",
+        "terminal.ansiWhite": "#adadad",
+        "terminal.ansiYellow": "#fa771d",
+        "terminal.ansiBrightBlack": "#5fac6d",
+        "terminal.ansiBrightBlue": "#3393ca",
+        "terminal.ansiBrightCyan": "#4fbce6",
+        "terminal.ansiBrightGreen": "#74ec4c",
+        "terminal.ansiBrightMagenta": "#e75e4f",
+        "terminal.ansiBrightRed": "#f74319",
+        "terminal.ansiBrightWhite": "#8c735b",
+        "terminal.ansiBrightYellow": "#fdc325"
+    }
+}

--- a/vscode/FunForrest.json
+++ b/vscode/FunForrest.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dec165",
+        "terminal.background": "#251200",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#4699a3",
+        "terminal.ansiCyan": "#da8213",
+        "terminal.ansiGreen": "#919c00",
+        "terminal.ansiMagenta": "#8d4331",
+        "terminal.ansiRed": "#d6262b",
+        "terminal.ansiWhite": "#ddc265",
+        "terminal.ansiYellow": "#be8a13",
+        "terminal.ansiBrightBlack": "#7f6a55",
+        "terminal.ansiBrightBlue": "#7cc9cf",
+        "terminal.ansiBrightCyan": "#e6a96b",
+        "terminal.ansiBrightGreen": "#bfc65a",
+        "terminal.ansiBrightMagenta": "#d26349",
+        "terminal.ansiBrightRed": "#e55a1c",
+        "terminal.ansiBrightWhite": "#ffeaa3",
+        "terminal.ansiBrightYellow": "#ffcb1b"
+    }
+}

--- a/vscode/Galaxy.json
+++ b/vscode/Galaxy.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#1d2837",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#589df6",
+        "terminal.ansiCyan": "#1f9ee7",
+        "terminal.ansiGreen": "#21b089",
+        "terminal.ansiMagenta": "#944d95",
+        "terminal.ansiRed": "#f9555f",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#fef02a",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#589df6",
+        "terminal.ansiBrightCyan": "#3979bc",
+        "terminal.ansiBrightGreen": "#35bb9a",
+        "terminal.ansiBrightMagenta": "#e75699",
+        "terminal.ansiBrightRed": "#fa8c8f",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Github.json
+++ b/vscode/Github.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#3e3e3e",
+        "terminal.background": "#f4f4f4",
+        "terminal.ansiBlack": "#3e3e3e",
+        "terminal.ansiBlue": "#003e8a",
+        "terminal.ansiCyan": "#89d1ec",
+        "terminal.ansiGreen": "#07962a",
+        "terminal.ansiMagenta": "#e94691",
+        "terminal.ansiRed": "#970b16",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f8eec7",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#2e6cba",
+        "terminal.ansiBrightCyan": "#1cfafe",
+        "terminal.ansiBrightGreen": "#87d5a2",
+        "terminal.ansiBrightMagenta": "#ffa29f",
+        "terminal.ansiBrightRed": "#de0000",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f1d007"
+    }
+}

--- a/vscode/Glacier.json
+++ b/vscode/Glacier.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#0c1115",
+        "terminal.ansiBlack": "#2e343c",
+        "terminal.ansiBlue": "#1f5872",
+        "terminal.ansiCyan": "#778397",
+        "terminal.ansiGreen": "#35a770",
+        "terminal.ansiMagenta": "#bd2523",
+        "terminal.ansiRed": "#bd0f2f",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fb9435",
+        "terminal.ansiBrightBlack": "#404a55",
+        "terminal.ansiBrightBlue": "#2a8bc1",
+        "terminal.ansiBrightCyan": "#a0b6d3",
+        "terminal.ansiBrightGreen": "#49e998",
+        "terminal.ansiBrightMagenta": "#ea4727",
+        "terminal.ansiBrightRed": "#bd0f2f",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fddf6e"
+    }
+}

--- a/vscode/Grape.json
+++ b/vscode/Grape.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#9f9fa1",
+        "terminal.background": "#171423",
+        "terminal.ansiBlack": "#2d283f",
+        "terminal.ansiBlue": "#487df4",
+        "terminal.ansiCyan": "#3bdeed",
+        "terminal.ansiGreen": "#1fa91b",
+        "terminal.ansiMagenta": "#8d35c9",
+        "terminal.ansiRed": "#ed2261",
+        "terminal.ansiWhite": "#9e9ea0",
+        "terminal.ansiYellow": "#8ddc20",
+        "terminal.ansiBrightBlack": "#59516a",
+        "terminal.ansiBrightBlue": "#a9bcec",
+        "terminal.ansiBrightCyan": "#9de3eb",
+        "terminal.ansiBrightGreen": "#53aa5e",
+        "terminal.ansiBrightMagenta": "#ad81c2",
+        "terminal.ansiBrightRed": "#f0729a",
+        "terminal.ansiBrightWhite": "#a288f7",
+        "terminal.ansiBrightYellow": "#b2dc87"
+    }
+}

--- a/vscode/Grass.json
+++ b/vscode/Grass.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#fff0a5",
+        "terminal.background": "#13773d",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000a3",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#00bb00",
+        "terminal.ansiMagenta": "#950062",
+        "terminal.ansiRed": "#bb0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#e7b000",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#0000bb",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#00bb00",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#bb0000",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e7b000"
+    }
+}

--- a/vscode/Gruvbox Dark.json
+++ b/vscode/Gruvbox Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e6d4a3",
+        "terminal.background": "#1e1e1e",
+        "terminal.ansiBlack": "#161819",
+        "terminal.ansiBlue": "#719586",
+        "terminal.ansiCyan": "#7db669",
+        "terminal.ansiGreen": "#aab01e",
+        "terminal.ansiMagenta": "#c77089",
+        "terminal.ansiRed": "#f73028",
+        "terminal.ansiWhite": "#faefbb",
+        "terminal.ansiYellow": "#f7b125",
+        "terminal.ansiBrightBlack": "#7f7061",
+        "terminal.ansiBrightBlue": "#377375",
+        "terminal.ansiBrightCyan": "#578e57",
+        "terminal.ansiBrightGreen": "#868715",
+        "terminal.ansiBrightMagenta": "#a04b73",
+        "terminal.ansiBrightRed": "#be0f17",
+        "terminal.ansiBrightWhite": "#e6d4a3",
+        "terminal.ansiBrightYellow": "#cc881a"
+    }
+}

--- a/vscode/Hacktober.json
+++ b/vscode/Hacktober.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c9c9c9",
+        "terminal.background": "#141414",
+        "terminal.ansiBlack": "#191918",
+        "terminal.ansiBlue": "#206ec5",
+        "terminal.ansiCyan": "#ac9166",
+        "terminal.ansiGreen": "#587744",
+        "terminal.ansiMagenta": "#864651",
+        "terminal.ansiRed": "#b34538",
+        "terminal.ansiWhite": "#f1eee7",
+        "terminal.ansiYellow": "#d08949",
+        "terminal.ansiBrightBlack": "#2c2b2a",
+        "terminal.ansiBrightBlue": "#5389c5",
+        "terminal.ansiBrightCyan": "#ebc587",
+        "terminal.ansiBrightGreen": "#42824a",
+        "terminal.ansiBrightMagenta": "#e795a5",
+        "terminal.ansiBrightRed": "#b33323",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#c75a22"
+    }
+}

--- a/vscode/Hardcore.json
+++ b/vscode/Hardcore.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a0a0a0",
+        "terminal.background": "#121212",
+        "terminal.ansiBlack": "#1b1d1e",
+        "terminal.ansiBlue": "#66d9ef",
+        "terminal.ansiCyan": "#5e7175",
+        "terminal.ansiGreen": "#a6e22e",
+        "terminal.ansiMagenta": "#9e6ffe",
+        "terminal.ansiRed": "#f92672",
+        "terminal.ansiWhite": "#ccccc6",
+        "terminal.ansiYellow": "#fd971f",
+        "terminal.ansiBrightBlack": "#505354",
+        "terminal.ansiBrightBlue": "#66d9ef",
+        "terminal.ansiBrightCyan": "#a3babf",
+        "terminal.ansiBrightGreen": "#beed5f",
+        "terminal.ansiBrightMagenta": "#9e6ffe",
+        "terminal.ansiBrightRed": "#ff669d",
+        "terminal.ansiBrightWhite": "#f8f8f2",
+        "terminal.ansiBrightYellow": "#e6db74"
+    }
+}

--- a/vscode/Harper.json
+++ b/vscode/Harper.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a8a49d",
+        "terminal.background": "#010101",
+        "terminal.ansiBlack": "#010101",
+        "terminal.ansiBlue": "#489e48",
+        "terminal.ansiCyan": "#f5bfd7",
+        "terminal.ansiGreen": "#7fb5e1",
+        "terminal.ansiMagenta": "#b296c6",
+        "terminal.ansiRed": "#f8b63f",
+        "terminal.ansiWhite": "#a8a49d",
+        "terminal.ansiYellow": "#d6da25",
+        "terminal.ansiBrightBlack": "#726e6a",
+        "terminal.ansiBrightBlue": "#489e48",
+        "terminal.ansiBrightCyan": "#f5bfd7",
+        "terminal.ansiBrightGreen": "#7fb5e1",
+        "terminal.ansiBrightMagenta": "#b296c6",
+        "terminal.ansiBrightRed": "#f8b63f",
+        "terminal.ansiBrightWhite": "#fefbea",
+        "terminal.ansiBrightYellow": "#d6da25"
+    }
+}

--- a/vscode/Highway.json
+++ b/vscode/Highway.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ededed",
+        "terminal.background": "#222225",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#006bb3",
+        "terminal.ansiCyan": "#384564",
+        "terminal.ansiGreen": "#138034",
+        "terminal.ansiMagenta": "#6b2775",
+        "terminal.ansiRed": "#d00e18",
+        "terminal.ansiWhite": "#ededed",
+        "terminal.ansiYellow": "#ffcb3e",
+        "terminal.ansiBrightBlack": "#5d504a",
+        "terminal.ansiBrightBlue": "#4fc2fd",
+        "terminal.ansiBrightCyan": "#5d504a",
+        "terminal.ansiBrightGreen": "#b1d130",
+        "terminal.ansiBrightMagenta": "#de0071",
+        "terminal.ansiBrightRed": "#f07e18",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff120"
+    }
+}

--- a/vscode/Hipster Green.json
+++ b/vscode/Hipster Green.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#84c138",
+        "terminal.background": "#100b05",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#246eb2",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#b6214a",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#bfbf00",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#86a93e",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Homebrew.json
+++ b/vscode/Homebrew.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#00ff00",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000b2",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#990000",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#999900",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#00d900",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Hopscotch.256.json
+++ b/vscode/Hopscotch.256.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b9b5b8",
+        "terminal.background": "#322931",
+        "terminal.ansiBlack": "#322931",
+        "terminal.ansiBlue": "#1290bf",
+        "terminal.ansiCyan": "#149b93",
+        "terminal.ansiGreen": "#8fc13e",
+        "terminal.ansiMagenta": "#c85e7c",
+        "terminal.ansiRed": "#dd464c",
+        "terminal.ansiWhite": "#b9b5b8",
+        "terminal.ansiYellow": "#fdcc59",
+        "terminal.ansiBrightBlack": "#797379",
+        "terminal.ansiBrightBlue": "#1290bf",
+        "terminal.ansiBrightCyan": "#149b93",
+        "terminal.ansiBrightGreen": "#8fc13e",
+        "terminal.ansiBrightMagenta": "#c85e7c",
+        "terminal.ansiBrightRed": "#dd464c",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fdcc59"
+    }
+}

--- a/vscode/Hopscotch.json
+++ b/vscode/Hopscotch.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b9b5b8",
+        "terminal.background": "#322931",
+        "terminal.ansiBlack": "#322931",
+        "terminal.ansiBlue": "#1290bf",
+        "terminal.ansiCyan": "#149b93",
+        "terminal.ansiGreen": "#8fc13e",
+        "terminal.ansiMagenta": "#c85e7c",
+        "terminal.ansiRed": "#dd464c",
+        "terminal.ansiWhite": "#b9b5b8",
+        "terminal.ansiYellow": "#fdcc59",
+        "terminal.ansiBrightBlack": "#797379",
+        "terminal.ansiBrightBlue": "#989498",
+        "terminal.ansiBrightCyan": "#b33508",
+        "terminal.ansiBrightGreen": "#433b42",
+        "terminal.ansiBrightMagenta": "#d5d3d5",
+        "terminal.ansiBrightRed": "#fd8b19",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#5c545b"
+    }
+}

--- a/vscode/Hurtado.json
+++ b/vscode/Hurtado.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dbdbdb",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#575757",
+        "terminal.ansiBlue": "#496487",
+        "terminal.ansiCyan": "#86e9fe",
+        "terminal.ansiGreen": "#a5e055",
+        "terminal.ansiMagenta": "#fd5ff1",
+        "terminal.ansiRed": "#ff1b00",
+        "terminal.ansiWhite": "#cbcccb",
+        "terminal.ansiYellow": "#fbe74a",
+        "terminal.ansiBrightBlack": "#262626",
+        "terminal.ansiBrightBlue": "#89beff",
+        "terminal.ansiBrightCyan": "#86eafe",
+        "terminal.ansiBrightGreen": "#a5df55",
+        "terminal.ansiBrightMagenta": "#c001c1",
+        "terminal.ansiBrightRed": "#d51d00",
+        "terminal.ansiBrightWhite": "#dbdbdb",
+        "terminal.ansiBrightYellow": "#fbe84a"
+    }
+}

--- a/vscode/Hybrid.json
+++ b/vscode/Hybrid.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b7bcba",
+        "terminal.background": "#161719",
+        "terminal.ansiBlack": "#2a2e33",
+        "terminal.ansiBlue": "#6e90b0",
+        "terminal.ansiCyan": "#7fbfb4",
+        "terminal.ansiGreen": "#b3bf5a",
+        "terminal.ansiMagenta": "#a17eac",
+        "terminal.ansiRed": "#b84d51",
+        "terminal.ansiWhite": "#b5b9b6",
+        "terminal.ansiYellow": "#e4b55e",
+        "terminal.ansiBrightBlack": "#1d1f22",
+        "terminal.ansiBrightBlue": "#4b6b88",
+        "terminal.ansiBrightCyan": "#4d7b74",
+        "terminal.ansiBrightGreen": "#798431",
+        "terminal.ansiBrightMagenta": "#6e5079",
+        "terminal.ansiBrightRed": "#8d2e32",
+        "terminal.ansiBrightWhite": "#5a626a",
+        "terminal.ansiBrightYellow": "#e58a50"
+    }
+}

--- a/vscode/IC_Green_PPL.json
+++ b/vscode/IC_Green_PPL.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d9efd3",
+        "terminal.background": "#3a3d3f",
+        "terminal.ansiBlack": "#1f1f1f",
+        "terminal.ansiBlue": "#149b45",
+        "terminal.ansiCyan": "#2cb868",
+        "terminal.ansiGreen": "#339c24",
+        "terminal.ansiMagenta": "#53b82c",
+        "terminal.ansiRed": "#fb002a",
+        "terminal.ansiWhite": "#e0ffef",
+        "terminal.ansiYellow": "#659b25",
+        "terminal.ansiBrightBlack": "#032710",
+        "terminal.ansiBrightBlue": "#72ffb5",
+        "terminal.ansiBrightCyan": "#22ff71",
+        "terminal.ansiBrightGreen": "#9fff6d",
+        "terminal.ansiBrightMagenta": "#50ff3e",
+        "terminal.ansiBrightRed": "#a7ff3f",
+        "terminal.ansiBrightWhite": "#daefd0",
+        "terminal.ansiBrightYellow": "#d2ff6d"
+    }
+}

--- a/vscode/IC_Orange_PPL.json
+++ b/vscode/IC_Orange_PPL.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffcb83",
+        "terminal.background": "#262626",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#bd6d00",
+        "terminal.ansiCyan": "#f79500",
+        "terminal.ansiGreen": "#a4a900",
+        "terminal.ansiMagenta": "#fc5e00",
+        "terminal.ansiRed": "#c13900",
+        "terminal.ansiWhite": "#ffc88a",
+        "terminal.ansiYellow": "#caaf00",
+        "terminal.ansiBrightBlack": "#6a4f2a",
+        "terminal.ansiBrightBlue": "#ffbe55",
+        "terminal.ansiBrightCyan": "#c69752",
+        "terminal.ansiBrightGreen": "#f6ff40",
+        "terminal.ansiBrightMagenta": "#fc874f",
+        "terminal.ansiBrightRed": "#ff8c68",
+        "terminal.ansiBrightWhite": "#fafaff",
+        "terminal.ansiBrightYellow": "#ffe36e"
+    }
+}

--- a/vscode/IR_Black.json
+++ b/vscode/IR_Black.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f1f1f1",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#4f4f4f",
+        "terminal.ansiBlue": "#96cafe",
+        "terminal.ansiCyan": "#c6c5fe",
+        "terminal.ansiGreen": "#a8ff60",
+        "terminal.ansiMagenta": "#fa73fd",
+        "terminal.ansiRed": "#fa6c60",
+        "terminal.ansiWhite": "#efedef",
+        "terminal.ansiYellow": "#fffeb7",
+        "terminal.ansiBrightBlack": "#7b7b7b",
+        "terminal.ansiBrightBlue": "#b5dcff",
+        "terminal.ansiBrightCyan": "#e0e0fe",
+        "terminal.ansiBrightGreen": "#cfffab",
+        "terminal.ansiBrightMagenta": "#fb9cfe",
+        "terminal.ansiBrightRed": "#fcb6b0",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffffcc"
+    }
+}

--- a/vscode/Jackie Brown.json
+++ b/vscode/Jackie Brown.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffcc2f",
+        "terminal.background": "#2c1d16",
+        "terminal.ansiBlack": "#2c1d16",
+        "terminal.ansiBlue": "#246eb2",
+        "terminal.ansiCyan": "#00acee",
+        "terminal.ansiGreen": "#2baf2b",
+        "terminal.ansiMagenta": "#d05ec1",
+        "terminal.ansiRed": "#ef5734",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#bebf00",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#86a93e",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Japanesque.json
+++ b/vscode/Japanesque.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f7f6ec",
+        "terminal.background": "#1e1e1e",
+        "terminal.ansiBlack": "#343935",
+        "terminal.ansiBlue": "#4c9ad4",
+        "terminal.ansiCyan": "#389aad",
+        "terminal.ansiGreen": "#7bb75b",
+        "terminal.ansiMagenta": "#a57fc4",
+        "terminal.ansiRed": "#cf3f61",
+        "terminal.ansiWhite": "#fafaf6",
+        "terminal.ansiYellow": "#e9b32a",
+        "terminal.ansiBrightBlack": "#595b59",
+        "terminal.ansiBrightBlue": "#135979",
+        "terminal.ansiBrightCyan": "#76bbca",
+        "terminal.ansiBrightGreen": "#767f2c",
+        "terminal.ansiBrightMagenta": "#604291",
+        "terminal.ansiBrightRed": "#d18fa6",
+        "terminal.ansiBrightWhite": "#b2b5ae",
+        "terminal.ansiBrightYellow": "#78592f"
+    }
+}

--- a/vscode/Jellybeans.json
+++ b/vscode/Jellybeans.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dedede",
+        "terminal.background": "#121212",
+        "terminal.ansiBlack": "#929292",
+        "terminal.ansiBlue": "#97bedc",
+        "terminal.ansiCyan": "#00988e",
+        "terminal.ansiGreen": "#94b979",
+        "terminal.ansiMagenta": "#e1c0fa",
+        "terminal.ansiRed": "#e27373",
+        "terminal.ansiWhite": "#dedede",
+        "terminal.ansiYellow": "#ffba7b",
+        "terminal.ansiBrightBlack": "#bdbdbd",
+        "terminal.ansiBrightBlue": "#b1d8f6",
+        "terminal.ansiBrightCyan": "#1ab2a8",
+        "terminal.ansiBrightGreen": "#bddeab",
+        "terminal.ansiBrightMagenta": "#fbdaff",
+        "terminal.ansiBrightRed": "#ffa1a1",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffdca0"
+    }
+}

--- a/vscode/JetBrains Darcula.json
+++ b/vscode/JetBrains Darcula.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#adadad",
+        "terminal.background": "#202020",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#4581eb",
+        "terminal.ansiCyan": "#33c2c1",
+        "terminal.ansiGreen": "#126e00",
+        "terminal.ansiMagenta": "#fa54ff",
+        "terminal.ansiRed": "#fa5355",
+        "terminal.ansiWhite": "#adadad",
+        "terminal.ansiYellow": "#c2c300",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#6d9df1",
+        "terminal.ansiBrightCyan": "#60d3d1",
+        "terminal.ansiBrightGreen": "#67ff4f",
+        "terminal.ansiBrightMagenta": "#fb82ff",
+        "terminal.ansiBrightRed": "#fb7172",
+        "terminal.ansiBrightWhite": "#eeeeee",
+        "terminal.ansiBrightYellow": "#ffff00"
+    }
+}

--- a/vscode/Kibble.json
+++ b/vscode/Kibble.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f7f7f7",
+        "terminal.background": "#0e100a",
+        "terminal.ansiBlack": "#4d4d4d",
+        "terminal.ansiBlue": "#3449d1",
+        "terminal.ansiCyan": "#0798ab",
+        "terminal.ansiGreen": "#29cf13",
+        "terminal.ansiMagenta": "#8400ff",
+        "terminal.ansiRed": "#c70031",
+        "terminal.ansiWhite": "#e2d1e3",
+        "terminal.ansiYellow": "#d8e30e",
+        "terminal.ansiBrightBlack": "#5a5a5a",
+        "terminal.ansiBrightBlue": "#97a4f7",
+        "terminal.ansiBrightCyan": "#68f2e0",
+        "terminal.ansiBrightGreen": "#6ce05c",
+        "terminal.ansiBrightMagenta": "#c495f0",
+        "terminal.ansiBrightRed": "#f01578",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f3f79e"
+    }
+}

--- a/vscode/Kolorit.json
+++ b/vscode/Kolorit.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#efecec",
+        "terminal.background": "#1d1a1e",
+        "terminal.ansiBlack": "#1d1a1e",
+        "terminal.ansiBlue": "#5db4ee",
+        "terminal.ansiCyan": "#57e9eb",
+        "terminal.ansiGreen": "#47d7a1",
+        "terminal.ansiMagenta": "#da6cda",
+        "terminal.ansiRed": "#ff5b82",
+        "terminal.ansiWhite": "#ededed",
+        "terminal.ansiYellow": "#e8e562",
+        "terminal.ansiBrightBlack": "#1d1a1e",
+        "terminal.ansiBrightBlue": "#5db4ee",
+        "terminal.ansiBrightCyan": "#57e9eb",
+        "terminal.ansiBrightGreen": "#47d7a1",
+        "terminal.ansiBrightMagenta": "#da6cda",
+        "terminal.ansiBrightRed": "#ff5b82",
+        "terminal.ansiBrightWhite": "#ededed",
+        "terminal.ansiBrightYellow": "#e8e562"
+    }
+}

--- a/vscode/Lab Fox.json
+++ b/vscode/Lab Fox.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#2e2e2e",
+        "terminal.ansiBlack": "#2e2e2e",
+        "terminal.ansiBlue": "#db3b21",
+        "terminal.ansiCyan": "#6e49cb",
+        "terminal.ansiGreen": "#3eb383",
+        "terminal.ansiMagenta": "#380d75",
+        "terminal.ansiRed": "#fc6d26",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fca121",
+        "terminal.ansiBrightBlack": "#464646",
+        "terminal.ansiBrightBlue": "#db501f",
+        "terminal.ansiBrightCyan": "#7d53e7",
+        "terminal.ansiBrightGreen": "#53eaa8",
+        "terminal.ansiBrightMagenta": "#441090",
+        "terminal.ansiBrightRed": "#ff6517",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fca013"
+    }
+}

--- a/vscode/Later This Evening.json
+++ b/vscode/Later This Evening.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#959595",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#2b2b2b",
+        "terminal.ansiBlue": "#a0bad6",
+        "terminal.ansiCyan": "#91bfb7",
+        "terminal.ansiGreen": "#afba67",
+        "terminal.ansiMagenta": "#c092d6",
+        "terminal.ansiRed": "#d45a60",
+        "terminal.ansiWhite": "#3c3d3d",
+        "terminal.ansiYellow": "#e5d289",
+        "terminal.ansiBrightBlack": "#454747",
+        "terminal.ansiBrightBlue": "#6699d6",
+        "terminal.ansiBrightCyan": "#5fc0ae",
+        "terminal.ansiBrightGreen": "#aabb39",
+        "terminal.ansiBrightMagenta": "#ab53d6",
+        "terminal.ansiBrightRed": "#d3232f",
+        "terminal.ansiBrightWhite": "#c1c2c2",
+        "terminal.ansiBrightYellow": "#e5be39"
+    }
+}

--- a/vscode/Lavandula.json
+++ b/vscode/Lavandula.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#736e7d",
+        "terminal.background": "#050014",
+        "terminal.ansiBlack": "#230046",
+        "terminal.ansiBlue": "#4f4a7f",
+        "terminal.ansiCyan": "#58777f",
+        "terminal.ansiGreen": "#337e6f",
+        "terminal.ansiMagenta": "#5a3f7f",
+        "terminal.ansiRed": "#7d1625",
+        "terminal.ansiWhite": "#736e7d",
+        "terminal.ansiYellow": "#7f6f49",
+        "terminal.ansiBrightBlack": "#372d46",
+        "terminal.ansiBrightBlue": "#8e87e0",
+        "terminal.ansiBrightCyan": "#9ad4e0",
+        "terminal.ansiBrightGreen": "#52e0c4",
+        "terminal.ansiBrightMagenta": "#a776e0",
+        "terminal.ansiBrightRed": "#e05167",
+        "terminal.ansiBrightWhite": "#8c91fa",
+        "terminal.ansiBrightYellow": "#e0c386"
+    }
+}

--- a/vscode/LiquidCarbon.json
+++ b/vscode/LiquidCarbon.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#afc2c2",
+        "terminal.background": "#303030",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0099cc",
+        "terminal.ansiCyan": "#7ac4cc",
+        "terminal.ansiGreen": "#559a70",
+        "terminal.ansiMagenta": "#cc69c8",
+        "terminal.ansiRed": "#ff3030",
+        "terminal.ansiWhite": "#bccccc",
+        "terminal.ansiYellow": "#ccac00",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#0099cc",
+        "terminal.ansiBrightCyan": "#7ac4cc",
+        "terminal.ansiBrightGreen": "#559a70",
+        "terminal.ansiBrightMagenta": "#cc69c8",
+        "terminal.ansiBrightRed": "#ff3030",
+        "terminal.ansiBrightWhite": "#bccccc",
+        "terminal.ansiBrightYellow": "#ccac00"
+    }
+}

--- a/vscode/LiquidCarbonTransparent.json
+++ b/vscode/LiquidCarbonTransparent.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#afc2c2",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0099cc",
+        "terminal.ansiCyan": "#7ac4cc",
+        "terminal.ansiGreen": "#559a70",
+        "terminal.ansiMagenta": "#cc69c8",
+        "terminal.ansiRed": "#ff3030",
+        "terminal.ansiWhite": "#bccccc",
+        "terminal.ansiYellow": "#ccac00",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#0099cc",
+        "terminal.ansiBrightCyan": "#7ac4cc",
+        "terminal.ansiBrightGreen": "#559a70",
+        "terminal.ansiBrightMagenta": "#cc69c8",
+        "terminal.ansiBrightRed": "#ff3030",
+        "terminal.ansiBrightWhite": "#bccccc",
+        "terminal.ansiBrightYellow": "#ccac00"
+    }
+}

--- a/vscode/LiquidCarbonTransparentInverse.json
+++ b/vscode/LiquidCarbonTransparentInverse.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#afc2c2",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#bccccd",
+        "terminal.ansiBlue": "#0099cc",
+        "terminal.ansiCyan": "#7ac4cc",
+        "terminal.ansiGreen": "#559a70",
+        "terminal.ansiMagenta": "#cc69c8",
+        "terminal.ansiRed": "#ff3030",
+        "terminal.ansiWhite": "#000000",
+        "terminal.ansiYellow": "#ccac00",
+        "terminal.ansiBrightBlack": "#ffffff",
+        "terminal.ansiBrightBlue": "#0099cc",
+        "terminal.ansiBrightCyan": "#7ac4cc",
+        "terminal.ansiBrightGreen": "#559a70",
+        "terminal.ansiBrightMagenta": "#cc69c8",
+        "terminal.ansiBrightRed": "#ff3030",
+        "terminal.ansiBrightWhite": "#000000",
+        "terminal.ansiBrightYellow": "#ccac00"
+    }
+}

--- a/vscode/Man Page.json
+++ b/vscode/Man Page.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#fef49c",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000b2",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#cccccc",
+        "terminal.ansiYellow": "#999900",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#00d900",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Material.json
+++ b/vscode/Material.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#232322",
+        "terminal.background": "#eaeaea",
+        "terminal.ansiBlack": "#212121",
+        "terminal.ansiBlue": "#134eb2",
+        "terminal.ansiCyan": "#0e717c",
+        "terminal.ansiGreen": "#457b24",
+        "terminal.ansiMagenta": "#560088",
+        "terminal.ansiRed": "#b7141f",
+        "terminal.ansiWhite": "#efefef",
+        "terminal.ansiYellow": "#f6981e",
+        "terminal.ansiBrightBlack": "#424242",
+        "terminal.ansiBrightBlue": "#54a4f3",
+        "terminal.ansiBrightCyan": "#26bbd1",
+        "terminal.ansiBrightGreen": "#7aba3a",
+        "terminal.ansiBrightMagenta": "#aa4dbc",
+        "terminal.ansiBrightRed": "#e83b3f",
+        "terminal.ansiBrightWhite": "#d9d9d9",
+        "terminal.ansiBrightYellow": "#ffea2e"
+    }
+}

--- a/vscode/MaterialDark.json
+++ b/vscode/MaterialDark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e5e5e5",
+        "terminal.background": "#232322",
+        "terminal.ansiBlack": "#212121",
+        "terminal.ansiBlue": "#134eb2",
+        "terminal.ansiCyan": "#0e717c",
+        "terminal.ansiGreen": "#457b24",
+        "terminal.ansiMagenta": "#560088",
+        "terminal.ansiRed": "#b7141f",
+        "terminal.ansiWhite": "#efefef",
+        "terminal.ansiYellow": "#f6981e",
+        "terminal.ansiBrightBlack": "#424242",
+        "terminal.ansiBrightBlue": "#54a4f3",
+        "terminal.ansiBrightCyan": "#26bbd1",
+        "terminal.ansiBrightGreen": "#7aba3a",
+        "terminal.ansiBrightMagenta": "#aa4dbc",
+        "terminal.ansiBrightRed": "#e83b3f",
+        "terminal.ansiBrightWhite": "#d9d9d9",
+        "terminal.ansiBrightYellow": "#ffea2e"
+    }
+}

--- a/vscode/MaterialOcean.json
+++ b/vscode/MaterialOcean.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#8f93a2",
+        "terminal.background": "#0f111a",
+        "terminal.ansiBlack": "#546e7a",
+        "terminal.ansiBlue": "#82aaff",
+        "terminal.ansiCyan": "#89ddff",
+        "terminal.ansiGreen": "#c3e88d",
+        "terminal.ansiMagenta": "#c792ea",
+        "terminal.ansiRed": "#ff5370",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffcb6b",
+        "terminal.ansiBrightBlack": "#546e7a",
+        "terminal.ansiBrightBlue": "#82aaff",
+        "terminal.ansiBrightCyan": "#89ddff",
+        "terminal.ansiBrightGreen": "#c3e88d",
+        "terminal.ansiBrightMagenta": "#c792ea",
+        "terminal.ansiBrightRed": "#ff5370",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffcb6b"
+    }
+}

--- a/vscode/Mathias.json
+++ b/vscode/Mathias.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#c48dff",
+        "terminal.ansiCyan": "#67d9f0",
+        "terminal.ansiGreen": "#a6e32d",
+        "terminal.ansiMagenta": "#fa2573",
+        "terminal.ansiRed": "#e52222",
+        "terminal.ansiWhite": "#f2f2f2",
+        "terminal.ansiYellow": "#fc951e",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Medallion.json
+++ b/vscode/Medallion.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cac296",
+        "terminal.background": "#1d1908",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#616bb0",
+        "terminal.ansiCyan": "#916c25",
+        "terminal.ansiGreen": "#7c8b16",
+        "terminal.ansiMagenta": "#8c5a90",
+        "terminal.ansiRed": "#b64c00",
+        "terminal.ansiWhite": "#cac29a",
+        "terminal.ansiYellow": "#d3bd26",
+        "terminal.ansiBrightBlack": "#5e5219",
+        "terminal.ansiBrightBlue": "#acb8ff",
+        "terminal.ansiBrightCyan": "#ffbc51",
+        "terminal.ansiBrightGreen": "#b2ca3b",
+        "terminal.ansiBrightMagenta": "#ffa0ff",
+        "terminal.ansiBrightRed": "#ff9149",
+        "terminal.ansiBrightWhite": "#fed698",
+        "terminal.ansiBrightYellow": "#ffe54a"
+    }
+}

--- a/vscode/Misterioso.json
+++ b/vscode/Misterioso.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e1e1e0",
+        "terminal.background": "#2d3743",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#338f86",
+        "terminal.ansiCyan": "#23d7d7",
+        "terminal.ansiGreen": "#74af68",
+        "terminal.ansiMagenta": "#9414e6",
+        "terminal.ansiRed": "#ff4242",
+        "terminal.ansiWhite": "#e1e1e0",
+        "terminal.ansiYellow": "#ffad29",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#23d7d7",
+        "terminal.ansiBrightCyan": "#00ede1",
+        "terminal.ansiBrightGreen": "#74cd68",
+        "terminal.ansiBrightMagenta": "#ff37ff",
+        "terminal.ansiBrightRed": "#ff3242",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffb929"
+    }
+}

--- a/vscode/Molokai.json
+++ b/vscode/Molokai.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#121212",
+        "terminal.ansiBlack": "#121212",
+        "terminal.ansiBlue": "#1080d0",
+        "terminal.ansiCyan": "#43a8d0",
+        "terminal.ansiGreen": "#98e123",
+        "terminal.ansiMagenta": "#8700ff",
+        "terminal.ansiRed": "#fa2573",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#dfd460",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#00afff",
+        "terminal.ansiBrightCyan": "#51ceff",
+        "terminal.ansiBrightGreen": "#b1e05f",
+        "terminal.ansiBrightMagenta": "#af87ff",
+        "terminal.ansiBrightRed": "#f6669d",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff26d"
+    }
+}

--- a/vscode/MonaLisa.json
+++ b/vscode/MonaLisa.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f7d66a",
+        "terminal.background": "#120b0d",
+        "terminal.ansiBlack": "#351b0e",
+        "terminal.ansiBlue": "#515c5d",
+        "terminal.ansiCyan": "#588056",
+        "terminal.ansiGreen": "#636232",
+        "terminal.ansiMagenta": "#9b1d29",
+        "terminal.ansiRed": "#9b291c",
+        "terminal.ansiWhite": "#f7d75c",
+        "terminal.ansiYellow": "#c36e28",
+        "terminal.ansiBrightBlack": "#874228",
+        "terminal.ansiBrightBlue": "#9eb2b4",
+        "terminal.ansiBrightCyan": "#8acd8f",
+        "terminal.ansiBrightGreen": "#b4b264",
+        "terminal.ansiBrightMagenta": "#ff5b6a",
+        "terminal.ansiBrightRed": "#ff4331",
+        "terminal.ansiBrightWhite": "#ffe598",
+        "terminal.ansiBrightYellow": "#ff9566"
+    }
+}

--- a/vscode/Monokai Remastered.json
+++ b/vscode/Monokai Remastered.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d9d9d9",
+        "terminal.background": "#0c0c0c",
+        "terminal.ansiBlack": "#1a1a1a",
+        "terminal.ansiBlue": "#9d65ff",
+        "terminal.ansiCyan": "#58d1eb",
+        "terminal.ansiGreen": "#98e024",
+        "terminal.ansiMagenta": "#f4005f",
+        "terminal.ansiRed": "#f4005f",
+        "terminal.ansiWhite": "#c4c5b5",
+        "terminal.ansiYellow": "#fd971f",
+        "terminal.ansiBrightBlack": "#625e4c",
+        "terminal.ansiBrightBlue": "#9d65ff",
+        "terminal.ansiBrightCyan": "#58d1eb",
+        "terminal.ansiBrightGreen": "#98e024",
+        "terminal.ansiBrightMagenta": "#f4005f",
+        "terminal.ansiBrightRed": "#f4005f",
+        "terminal.ansiBrightWhite": "#f6f6ef",
+        "terminal.ansiBrightYellow": "#e0d561"
+    }
+}

--- a/vscode/Monokai Soda.json
+++ b/vscode/Monokai Soda.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c4c5b5",
+        "terminal.background": "#1a1a1a",
+        "terminal.ansiBlack": "#1a1a1a",
+        "terminal.ansiBlue": "#9d65ff",
+        "terminal.ansiCyan": "#58d1eb",
+        "terminal.ansiGreen": "#98e024",
+        "terminal.ansiMagenta": "#f4005f",
+        "terminal.ansiRed": "#f4005f",
+        "terminal.ansiWhite": "#c4c5b5",
+        "terminal.ansiYellow": "#fa8419",
+        "terminal.ansiBrightBlack": "#625e4c",
+        "terminal.ansiBrightBlue": "#9d65ff",
+        "terminal.ansiBrightCyan": "#58d1eb",
+        "terminal.ansiBrightGreen": "#98e024",
+        "terminal.ansiBrightMagenta": "#f4005f",
+        "terminal.ansiBrightRed": "#f4005f",
+        "terminal.ansiBrightWhite": "#f6f6ef",
+        "terminal.ansiBrightYellow": "#e0d561"
+    }
+}

--- a/vscode/Monokai Vivid.json
+++ b/vscode/Monokai Vivid.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f9f9f9",
+        "terminal.background": "#121212",
+        "terminal.ansiBlack": "#121212",
+        "terminal.ansiBlue": "#0443ff",
+        "terminal.ansiCyan": "#01b6ed",
+        "terminal.ansiGreen": "#98e123",
+        "terminal.ansiMagenta": "#f800f8",
+        "terminal.ansiRed": "#fa2934",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fff30a",
+        "terminal.ansiBrightBlack": "#838383",
+        "terminal.ansiBrightBlue": "#0443ff",
+        "terminal.ansiBrightCyan": "#51ceff",
+        "terminal.ansiBrightGreen": "#b1e05f",
+        "terminal.ansiBrightMagenta": "#f200f6",
+        "terminal.ansiBrightRed": "#f6669d",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff26d"
+    }
+}

--- a/vscode/N0tch2k.json
+++ b/vscode/N0tch2k.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a0a0a0",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#383838",
+        "terminal.ansiBlue": "#657d3e",
+        "terminal.ansiCyan": "#c9c9c9",
+        "terminal.ansiGreen": "#666666",
+        "terminal.ansiMagenta": "#767676",
+        "terminal.ansiRed": "#a95551",
+        "terminal.ansiWhite": "#d0b8a3",
+        "terminal.ansiYellow": "#a98051",
+        "terminal.ansiBrightBlack": "#474747",
+        "terminal.ansiBrightBlue": "#98bd5e",
+        "terminal.ansiBrightCyan": "#dcdcdc",
+        "terminal.ansiBrightGreen": "#8c8c8c",
+        "terminal.ansiBrightMagenta": "#a3a3a3",
+        "terminal.ansiBrightRed": "#a97775",
+        "terminal.ansiBrightWhite": "#d8c8bb",
+        "terminal.ansiBrightYellow": "#a99175"
+    }
+}

--- a/vscode/Neopolitan.json
+++ b/vscode/Neopolitan.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#271f19",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#253b76",
+        "terminal.ansiCyan": "#8da6ce",
+        "terminal.ansiGreen": "#61ce3c",
+        "terminal.ansiMagenta": "#ff0080",
+        "terminal.ansiRed": "#800000",
+        "terminal.ansiWhite": "#f8f8f8",
+        "terminal.ansiYellow": "#fbde2d",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#253b76",
+        "terminal.ansiBrightCyan": "#8da6ce",
+        "terminal.ansiBrightGreen": "#61ce3c",
+        "terminal.ansiBrightMagenta": "#ff0080",
+        "terminal.ansiBrightRed": "#800000",
+        "terminal.ansiBrightWhite": "#f8f8f8",
+        "terminal.ansiBrightYellow": "#fbde2d"
+    }
+}

--- a/vscode/Neutron.json
+++ b/vscode/Neutron.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e6e8ef",
+        "terminal.background": "#1c1e22",
+        "terminal.ansiBlack": "#23252b",
+        "terminal.ansiBlue": "#6a7c93",
+        "terminal.ansiCyan": "#3f94a8",
+        "terminal.ansiGreen": "#5ab977",
+        "terminal.ansiMagenta": "#a4799d",
+        "terminal.ansiRed": "#b54036",
+        "terminal.ansiWhite": "#e6e8ef",
+        "terminal.ansiYellow": "#deb566",
+        "terminal.ansiBrightBlack": "#23252b",
+        "terminal.ansiBrightBlue": "#6a7c93",
+        "terminal.ansiBrightCyan": "#3f94a8",
+        "terminal.ansiBrightGreen": "#5ab977",
+        "terminal.ansiBrightMagenta": "#a4799d",
+        "terminal.ansiBrightRed": "#b54036",
+        "terminal.ansiBrightWhite": "#ebedf2",
+        "terminal.ansiBrightYellow": "#deb566"
+    }
+}

--- a/vscode/Night Owlish Light.json
+++ b/vscode/Night Owlish Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#403f53",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#011627",
+        "terminal.ansiBlue": "#4876d6",
+        "terminal.ansiCyan": "#08916a",
+        "terminal.ansiGreen": "#2aa298",
+        "terminal.ansiMagenta": "#403f53",
+        "terminal.ansiRed": "#d3423e",
+        "terminal.ansiWhite": "#7a8181",
+        "terminal.ansiYellow": "#daaa01",
+        "terminal.ansiBrightBlack": "#7a8181",
+        "terminal.ansiBrightBlue": "#5ca7e4",
+        "terminal.ansiBrightCyan": "#00c990",
+        "terminal.ansiBrightGreen": "#49d0c5",
+        "terminal.ansiBrightMagenta": "#697098",
+        "terminal.ansiBrightRed": "#f76e6e",
+        "terminal.ansiBrightWhite": "#989fb1",
+        "terminal.ansiBrightYellow": "#dac26b"
+    }
+}

--- a/vscode/NightLion v1.json
+++ b/vscode/NightLion v1.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#4c4c4c",
+        "terminal.ansiBlue": "#276bd8",
+        "terminal.ansiCyan": "#00dadf",
+        "terminal.ansiGreen": "#5fde8f",
+        "terminal.ansiMagenta": "#bb00bb",
+        "terminal.ansiRed": "#bb0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#f3f167",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/NightLion v2.json
+++ b/vscode/NightLion v2.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bbbbbb",
+        "terminal.background": "#171717",
+        "terminal.ansiBlack": "#4c4c4c",
+        "terminal.ansiBlue": "#64d0f0",
+        "terminal.ansiCyan": "#00dadf",
+        "terminal.ansiGreen": "#04f623",
+        "terminal.ansiMagenta": "#ce6fdb",
+        "terminal.ansiRed": "#bb0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#f3f167",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#62cbe8",
+        "terminal.ansiBrightCyan": "#00ccd8",
+        "terminal.ansiBrightGreen": "#7df71d",
+        "terminal.ansiBrightMagenta": "#ff9bf5",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Nocturnal Winter.json
+++ b/vscode/Nocturnal Winter.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e6e5e5",
+        "terminal.background": "#0d0d17",
+        "terminal.ansiBlack": "#4d4d4d",
+        "terminal.ansiBlue": "#3182e0",
+        "terminal.ansiCyan": "#09c87a",
+        "terminal.ansiGreen": "#09cd7e",
+        "terminal.ansiMagenta": "#ff2b6d",
+        "terminal.ansiRed": "#f12d52",
+        "terminal.ansiWhite": "#fcfcfc",
+        "terminal.ansiYellow": "#f5f17a",
+        "terminal.ansiBrightBlack": "#808080",
+        "terminal.ansiBrightBlue": "#6096ff",
+        "terminal.ansiBrightCyan": "#0ae78d",
+        "terminal.ansiBrightGreen": "#0ae78d",
+        "terminal.ansiBrightMagenta": "#ff78a2",
+        "terminal.ansiBrightRed": "#f16d86",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fffc67"
+    }
+}

--- a/vscode/Novel.json
+++ b/vscode/Novel.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#3b2322",
+        "terminal.background": "#dfdbc3",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000cc",
+        "terminal.ansiCyan": "#0087cc",
+        "terminal.ansiGreen": "#009600",
+        "terminal.ansiMagenta": "#cc00cc",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#cccccc",
+        "terminal.ansiYellow": "#d06b00",
+        "terminal.ansiBrightBlack": "#808080",
+        "terminal.ansiBrightBlue": "#0000cc",
+        "terminal.ansiBrightCyan": "#0087cc",
+        "terminal.ansiBrightGreen": "#009600",
+        "terminal.ansiBrightMagenta": "#cc00cc",
+        "terminal.ansiBrightRed": "#cc0000",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#d06b00"
+    }
+}

--- a/vscode/Obsidian.json
+++ b/vscode/Obsidian.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cdcdcd",
+        "terminal.background": "#283033",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#3a9bdb",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#00bb00",
+        "terminal.ansiMagenta": "#bb00bb",
+        "terminal.ansiRed": "#a60001",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#fecd22",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#a1d7ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#93c863",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff0003",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fef874"
+    }
+}

--- a/vscode/Ocean.json
+++ b/vscode/Ocean.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#224fbc",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000b2",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#990000",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#999900",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#00d900",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/OceanicMaterial.json
+++ b/vscode/OceanicMaterial.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c2c8d7",
+        "terminal.background": "#1c262b",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#1e80f0",
+        "terminal.ansiCyan": "#16afca",
+        "terminal.ansiGreen": "#40a33f",
+        "terminal.ansiMagenta": "#8800a0",
+        "terminal.ansiRed": "#ee2b2a",
+        "terminal.ansiWhite": "#a4a4a4",
+        "terminal.ansiYellow": "#ffea2e",
+        "terminal.ansiBrightBlack": "#777777",
+        "terminal.ansiBrightBlue": "#54a4f3",
+        "terminal.ansiBrightCyan": "#42c7da",
+        "terminal.ansiBrightGreen": "#70be71",
+        "terminal.ansiBrightMagenta": "#aa4dbc",
+        "terminal.ansiBrightRed": "#dc5c60",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff163"
+    }
+}

--- a/vscode/Ollie.json
+++ b/vscode/Ollie.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#8a8dae",
+        "terminal.background": "#222125",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2d57ac",
+        "terminal.ansiCyan": "#1fa6ac",
+        "terminal.ansiGreen": "#31ac61",
+        "terminal.ansiMagenta": "#b08528",
+        "terminal.ansiRed": "#ac2e31",
+        "terminal.ansiWhite": "#8a8eac",
+        "terminal.ansiYellow": "#ac4300",
+        "terminal.ansiBrightBlack": "#5b3725",
+        "terminal.ansiBrightBlue": "#4488ff",
+        "terminal.ansiBrightCyan": "#1ffaff",
+        "terminal.ansiBrightGreen": "#3bff99",
+        "terminal.ansiBrightMagenta": "#ffc21d",
+        "terminal.ansiBrightRed": "#ff3d48",
+        "terminal.ansiBrightWhite": "#5b6ea7",
+        "terminal.ansiBrightYellow": "#ff5e1e"
+    }
+}

--- a/vscode/OneHalfDark.json
+++ b/vscode/OneHalfDark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dcdfe4",
+        "terminal.background": "#282c34",
+        "terminal.ansiBlack": "#282c34",
+        "terminal.ansiBlue": "#61afef",
+        "terminal.ansiCyan": "#56b6c2",
+        "terminal.ansiGreen": "#98c379",
+        "terminal.ansiMagenta": "#c678dd",
+        "terminal.ansiRed": "#e06c75",
+        "terminal.ansiWhite": "#dcdfe4",
+        "terminal.ansiYellow": "#e5c07b",
+        "terminal.ansiBrightBlack": "#282c34",
+        "terminal.ansiBrightBlue": "#61afef",
+        "terminal.ansiBrightCyan": "#56b6c2",
+        "terminal.ansiBrightGreen": "#98c379",
+        "terminal.ansiBrightMagenta": "#c678dd",
+        "terminal.ansiBrightRed": "#e06c75",
+        "terminal.ansiBrightWhite": "#dcdfe4",
+        "terminal.ansiBrightYellow": "#e5c07b"
+    }
+}

--- a/vscode/OneHalfLight.json
+++ b/vscode/OneHalfLight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#383a42",
+        "terminal.background": "#fafafa",
+        "terminal.ansiBlack": "#383a42",
+        "terminal.ansiBlue": "#0184bc",
+        "terminal.ansiCyan": "#0997b3",
+        "terminal.ansiGreen": "#50a14f",
+        "terminal.ansiMagenta": "#a626a4",
+        "terminal.ansiRed": "#e45649",
+        "terminal.ansiWhite": "#fafafa",
+        "terminal.ansiYellow": "#c18401",
+        "terminal.ansiBrightBlack": "#4f525e",
+        "terminal.ansiBrightBlue": "#61afef",
+        "terminal.ansiBrightCyan": "#56b6c2",
+        "terminal.ansiBrightGreen": "#98c379",
+        "terminal.ansiBrightMagenta": "#c678dd",
+        "terminal.ansiBrightRed": "#e06c75",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e5c07b"
+    }
+}

--- a/vscode/Operator Mono Dark.json
+++ b/vscode/Operator Mono Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c3cac2",
+        "terminal.background": "#191919",
+        "terminal.ansiBlack": "#5a5a5a",
+        "terminal.ansiBlue": "#4387cf",
+        "terminal.ansiCyan": "#72d5c6",
+        "terminal.ansiGreen": "#4d7b3a",
+        "terminal.ansiMagenta": "#b86cb4",
+        "terminal.ansiRed": "#ca372d",
+        "terminal.ansiWhite": "#ced4cd",
+        "terminal.ansiYellow": "#d4d697",
+        "terminal.ansiBrightBlack": "#9a9b99",
+        "terminal.ansiBrightBlue": "#89d3f6",
+        "terminal.ansiBrightCyan": "#82eada",
+        "terminal.ansiBrightGreen": "#83d0a2",
+        "terminal.ansiBrightMagenta": "#ff2c7a",
+        "terminal.ansiBrightRed": "#c37d62",
+        "terminal.ansiBrightWhite": "#fdfdf6",
+        "terminal.ansiBrightYellow": "#fdfdc5"
+    }
+}

--- a/vscode/Pandora.json
+++ b/vscode/Pandora.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e1e1e1",
+        "terminal.background": "#141e43",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#338f86",
+        "terminal.ansiCyan": "#23d7d7",
+        "terminal.ansiGreen": "#74af68",
+        "terminal.ansiMagenta": "#9414e6",
+        "terminal.ansiRed": "#ff4242",
+        "terminal.ansiWhite": "#e2e2e2",
+        "terminal.ansiYellow": "#ffad29",
+        "terminal.ansiBrightBlack": "#3f5648",
+        "terminal.ansiBrightBlue": "#23d7d7",
+        "terminal.ansiBrightCyan": "#00ede1",
+        "terminal.ansiBrightGreen": "#74cd68",
+        "terminal.ansiBrightMagenta": "#ff37ff",
+        "terminal.ansiBrightRed": "#ff3242",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffb929"
+    }
+}

--- a/vscode/Paraiso Dark.json
+++ b/vscode/Paraiso Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a39e9b",
+        "terminal.background": "#2f1e2e",
+        "terminal.ansiBlack": "#2f1e2e",
+        "terminal.ansiBlue": "#06b6ef",
+        "terminal.ansiCyan": "#5bc4bf",
+        "terminal.ansiGreen": "#48b685",
+        "terminal.ansiMagenta": "#815ba4",
+        "terminal.ansiRed": "#ef6155",
+        "terminal.ansiWhite": "#a39e9b",
+        "terminal.ansiYellow": "#fec418",
+        "terminal.ansiBrightBlack": "#776e71",
+        "terminal.ansiBrightBlue": "#06b6ef",
+        "terminal.ansiBrightCyan": "#5bc4bf",
+        "terminal.ansiBrightGreen": "#48b685",
+        "terminal.ansiBrightMagenta": "#815ba4",
+        "terminal.ansiBrightRed": "#ef6155",
+        "terminal.ansiBrightWhite": "#e7e9db",
+        "terminal.ansiBrightYellow": "#fec418"
+    }
+}

--- a/vscode/Parasio Dark.json
+++ b/vscode/Parasio Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a39e9b",
+        "terminal.background": "#2f1e2e",
+        "terminal.ansiBlack": "#2f1e2e",
+        "terminal.ansiBlue": "#06b6ef",
+        "terminal.ansiCyan": "#5bc4bf",
+        "terminal.ansiGreen": "#48b685",
+        "terminal.ansiMagenta": "#815ba4",
+        "terminal.ansiRed": "#ef6155",
+        "terminal.ansiWhite": "#a39e9b",
+        "terminal.ansiYellow": "#fec418",
+        "terminal.ansiBrightBlack": "#776e71",
+        "terminal.ansiBrightBlue": "#06b6ef",
+        "terminal.ansiBrightCyan": "#5bc4bf",
+        "terminal.ansiBrightGreen": "#48b685",
+        "terminal.ansiBrightMagenta": "#815ba4",
+        "terminal.ansiBrightRed": "#ef6155",
+        "terminal.ansiBrightWhite": "#e7e9db",
+        "terminal.ansiBrightYellow": "#fec418"
+    }
+}

--- a/vscode/PaulMillr.json
+++ b/vscode/PaulMillr.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f2f2f2",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#2a2a2a",
+        "terminal.ansiBlue": "#396bd7",
+        "terminal.ansiCyan": "#66ccff",
+        "terminal.ansiGreen": "#79ff0f",
+        "terminal.ansiMagenta": "#b449be",
+        "terminal.ansiRed": "#ff0000",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#e7bf00",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#709aed",
+        "terminal.ansiBrightCyan": "#7adff2",
+        "terminal.ansiBrightGreen": "#66ff66",
+        "terminal.ansiBrightMagenta": "#db67e6",
+        "terminal.ansiBrightRed": "#ff0080",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f3d64e"
+    }
+}

--- a/vscode/PencilDark.json
+++ b/vscode/PencilDark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f1f1f1",
+        "terminal.background": "#212121",
+        "terminal.ansiBlack": "#212121",
+        "terminal.ansiBlue": "#008ec4",
+        "terminal.ansiCyan": "#20a5ba",
+        "terminal.ansiGreen": "#10a778",
+        "terminal.ansiMagenta": "#523c79",
+        "terminal.ansiRed": "#c30771",
+        "terminal.ansiWhite": "#d9d9d9",
+        "terminal.ansiYellow": "#a89c14",
+        "terminal.ansiBrightBlack": "#424242",
+        "terminal.ansiBrightBlue": "#20bbfc",
+        "terminal.ansiBrightCyan": "#4fb8cc",
+        "terminal.ansiBrightGreen": "#5fd7af",
+        "terminal.ansiBrightMagenta": "#6855de",
+        "terminal.ansiBrightRed": "#fb007a",
+        "terminal.ansiBrightWhite": "#f1f1f1",
+        "terminal.ansiBrightYellow": "#f3e430"
+    }
+}

--- a/vscode/PencilLight.json
+++ b/vscode/PencilLight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#424242",
+        "terminal.background": "#f1f1f1",
+        "terminal.ansiBlack": "#212121",
+        "terminal.ansiBlue": "#008ec4",
+        "terminal.ansiCyan": "#20a5ba",
+        "terminal.ansiGreen": "#10a778",
+        "terminal.ansiMagenta": "#523c79",
+        "terminal.ansiRed": "#c30771",
+        "terminal.ansiWhite": "#d9d9d9",
+        "terminal.ansiYellow": "#a89c14",
+        "terminal.ansiBrightBlack": "#424242",
+        "terminal.ansiBrightBlue": "#20bbfc",
+        "terminal.ansiBrightCyan": "#4fb8cc",
+        "terminal.ansiBrightGreen": "#5fd7af",
+        "terminal.ansiBrightMagenta": "#6855de",
+        "terminal.ansiBrightRed": "#fb007a",
+        "terminal.ansiBrightWhite": "#f1f1f1",
+        "terminal.ansiBrightYellow": "#f3e430"
+    }
+}

--- a/vscode/Piatto Light.json
+++ b/vscode/Piatto Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#414141",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#414141",
+        "terminal.ansiBlue": "#3c5ea8",
+        "terminal.ansiCyan": "#66781e",
+        "terminal.ansiGreen": "#66781e",
+        "terminal.ansiMagenta": "#a454b2",
+        "terminal.ansiRed": "#b23771",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#cd6f34",
+        "terminal.ansiBrightBlack": "#3f3f3f",
+        "terminal.ansiBrightBlue": "#3c5ea8",
+        "terminal.ansiBrightCyan": "#829429",
+        "terminal.ansiBrightGreen": "#829429",
+        "terminal.ansiBrightMagenta": "#a454b2",
+        "terminal.ansiBrightRed": "#db3365",
+        "terminal.ansiBrightWhite": "#f2f2f2",
+        "terminal.ansiBrightYellow": "#cd6f34"
+    }
+}

--- a/vscode/Pnevma.json
+++ b/vscode/Pnevma.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d0d0d0",
+        "terminal.background": "#1c1c1c",
+        "terminal.ansiBlack": "#2f2e2d",
+        "terminal.ansiBlue": "#7fa5bd",
+        "terminal.ansiCyan": "#8adbb4",
+        "terminal.ansiGreen": "#90a57d",
+        "terminal.ansiMagenta": "#c79ec4",
+        "terminal.ansiRed": "#a36666",
+        "terminal.ansiWhite": "#d0d0d0",
+        "terminal.ansiYellow": "#d7af87",
+        "terminal.ansiBrightBlack": "#4a4845",
+        "terminal.ansiBrightBlue": "#a1bdce",
+        "terminal.ansiBrightCyan": "#b1e7dd",
+        "terminal.ansiBrightGreen": "#afbea2",
+        "terminal.ansiBrightMagenta": "#d7beda",
+        "terminal.ansiBrightRed": "#d78787",
+        "terminal.ansiBrightWhite": "#efefef",
+        "terminal.ansiBrightYellow": "#e4c9af"
+    }
+}

--- a/vscode/Pro Light.json
+++ b/vscode/Pro Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#191919",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#3b75ff",
+        "terminal.ansiCyan": "#4ed2de",
+        "terminal.ansiGreen": "#50d148",
+        "terminal.ansiMagenta": "#ed66e8",
+        "terminal.ansiRed": "#e5492b",
+        "terminal.ansiWhite": "#dcdcdc",
+        "terminal.ansiYellow": "#c6c440",
+        "terminal.ansiBrightBlack": "#9f9f9f",
+        "terminal.ansiBrightBlue": "#0082ff",
+        "terminal.ansiBrightCyan": "#61f7f8",
+        "terminal.ansiBrightGreen": "#61ef57",
+        "terminal.ansiBrightMagenta": "#ff7eff",
+        "terminal.ansiBrightRed": "#ff6640",
+        "terminal.ansiBrightWhite": "#f2f2f2",
+        "terminal.ansiBrightYellow": "#f2f156"
+    }
+}

--- a/vscode/Pro.json
+++ b/vscode/Pro.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f2f2f2",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2009db",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#990000",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#999900",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#00d900",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Purple Rain.json
+++ b/vscode/Purple Rain.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#fffbf6",
+        "terminal.background": "#21084a",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#00a2fa",
+        "terminal.ansiCyan": "#00deef",
+        "terminal.ansiGreen": "#9be205",
+        "terminal.ansiMagenta": "#815bb5",
+        "terminal.ansiRed": "#ff260e",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffc400",
+        "terminal.ansiBrightBlack": "#565656",
+        "terminal.ansiBrightBlue": "#00a6ff",
+        "terminal.ansiBrightCyan": "#74fdf3",
+        "terminal.ansiBrightGreen": "#b8e36e",
+        "terminal.ansiBrightMagenta": "#ac7bf0",
+        "terminal.ansiBrightRed": "#ff4250",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffd852"
+    }
+}

--- a/vscode/Red Alert.json
+++ b/vscode/Red Alert.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#762423",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#489bee",
+        "terminal.ansiCyan": "#6bbeb8",
+        "terminal.ansiGreen": "#71be6b",
+        "terminal.ansiMagenta": "#e979d7",
+        "terminal.ansiRed": "#d62e4e",
+        "terminal.ansiWhite": "#d6d6d6",
+        "terminal.ansiYellow": "#beb86b",
+        "terminal.ansiBrightBlack": "#262626",
+        "terminal.ansiBrightBlue": "#65aaf1",
+        "terminal.ansiBrightCyan": "#b7dfdd",
+        "terminal.ansiBrightGreen": "#aff08c",
+        "terminal.ansiBrightMagenta": "#ddb7df",
+        "terminal.ansiBrightRed": "#e02553",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#dfddb7"
+    }
+}

--- a/vscode/Red Planet.json
+++ b/vscode/Red Planet.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c2b790",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#202020",
+        "terminal.ansiBlue": "#69819e",
+        "terminal.ansiCyan": "#5b8390",
+        "terminal.ansiGreen": "#728271",
+        "terminal.ansiMagenta": "#896492",
+        "terminal.ansiRed": "#8c3432",
+        "terminal.ansiWhite": "#b9aa99",
+        "terminal.ansiYellow": "#e8bf6a",
+        "terminal.ansiBrightBlack": "#676767",
+        "terminal.ansiBrightBlue": "#60827e",
+        "terminal.ansiBrightCyan": "#38add8",
+        "terminal.ansiBrightGreen": "#869985",
+        "terminal.ansiBrightMagenta": "#de4974",
+        "terminal.ansiBrightRed": "#b55242",
+        "terminal.ansiBrightWhite": "#d6bfb8",
+        "terminal.ansiBrightYellow": "#ebeb91"
+    }
+}

--- a/vscode/Red Sands.json
+++ b/vscode/Red Sands.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d7c9a7",
+        "terminal.background": "#7a251e",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0072ff",
+        "terminal.ansiCyan": "#00bbbb",
+        "terminal.ansiGreen": "#00bb00",
+        "terminal.ansiMagenta": "#bb00bb",
+        "terminal.ansiRed": "#ff3f00",
+        "terminal.ansiWhite": "#bbbbbb",
+        "terminal.ansiYellow": "#e7b000",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#0072ae",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#00bb00",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#bb0000",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e7b000"
+    }
+}

--- a/vscode/Relaxed.json
+++ b/vscode/Relaxed.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d9d9d9",
+        "terminal.background": "#353a44",
+        "terminal.ansiBlack": "#151515",
+        "terminal.ansiBlue": "#6a8799",
+        "terminal.ansiCyan": "#c9dfff",
+        "terminal.ansiGreen": "#909d63",
+        "terminal.ansiMagenta": "#b06698",
+        "terminal.ansiRed": "#bc5653",
+        "terminal.ansiWhite": "#d9d9d9",
+        "terminal.ansiYellow": "#ebc17a",
+        "terminal.ansiBrightBlack": "#636363",
+        "terminal.ansiBrightBlue": "#7eaac7",
+        "terminal.ansiBrightCyan": "#acbbd0",
+        "terminal.ansiBrightGreen": "#a0ac77",
+        "terminal.ansiBrightMagenta": "#b06698",
+        "terminal.ansiBrightRed": "#bc5653",
+        "terminal.ansiBrightWhite": "#f7f7f7",
+        "terminal.ansiBrightYellow": "#ebc17a"
+    }
+}

--- a/vscode/Rippedcasts.json
+++ b/vscode/Rippedcasts.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#2b2b2b",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#75a5b0",
+        "terminal.ansiCyan": "#5a647e",
+        "terminal.ansiGreen": "#a8ff60",
+        "terminal.ansiMagenta": "#ff73fd",
+        "terminal.ansiRed": "#cdaf95",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#bfbb1f",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#86bdc9",
+        "terminal.ansiBrightCyan": "#8c9bc4",
+        "terminal.ansiBrightGreen": "#bcee68",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#eecbad",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Royal.json
+++ b/vscode/Royal.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#514968",
+        "terminal.background": "#100815",
+        "terminal.ansiBlack": "#241f2b",
+        "terminal.ansiBlue": "#6580b0",
+        "terminal.ansiCyan": "#8aaabe",
+        "terminal.ansiGreen": "#23801c",
+        "terminal.ansiMagenta": "#674d96",
+        "terminal.ansiRed": "#91284c",
+        "terminal.ansiWhite": "#524966",
+        "terminal.ansiYellow": "#b49d27",
+        "terminal.ansiBrightBlack": "#312d3d",
+        "terminal.ansiBrightBlue": "#90baf9",
+        "terminal.ansiBrightCyan": "#acd4eb",
+        "terminal.ansiBrightGreen": "#2cd946",
+        "terminal.ansiBrightMagenta": "#a479e3",
+        "terminal.ansiBrightRed": "#d5356c",
+        "terminal.ansiBrightWhite": "#9e8cbd",
+        "terminal.ansiBrightYellow": "#fde83b"
+    }
+}

--- a/vscode/Ryuuko.json
+++ b/vscode/Ryuuko.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ececec",
+        "terminal.background": "#2c3941",
+        "terminal.ansiBlack": "#2c3941",
+        "terminal.ansiBlue": "#6a8e95",
+        "terminal.ansiCyan": "#88b2ac",
+        "terminal.ansiGreen": "#66907d",
+        "terminal.ansiMagenta": "#b18a73",
+        "terminal.ansiRed": "#865f5b",
+        "terminal.ansiWhite": "#ececec",
+        "terminal.ansiYellow": "#b1a990",
+        "terminal.ansiBrightBlack": "#5d7079",
+        "terminal.ansiBrightBlue": "#6a8e95",
+        "terminal.ansiBrightCyan": "#88b2ac",
+        "terminal.ansiBrightGreen": "#66907d",
+        "terminal.ansiBrightMagenta": "#b18a73",
+        "terminal.ansiBrightRed": "#865f5b",
+        "terminal.ansiBrightWhite": "#ececec",
+        "terminal.ansiBrightYellow": "#b1a990"
+    }
+}

--- a/vscode/SeaShells.json
+++ b/vscode/SeaShells.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#deb88d",
+        "terminal.background": "#09141b",
+        "terminal.ansiBlack": "#17384c",
+        "terminal.ansiBlue": "#1e4950",
+        "terminal.ansiCyan": "#50a3b5",
+        "terminal.ansiGreen": "#027c9b",
+        "terminal.ansiMagenta": "#68d4f1",
+        "terminal.ansiRed": "#d15123",
+        "terminal.ansiWhite": "#deb88d",
+        "terminal.ansiYellow": "#fca02f",
+        "terminal.ansiBrightBlack": "#434b53",
+        "terminal.ansiBrightBlue": "#1bbcdd",
+        "terminal.ansiBrightCyan": "#87acb4",
+        "terminal.ansiBrightGreen": "#628d98",
+        "terminal.ansiBrightMagenta": "#bbe3ee",
+        "terminal.ansiBrightRed": "#d48678",
+        "terminal.ansiBrightWhite": "#fee4ce",
+        "terminal.ansiBrightYellow": "#fdd39f"
+    }
+}

--- a/vscode/Seafoam Pastel.json
+++ b/vscode/Seafoam Pastel.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d4e7d4",
+        "terminal.background": "#243435",
+        "terminal.ansiBlack": "#757575",
+        "terminal.ansiBlue": "#4d7b82",
+        "terminal.ansiCyan": "#729494",
+        "terminal.ansiGreen": "#728c62",
+        "terminal.ansiMagenta": "#8a7267",
+        "terminal.ansiRed": "#825d4d",
+        "terminal.ansiWhite": "#e0e0e0",
+        "terminal.ansiYellow": "#ada16d",
+        "terminal.ansiBrightBlack": "#8a8a8a",
+        "terminal.ansiBrightBlue": "#7ac3cf",
+        "terminal.ansiBrightCyan": "#ade0e0",
+        "terminal.ansiBrightGreen": "#98d9aa",
+        "terminal.ansiBrightMagenta": "#d6b2a1",
+        "terminal.ansiBrightRed": "#cf937a",
+        "terminal.ansiBrightWhite": "#e0e0e0",
+        "terminal.ansiBrightYellow": "#fae79d"
+    }
+}

--- a/vscode/Seti.json
+++ b/vscode/Seti.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cacecd",
+        "terminal.background": "#111213",
+        "terminal.ansiBlack": "#323232",
+        "terminal.ansiBlue": "#43a5d5",
+        "terminal.ansiCyan": "#8ec43d",
+        "terminal.ansiGreen": "#8ec43d",
+        "terminal.ansiMagenta": "#8b57b5",
+        "terminal.ansiRed": "#c22832",
+        "terminal.ansiWhite": "#eeeeee",
+        "terminal.ansiYellow": "#e0c64f",
+        "terminal.ansiBrightBlack": "#323232",
+        "terminal.ansiBrightBlue": "#43a5d5",
+        "terminal.ansiBrightCyan": "#8ec43d",
+        "terminal.ansiBrightGreen": "#8ec43d",
+        "terminal.ansiBrightMagenta": "#8b57b5",
+        "terminal.ansiBrightRed": "#c22832",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e0c64f"
+    }
+}

--- a/vscode/Shaman.json
+++ b/vscode/Shaman.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#405555",
+        "terminal.background": "#001015",
+        "terminal.ansiBlack": "#012026",
+        "terminal.ansiBlue": "#449a86",
+        "terminal.ansiCyan": "#5d7e19",
+        "terminal.ansiGreen": "#00a941",
+        "terminal.ansiMagenta": "#00599d",
+        "terminal.ansiRed": "#b2302d",
+        "terminal.ansiWhite": "#405555",
+        "terminal.ansiYellow": "#5e8baa",
+        "terminal.ansiBrightBlack": "#384451",
+        "terminal.ansiBrightBlue": "#61d5ba",
+        "terminal.ansiBrightCyan": "#98d028",
+        "terminal.ansiBrightGreen": "#2aea5e",
+        "terminal.ansiBrightMagenta": "#1298ff",
+        "terminal.ansiBrightRed": "#ff4242",
+        "terminal.ansiBrightWhite": "#58fbd6",
+        "terminal.ansiBrightYellow": "#8ed4fd"
+    }
+}

--- a/vscode/Slate.json
+++ b/vscode/Slate.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#35b1d2",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#222222",
+        "terminal.ansiBlue": "#264b49",
+        "terminal.ansiCyan": "#15ab9c",
+        "terminal.ansiGreen": "#81d778",
+        "terminal.ansiMagenta": "#a481d3",
+        "terminal.ansiRed": "#e2a8bf",
+        "terminal.ansiWhite": "#02c5e0",
+        "terminal.ansiYellow": "#c4c9c0",
+        "terminal.ansiBrightBlack": "#ffffff",
+        "terminal.ansiBrightBlue": "#7ab0d2",
+        "terminal.ansiBrightCyan": "#8cdfe0",
+        "terminal.ansiBrightGreen": "#beffa8",
+        "terminal.ansiBrightMagenta": "#c5a7d9",
+        "terminal.ansiBrightRed": "#ffcdd9",
+        "terminal.ansiBrightWhite": "#e0e0e0",
+        "terminal.ansiBrightYellow": "#d0ccca"
+    }
+}

--- a/vscode/Smyck.json
+++ b/vscode/Smyck.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f7f7f7",
+        "terminal.background": "#1b1b1b",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#62a3c4",
+        "terminal.ansiCyan": "#207383",
+        "terminal.ansiGreen": "#7da900",
+        "terminal.ansiMagenta": "#ba8acc",
+        "terminal.ansiRed": "#b84131",
+        "terminal.ansiWhite": "#a1a1a1",
+        "terminal.ansiYellow": "#c4a500",
+        "terminal.ansiBrightBlack": "#7a7a7a",
+        "terminal.ansiBrightBlue": "#8dcff0",
+        "terminal.ansiBrightCyan": "#6ad9cf",
+        "terminal.ansiBrightGreen": "#c4f137",
+        "terminal.ansiBrightMagenta": "#f79aff",
+        "terminal.ansiBrightRed": "#d6837c",
+        "terminal.ansiBrightWhite": "#f7f7f7",
+        "terminal.ansiBrightYellow": "#fee14d"
+    }
+}

--- a/vscode/Snazzy.json
+++ b/vscode/Snazzy.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ebece6",
+        "terminal.background": "#1e1f29",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#49baff",
+        "terminal.ansiCyan": "#8be9fe",
+        "terminal.ansiGreen": "#50fb7c",
+        "terminal.ansiMagenta": "#fc4cb4",
+        "terminal.ansiRed": "#fc4346",
+        "terminal.ansiWhite": "#ededec",
+        "terminal.ansiYellow": "#f0fb8c",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#49baff",
+        "terminal.ansiBrightCyan": "#8be9fe",
+        "terminal.ansiBrightGreen": "#50fb7c",
+        "terminal.ansiBrightMagenta": "#fc4cb4",
+        "terminal.ansiBrightRed": "#fc4346",
+        "terminal.ansiBrightWhite": "#ededec",
+        "terminal.ansiBrightYellow": "#f0fb8c"
+    }
+}

--- a/vscode/SoftServer.json
+++ b/vscode/SoftServer.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#99a3a2",
+        "terminal.background": "#242626",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#6b8fa3",
+        "terminal.ansiCyan": "#6ba58f",
+        "terminal.ansiGreen": "#9aa56a",
+        "terminal.ansiMagenta": "#6a71a3",
+        "terminal.ansiRed": "#a2686a",
+        "terminal.ansiWhite": "#99a3a2",
+        "terminal.ansiYellow": "#a3906a",
+        "terminal.ansiBrightBlack": "#666c6c",
+        "terminal.ansiBrightBlue": "#62b1df",
+        "terminal.ansiBrightCyan": "#64e39c",
+        "terminal.ansiBrightGreen": "#bfdf55",
+        "terminal.ansiBrightMagenta": "#606edf",
+        "terminal.ansiBrightRed": "#dd5c60",
+        "terminal.ansiBrightWhite": "#d2e0de",
+        "terminal.ansiBrightYellow": "#deb360"
+    }
+}

--- a/vscode/Solarized Darcula.json
+++ b/vscode/Solarized Darcula.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d2d8d9",
+        "terminal.background": "#3d3f41",
+        "terminal.ansiBlack": "#25292a",
+        "terminal.ansiBlue": "#2075c7",
+        "terminal.ansiCyan": "#15968d",
+        "terminal.ansiGreen": "#629655",
+        "terminal.ansiMagenta": "#797fd4",
+        "terminal.ansiRed": "#f24840",
+        "terminal.ansiWhite": "#d2d8d9",
+        "terminal.ansiYellow": "#b68800",
+        "terminal.ansiBrightBlack": "#25292a",
+        "terminal.ansiBrightBlue": "#2075c7",
+        "terminal.ansiBrightCyan": "#15968d",
+        "terminal.ansiBrightGreen": "#629655",
+        "terminal.ansiBrightMagenta": "#797fd4",
+        "terminal.ansiBrightRed": "#f24840",
+        "terminal.ansiBrightWhite": "#d2d8d9",
+        "terminal.ansiBrightYellow": "#b68800"
+    }
+}

--- a/vscode/Solarized Dark - Patched.json
+++ b/vscode/Solarized Dark - Patched.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#708284",
+        "terminal.background": "#001e27",
+        "terminal.ansiBlack": "#002831",
+        "terminal.ansiBlue": "#2176c7",
+        "terminal.ansiCyan": "#259286",
+        "terminal.ansiGreen": "#738a05",
+        "terminal.ansiMagenta": "#c61c6f",
+        "terminal.ansiRed": "#d11c24",
+        "terminal.ansiWhite": "#eae3cb",
+        "terminal.ansiYellow": "#a57706",
+        "terminal.ansiBrightBlack": "#475b62",
+        "terminal.ansiBrightBlue": "#708284",
+        "terminal.ansiBrightCyan": "#819090",
+        "terminal.ansiBrightGreen": "#475b62",
+        "terminal.ansiBrightMagenta": "#5956ba",
+        "terminal.ansiBrightRed": "#bd3613",
+        "terminal.ansiBrightWhite": "#fcf4dc",
+        "terminal.ansiBrightYellow": "#536870"
+    }
+}

--- a/vscode/Solarized Dark Higher Contrast.json
+++ b/vscode/Solarized Dark Higher Contrast.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#9cc2c3",
+        "terminal.background": "#001e27",
+        "terminal.ansiBlack": "#002831",
+        "terminal.ansiBlue": "#2176c7",
+        "terminal.ansiCyan": "#259286",
+        "terminal.ansiGreen": "#6cbe6c",
+        "terminal.ansiMagenta": "#c61c6f",
+        "terminal.ansiRed": "#d11c24",
+        "terminal.ansiWhite": "#eae3cb",
+        "terminal.ansiYellow": "#a57706",
+        "terminal.ansiBrightBlack": "#006488",
+        "terminal.ansiBrightBlue": "#178ec8",
+        "terminal.ansiBrightCyan": "#00b39e",
+        "terminal.ansiBrightGreen": "#51ef84",
+        "terminal.ansiBrightMagenta": "#e24d8e",
+        "terminal.ansiBrightRed": "#f5163b",
+        "terminal.ansiBrightWhite": "#fcf4dc",
+        "terminal.ansiBrightYellow": "#b27e28"
+    }
+}

--- a/vscode/SpaceGray Eighties Dull.json
+++ b/vscode/SpaceGray Eighties Dull.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c9c6bc",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#15171c",
+        "terminal.ansiBlue": "#7c8fa5",
+        "terminal.ansiCyan": "#80cdcb",
+        "terminal.ansiGreen": "#92b477",
+        "terminal.ansiMagenta": "#a5789e",
+        "terminal.ansiRed": "#b24a56",
+        "terminal.ansiWhite": "#b3b8c3",
+        "terminal.ansiYellow": "#c6735a",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5486c0",
+        "terminal.ansiBrightCyan": "#58c2c1",
+        "terminal.ansiBrightGreen": "#89e986",
+        "terminal.ansiBrightMagenta": "#bf83c1",
+        "terminal.ansiBrightRed": "#ec5f67",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fec254"
+    }
+}

--- a/vscode/SpaceGray Eighties.json
+++ b/vscode/SpaceGray Eighties.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#bdbaae",
+        "terminal.background": "#222222",
+        "terminal.ansiBlack": "#15171c",
+        "terminal.ansiBlue": "#5486c0",
+        "terminal.ansiCyan": "#57c2c1",
+        "terminal.ansiGreen": "#81a764",
+        "terminal.ansiMagenta": "#bf83c1",
+        "terminal.ansiRed": "#ec5f67",
+        "terminal.ansiWhite": "#efece7",
+        "terminal.ansiYellow": "#fec254",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#4d84d1",
+        "terminal.ansiBrightCyan": "#83e9e4",
+        "terminal.ansiBrightGreen": "#93d493",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff6973",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffd256"
+    }
+}

--- a/vscode/SpaceGray.json
+++ b/vscode/SpaceGray.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b3b8c3",
+        "terminal.background": "#20242d",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#7d8fa4",
+        "terminal.ansiCyan": "#85a7a5",
+        "terminal.ansiGreen": "#87b379",
+        "terminal.ansiMagenta": "#a47996",
+        "terminal.ansiRed": "#b04b57",
+        "terminal.ansiWhite": "#b3b8c3",
+        "terminal.ansiYellow": "#e5c179",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#7d8fa4",
+        "terminal.ansiBrightCyan": "#85a7a5",
+        "terminal.ansiBrightGreen": "#87b379",
+        "terminal.ansiBrightMagenta": "#a47996",
+        "terminal.ansiBrightRed": "#b04b57",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e5c179"
+    }
+}

--- a/vscode/Spacedust.json
+++ b/vscode/Spacedust.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ecf0c1",
+        "terminal.background": "#0a1e24",
+        "terminal.ansiBlack": "#6e5346",
+        "terminal.ansiBlue": "#0f548b",
+        "terminal.ansiCyan": "#06afc7",
+        "terminal.ansiGreen": "#5cab96",
+        "terminal.ansiMagenta": "#e35b00",
+        "terminal.ansiRed": "#e35b00",
+        "terminal.ansiWhite": "#f0f1ce",
+        "terminal.ansiYellow": "#e3cd7b",
+        "terminal.ansiBrightBlack": "#684c31",
+        "terminal.ansiBrightBlue": "#67a0ce",
+        "terminal.ansiBrightCyan": "#83a7b4",
+        "terminal.ansiBrightGreen": "#aecab8",
+        "terminal.ansiBrightMagenta": "#ff8a3a",
+        "terminal.ansiBrightRed": "#ff8a3a",
+        "terminal.ansiBrightWhite": "#fefff1",
+        "terminal.ansiBrightYellow": "#ffc878"
+    }
+}

--- a/vscode/Spiderman.json
+++ b/vscode/Spiderman.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e3e3e3",
+        "terminal.background": "#1b1d1e",
+        "terminal.ansiBlack": "#1b1d1e",
+        "terminal.ansiBlue": "#2c3fff",
+        "terminal.ansiCyan": "#3256ff",
+        "terminal.ansiGreen": "#e22928",
+        "terminal.ansiMagenta": "#2435db",
+        "terminal.ansiRed": "#e60813",
+        "terminal.ansiWhite": "#fffef6",
+        "terminal.ansiYellow": "#e24756",
+        "terminal.ansiBrightBlack": "#505354",
+        "terminal.ansiBrightBlue": "#1d50ff",
+        "terminal.ansiBrightCyan": "#6184ff",
+        "terminal.ansiBrightGreen": "#ff3338",
+        "terminal.ansiBrightMagenta": "#747cff",
+        "terminal.ansiBrightRed": "#ff0325",
+        "terminal.ansiBrightWhite": "#fffff9",
+        "terminal.ansiBrightYellow": "#fe3a35"
+    }
+}

--- a/vscode/Spring.json
+++ b/vscode/Spring.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#4d4d4c",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#1dd3ee",
+        "terminal.ansiCyan": "#3e999f",
+        "terminal.ansiGreen": "#1f8c3b",
+        "terminal.ansiMagenta": "#8959a8",
+        "terminal.ansiRed": "#ff4d83",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#1fc95b",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#15a9fd",
+        "terminal.ansiBrightCyan": "#3e999f",
+        "terminal.ansiBrightGreen": "#1fc231",
+        "terminal.ansiBrightMagenta": "#8959a8",
+        "terminal.ansiBrightRed": "#ff0021",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#d5b807"
+    }
+}

--- a/vscode/Square.json
+++ b/vscode/Square.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#acacab",
+        "terminal.background": "#1a1a1a",
+        "terminal.ansiBlack": "#050505",
+        "terminal.ansiBlue": "#a9cdeb",
+        "terminal.ansiCyan": "#c9caec",
+        "terminal.ansiGreen": "#b6377d",
+        "terminal.ansiMagenta": "#75507b",
+        "terminal.ansiRed": "#e9897c",
+        "terminal.ansiWhite": "#f2f2f2",
+        "terminal.ansiYellow": "#ecebbe",
+        "terminal.ansiBrightBlack": "#141414",
+        "terminal.ansiBrightBlue": "#b6defb",
+        "terminal.ansiBrightCyan": "#d7d9fc",
+        "terminal.ansiBrightGreen": "#c3f786",
+        "terminal.ansiBrightMagenta": "#ad7fa8",
+        "terminal.ansiBrightRed": "#f99286",
+        "terminal.ansiBrightWhite": "#e2e2e2",
+        "terminal.ansiBrightYellow": "#fcfbcc"
+    }
+}

--- a/vscode/Subliminal.json
+++ b/vscode/Subliminal.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d4d4d4",
+        "terminal.background": "#282c35",
+        "terminal.ansiBlack": "#7f7f7f",
+        "terminal.ansiBlue": "#6699cc",
+        "terminal.ansiCyan": "#5fb3b3",
+        "terminal.ansiGreen": "#a9cfa4",
+        "terminal.ansiMagenta": "#f1a5ab",
+        "terminal.ansiRed": "#e15a60",
+        "terminal.ansiWhite": "#d4d4d4",
+        "terminal.ansiYellow": "#ffe2a9",
+        "terminal.ansiBrightBlack": "#7f7f7f",
+        "terminal.ansiBrightBlue": "#6699cc",
+        "terminal.ansiBrightCyan": "#5fb3b3",
+        "terminal.ansiBrightGreen": "#a9cfa4",
+        "terminal.ansiBrightMagenta": "#f1a5ab",
+        "terminal.ansiBrightRed": "#e15a60",
+        "terminal.ansiBrightWhite": "#d4d4d4",
+        "terminal.ansiBrightYellow": "#ffe2a9"
+    }
+}

--- a/vscode/Sundried.json
+++ b/vscode/Sundried.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c9c9c9",
+        "terminal.background": "#1a1818",
+        "terminal.ansiBlack": "#302b2a",
+        "terminal.ansiBlue": "#485b98",
+        "terminal.ansiCyan": "#9c814f",
+        "terminal.ansiGreen": "#587744",
+        "terminal.ansiMagenta": "#864651",
+        "terminal.ansiRed": "#a7463d",
+        "terminal.ansiWhite": "#c9c9c9",
+        "terminal.ansiYellow": "#9d602a",
+        "terminal.ansiBrightBlack": "#4d4e48",
+        "terminal.ansiBrightBlue": "#7999f7",
+        "terminal.ansiBrightCyan": "#fad484",
+        "terminal.ansiBrightGreen": "#128c21",
+        "terminal.ansiBrightMagenta": "#fd8aa1",
+        "terminal.ansiBrightRed": "#aa000c",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fc6a21"
+    }
+}

--- a/vscode/Symfonic.json
+++ b/vscode/Symfonic.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0084d4",
+        "terminal.ansiCyan": "#ccccff",
+        "terminal.ansiGreen": "#56db3a",
+        "terminal.ansiMagenta": "#b729d9",
+        "terminal.ansiRed": "#dc322f",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ff8400",
+        "terminal.ansiBrightBlack": "#1b1d21",
+        "terminal.ansiBrightBlue": "#0084d4",
+        "terminal.ansiBrightCyan": "#ccccff",
+        "terminal.ansiBrightGreen": "#56db3a",
+        "terminal.ansiBrightMagenta": "#b729d9",
+        "terminal.ansiBrightRed": "#dc322f",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ff8400"
+    }
+}

--- a/vscode/Tango Adapted.json
+++ b/vscode/Tango Adapted.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#00a2ff",
+        "terminal.ansiCyan": "#00d0d6",
+        "terminal.ansiGreen": "#59d600",
+        "terminal.ansiMagenta": "#c17ecc",
+        "terminal.ansiRed": "#ff0000",
+        "terminal.ansiWhite": "#e6ebe1",
+        "terminal.ansiYellow": "#f0cb00",
+        "terminal.ansiBrightBlack": "#8f928b",
+        "terminal.ansiBrightBlue": "#88c9ff",
+        "terminal.ansiBrightCyan": "#00feff",
+        "terminal.ansiBrightGreen": "#93ff00",
+        "terminal.ansiBrightMagenta": "#e9a7e1",
+        "terminal.ansiBrightRed": "#ff0013",
+        "terminal.ansiBrightWhite": "#f6f6f4",
+        "terminal.ansiBrightYellow": "#fff121"
+    }
+}

--- a/vscode/Tango Half Adapted.json
+++ b/vscode/Tango Half Adapted.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#008ef6",
+        "terminal.ansiCyan": "#00bdc3",
+        "terminal.ansiGreen": "#4cc300",
+        "terminal.ansiMagenta": "#a96cb3",
+        "terminal.ansiRed": "#ff0000",
+        "terminal.ansiWhite": "#e0e5db",
+        "terminal.ansiYellow": "#e2c000",
+        "terminal.ansiBrightBlack": "#797d76",
+        "terminal.ansiBrightBlue": "#76bfff",
+        "terminal.ansiBrightCyan": "#00f6fa",
+        "terminal.ansiBrightGreen": "#8af600",
+        "terminal.ansiBrightMagenta": "#d898d1",
+        "terminal.ansiBrightRed": "#ff0013",
+        "terminal.ansiBrightWhite": "#f4f4f2",
+        "terminal.ansiBrightYellow": "#ffec00"
+    }
+}

--- a/vscode/Teerb.json
+++ b/vscode/Teerb.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#d0d0d0",
+        "terminal.background": "#262626",
+        "terminal.ansiBlack": "#1c1c1c",
+        "terminal.ansiBlue": "#86aed6",
+        "terminal.ansiCyan": "#8adbb4",
+        "terminal.ansiGreen": "#aed686",
+        "terminal.ansiMagenta": "#d6aed6",
+        "terminal.ansiRed": "#d68686",
+        "terminal.ansiWhite": "#d0d0d0",
+        "terminal.ansiYellow": "#d7af87",
+        "terminal.ansiBrightBlack": "#1c1c1c",
+        "terminal.ansiBrightBlue": "#86aed6",
+        "terminal.ansiBrightCyan": "#b1e7dd",
+        "terminal.ansiBrightGreen": "#aed686",
+        "terminal.ansiBrightMagenta": "#d6aed6",
+        "terminal.ansiBrightRed": "#d68686",
+        "terminal.ansiBrightWhite": "#efefef",
+        "terminal.ansiBrightYellow": "#e4c9af"
+    }
+}

--- a/vscode/Terminal Basic.json
+++ b/vscode/Terminal Basic.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#0000b2",
+        "terminal.ansiCyan": "#00a6b2",
+        "terminal.ansiGreen": "#00a600",
+        "terminal.ansiMagenta": "#b200b2",
+        "terminal.ansiRed": "#990000",
+        "terminal.ansiWhite": "#bfbfbf",
+        "terminal.ansiYellow": "#999900",
+        "terminal.ansiBrightBlack": "#666666",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00e5e5",
+        "terminal.ansiBrightGreen": "#00d900",
+        "terminal.ansiBrightMagenta": "#e500e5",
+        "terminal.ansiBrightRed": "#e50000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#e5e500"
+    }
+}

--- a/vscode/Thayer Bright.json
+++ b/vscode/Thayer Bright.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#f8f8f8",
+        "terminal.background": "#1b1d1e",
+        "terminal.ansiBlack": "#1b1d1e",
+        "terminal.ansiBlue": "#2757d6",
+        "terminal.ansiCyan": "#38c8b5",
+        "terminal.ansiGreen": "#4df840",
+        "terminal.ansiMagenta": "#8c54fe",
+        "terminal.ansiRed": "#f92672",
+        "terminal.ansiWhite": "#ccccc6",
+        "terminal.ansiYellow": "#f4fd22",
+        "terminal.ansiBrightBlack": "#505354",
+        "terminal.ansiBrightBlue": "#3f78ff",
+        "terminal.ansiBrightCyan": "#23cfd5",
+        "terminal.ansiBrightGreen": "#b6e354",
+        "terminal.ansiBrightMagenta": "#9e6ffe",
+        "terminal.ansiBrightRed": "#ff5995",
+        "terminal.ansiBrightWhite": "#f8f8f2",
+        "terminal.ansiBrightYellow": "#feed6c"
+    }
+}

--- a/vscode/The Hulk.json
+++ b/vscode/The Hulk.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b5b5b5",
+        "terminal.background": "#1b1d1e",
+        "terminal.ansiBlack": "#1b1d1e",
+        "terminal.ansiBlue": "#2525f5",
+        "terminal.ansiCyan": "#378ca9",
+        "terminal.ansiGreen": "#13ce30",
+        "terminal.ansiMagenta": "#641f74",
+        "terminal.ansiRed": "#269d1b",
+        "terminal.ansiWhite": "#d9d8d1",
+        "terminal.ansiYellow": "#63e457",
+        "terminal.ansiBrightBlack": "#505354",
+        "terminal.ansiBrightBlue": "#506b95",
+        "terminal.ansiBrightCyan": "#4085a6",
+        "terminal.ansiBrightGreen": "#48ff77",
+        "terminal.ansiBrightMagenta": "#72589d",
+        "terminal.ansiBrightRed": "#8dff2a",
+        "terminal.ansiBrightWhite": "#e5e6e1",
+        "terminal.ansiBrightYellow": "#3afe16"
+    }
+}

--- a/vscode/Tomorrow Night Blue.json
+++ b/vscode/Tomorrow Night Blue.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#002451",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#bbdaff",
+        "terminal.ansiCyan": "#99ffff",
+        "terminal.ansiGreen": "#d1f1a9",
+        "terminal.ansiMagenta": "#ebbbff",
+        "terminal.ansiRed": "#ff9da4",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffeead",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#bbdaff",
+        "terminal.ansiBrightCyan": "#99ffff",
+        "terminal.ansiBrightGreen": "#d1f1a9",
+        "terminal.ansiBrightMagenta": "#ebbbff",
+        "terminal.ansiBrightRed": "#ff9da4",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffeead"
+    }
+}

--- a/vscode/Tomorrow Night Bright.json
+++ b/vscode/Tomorrow Night Bright.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#eaeaea",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#7aa6da",
+        "terminal.ansiCyan": "#70c0b1",
+        "terminal.ansiGreen": "#b9ca4a",
+        "terminal.ansiMagenta": "#c397d8",
+        "terminal.ansiRed": "#d54e53",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#e7c547",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#7aa6da",
+        "terminal.ansiBrightCyan": "#70c0b1",
+        "terminal.ansiBrightGreen": "#b9ca4a",
+        "terminal.ansiBrightMagenta": "#c397d8",
+        "terminal.ansiBrightRed": "#d54e53",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e7c547"
+    }
+}

--- a/vscode/Tomorrow Night Burns.json
+++ b/vscode/Tomorrow Night Burns.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#a1b0b8",
+        "terminal.background": "#151515",
+        "terminal.ansiBlack": "#252525",
+        "terminal.ansiBlue": "#fc595f",
+        "terminal.ansiCyan": "#ba8586",
+        "terminal.ansiGreen": "#a63c40",
+        "terminal.ansiMagenta": "#df9395",
+        "terminal.ansiRed": "#832e31",
+        "terminal.ansiWhite": "#f5f5f5",
+        "terminal.ansiYellow": "#d3494e",
+        "terminal.ansiBrightBlack": "#5d6f71",
+        "terminal.ansiBrightBlue": "#fc595f",
+        "terminal.ansiBrightCyan": "#ba8586",
+        "terminal.ansiBrightGreen": "#a63c40",
+        "terminal.ansiBrightMagenta": "#df9395",
+        "terminal.ansiBrightRed": "#832e31",
+        "terminal.ansiBrightWhite": "#f5f5f5",
+        "terminal.ansiBrightYellow": "#d2494e"
+    }
+}

--- a/vscode/Tomorrow Night Eighties.json
+++ b/vscode/Tomorrow Night Eighties.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cccccc",
+        "terminal.background": "#2d2d2d",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#6699cc",
+        "terminal.ansiCyan": "#66cccc",
+        "terminal.ansiGreen": "#99cc99",
+        "terminal.ansiMagenta": "#cc99cc",
+        "terminal.ansiRed": "#f2777a",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffcc66",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#6699cc",
+        "terminal.ansiBrightCyan": "#66cccc",
+        "terminal.ansiBrightGreen": "#99cc99",
+        "terminal.ansiBrightMagenta": "#cc99cc",
+        "terminal.ansiBrightRed": "#f2777a",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffcc66"
+    }
+}

--- a/vscode/Tomorrow Night.json
+++ b/vscode/Tomorrow Night.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c5c8c6",
+        "terminal.background": "#1d1f21",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#81a2be",
+        "terminal.ansiCyan": "#8abeb7",
+        "terminal.ansiGreen": "#b5bd68",
+        "terminal.ansiMagenta": "#b294bb",
+        "terminal.ansiRed": "#cc6666",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f0c674",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#81a2be",
+        "terminal.ansiBrightCyan": "#8abeb7",
+        "terminal.ansiBrightGreen": "#b5bd68",
+        "terminal.ansiBrightMagenta": "#b294bb",
+        "terminal.ansiBrightRed": "#cc6666",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f0c674"
+    }
+}

--- a/vscode/Tomorrow.json
+++ b/vscode/Tomorrow.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#4d4d4c",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#4271ae",
+        "terminal.ansiCyan": "#3e999f",
+        "terminal.ansiGreen": "#718c00",
+        "terminal.ansiMagenta": "#8959a8",
+        "terminal.ansiRed": "#c82829",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#eab700",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#4271ae",
+        "terminal.ansiBrightCyan": "#3e999f",
+        "terminal.ansiBrightGreen": "#718c00",
+        "terminal.ansiBrightMagenta": "#8959a8",
+        "terminal.ansiBrightRed": "#c82829",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#eab700"
+    }
+}

--- a/vscode/ToyChest.json
+++ b/vscode/ToyChest.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#31d07b",
+        "terminal.background": "#24364b",
+        "terminal.ansiBlack": "#2c3f58",
+        "terminal.ansiBlue": "#325d96",
+        "terminal.ansiCyan": "#35a08f",
+        "terminal.ansiGreen": "#1a9172",
+        "terminal.ansiMagenta": "#8a5edc",
+        "terminal.ansiRed": "#be2d26",
+        "terminal.ansiWhite": "#23d183",
+        "terminal.ansiYellow": "#db8e27",
+        "terminal.ansiBrightBlack": "#336889",
+        "terminal.ansiBrightBlue": "#34a6da",
+        "terminal.ansiBrightCyan": "#42c3ae",
+        "terminal.ansiBrightGreen": "#31d07b",
+        "terminal.ansiBrightMagenta": "#ae6bdc",
+        "terminal.ansiBrightRed": "#dd5944",
+        "terminal.ansiBrightWhite": "#d5d5d5",
+        "terminal.ansiBrightYellow": "#e7d84b"
+    }
+}

--- a/vscode/Treehouse.json
+++ b/vscode/Treehouse.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#786b53",
+        "terminal.background": "#191919",
+        "terminal.ansiBlack": "#321300",
+        "terminal.ansiBlue": "#58859a",
+        "terminal.ansiCyan": "#b25a1e",
+        "terminal.ansiGreen": "#44a900",
+        "terminal.ansiMagenta": "#97363d",
+        "terminal.ansiRed": "#b2270e",
+        "terminal.ansiWhite": "#786b53",
+        "terminal.ansiYellow": "#aa820c",
+        "terminal.ansiBrightBlack": "#433626",
+        "terminal.ansiBrightBlue": "#85cfed",
+        "terminal.ansiBrightCyan": "#f07d14",
+        "terminal.ansiBrightGreen": "#55f238",
+        "terminal.ansiBrightMagenta": "#e14c5a",
+        "terminal.ansiBrightRed": "#ed5d20",
+        "terminal.ansiBrightWhite": "#ffc800",
+        "terminal.ansiBrightYellow": "#f2b732"
+    }
+}

--- a/vscode/Twilight.json
+++ b/vscode/Twilight.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffd4",
+        "terminal.background": "#141414",
+        "terminal.ansiBlack": "#141414",
+        "terminal.ansiBlue": "#44474a",
+        "terminal.ansiCyan": "#778385",
+        "terminal.ansiGreen": "#afb97a",
+        "terminal.ansiMagenta": "#b4be7c",
+        "terminal.ansiRed": "#c06d44",
+        "terminal.ansiWhite": "#ffffd4",
+        "terminal.ansiYellow": "#c2a86c",
+        "terminal.ansiBrightBlack": "#262626",
+        "terminal.ansiBrightBlue": "#5a5e62",
+        "terminal.ansiBrightCyan": "#8a989b",
+        "terminal.ansiBrightGreen": "#ccd88c",
+        "terminal.ansiBrightMagenta": "#d0dc8e",
+        "terminal.ansiBrightRed": "#de7c4c",
+        "terminal.ansiBrightWhite": "#ffffd4",
+        "terminal.ansiBrightYellow": "#e2c47e"
+    }
+}

--- a/vscode/Ubuntu.json
+++ b/vscode/Ubuntu.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#eeeeec",
+        "terminal.background": "#300a24",
+        "terminal.ansiBlack": "#2e3436",
+        "terminal.ansiBlue": "#3465a4",
+        "terminal.ansiCyan": "#06989a",
+        "terminal.ansiGreen": "#4e9a06",
+        "terminal.ansiMagenta": "#75507b",
+        "terminal.ansiRed": "#cc0000",
+        "terminal.ansiWhite": "#d3d7cf",
+        "terminal.ansiYellow": "#c4a000",
+        "terminal.ansiBrightBlack": "#555753",
+        "terminal.ansiBrightBlue": "#729fcf",
+        "terminal.ansiBrightCyan": "#34e2e2",
+        "terminal.ansiBrightGreen": "#8ae234",
+        "terminal.ansiBrightMagenta": "#ad7fa8",
+        "terminal.ansiBrightRed": "#ef2929",
+        "terminal.ansiBrightWhite": "#eeeeec",
+        "terminal.ansiBrightYellow": "#fce94f"
+    }
+}

--- a/vscode/UltraViolent.json
+++ b/vscode/UltraViolent.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#c1c1c1",
+        "terminal.background": "#242728",
+        "terminal.ansiBlack": "#242728",
+        "terminal.ansiBlue": "#47e0fb",
+        "terminal.ansiCyan": "#0effbb",
+        "terminal.ansiGreen": "#b6ff00",
+        "terminal.ansiMagenta": "#d731ff",
+        "terminal.ansiRed": "#ff0090",
+        "terminal.ansiWhite": "#e1e1e1",
+        "terminal.ansiYellow": "#fff727",
+        "terminal.ansiBrightBlack": "#636667",
+        "terminal.ansiBrightBlue": "#7fecff",
+        "terminal.ansiBrightCyan": "#69fcd3",
+        "terminal.ansiBrightGreen": "#deff8c",
+        "terminal.ansiBrightMagenta": "#e681ff",
+        "terminal.ansiBrightRed": "#fb58b4",
+        "terminal.ansiBrightWhite": "#f9f9f5",
+        "terminal.ansiBrightYellow": "#ebe087"
+    }
+}

--- a/vscode/UnderTheSea.json
+++ b/vscode/UnderTheSea.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#011116",
+        "terminal.ansiBlack": "#022026",
+        "terminal.ansiBlue": "#459a86",
+        "terminal.ansiCyan": "#5d7e19",
+        "terminal.ansiGreen": "#00a941",
+        "terminal.ansiMagenta": "#00599d",
+        "terminal.ansiRed": "#b2302d",
+        "terminal.ansiWhite": "#405555",
+        "terminal.ansiYellow": "#59819c",
+        "terminal.ansiBrightBlack": "#384451",
+        "terminal.ansiBrightBlue": "#61d5ba",
+        "terminal.ansiBrightCyan": "#98d028",
+        "terminal.ansiBrightGreen": "#2aea5e",
+        "terminal.ansiBrightMagenta": "#1298ff",
+        "terminal.ansiBrightRed": "#ff4242",
+        "terminal.ansiBrightWhite": "#58fbd6",
+        "terminal.ansiBrightYellow": "#8ed4fd"
+    }
+}

--- a/vscode/Unikitty.json
+++ b/vscode/Unikitty.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#0b0b0b",
+        "terminal.background": "#ff8cd9",
+        "terminal.ansiBlack": "#0c0c0c",
+        "terminal.ansiBlue": "#145fcd",
+        "terminal.ansiCyan": "#6bd1bc",
+        "terminal.ansiGreen": "#bafc8b",
+        "terminal.ansiMagenta": "#ff36a2",
+        "terminal.ansiRed": "#a80f20",
+        "terminal.ansiWhite": "#e2d7e1",
+        "terminal.ansiYellow": "#eedf4b",
+        "terminal.ansiBrightBlack": "#434343",
+        "terminal.ansiBrightBlue": "#0075ea",
+        "terminal.ansiBrightCyan": "#79ecd5",
+        "terminal.ansiBrightGreen": "#d3ffaf",
+        "terminal.ansiBrightMagenta": "#fdd5e5",
+        "terminal.ansiBrightRed": "#d91329",
+        "terminal.ansiBrightWhite": "#fff3fe",
+        "terminal.ansiBrightYellow": "#ffef50"
+    }
+}

--- a/vscode/Urple.json
+++ b/vscode/Urple.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#877a9b",
+        "terminal.background": "#1b1b23",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#564d9b",
+        "terminal.ansiCyan": "#808080",
+        "terminal.ansiGreen": "#37a415",
+        "terminal.ansiMagenta": "#6c3ca1",
+        "terminal.ansiRed": "#b0425b",
+        "terminal.ansiWhite": "#87799c",
+        "terminal.ansiYellow": "#ad5c42",
+        "terminal.ansiBrightBlack": "#5d3225",
+        "terminal.ansiBrightBlue": "#867aed",
+        "terminal.ansiBrightCyan": "#eaeaea",
+        "terminal.ansiBrightGreen": "#29e620",
+        "terminal.ansiBrightMagenta": "#a05eee",
+        "terminal.ansiBrightRed": "#ff6388",
+        "terminal.ansiBrightWhite": "#bfa3ff",
+        "terminal.ansiBrightYellow": "#f08161"
+    }
+}

--- a/vscode/Vaughn.json
+++ b/vscode/Vaughn.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dcdccc",
+        "terminal.background": "#25234f",
+        "terminal.ansiBlack": "#25234f",
+        "terminal.ansiBlue": "#5555ff",
+        "terminal.ansiCyan": "#8cd0d3",
+        "terminal.ansiGreen": "#60b48a",
+        "terminal.ansiMagenta": "#f08cc3",
+        "terminal.ansiRed": "#705050",
+        "terminal.ansiWhite": "#709080",
+        "terminal.ansiYellow": "#dfaf8f",
+        "terminal.ansiBrightBlack": "#709080",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#93e0e3",
+        "terminal.ansiBrightGreen": "#60b48a",
+        "terminal.ansiBrightMagenta": "#ec93d3",
+        "terminal.ansiBrightRed": "#dca3a3",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f0dfaf"
+    }
+}

--- a/vscode/VibrantInk.json
+++ b/vscode/VibrantInk.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#878787",
+        "terminal.ansiBlue": "#44b4cc",
+        "terminal.ansiCyan": "#44b4cc",
+        "terminal.ansiGreen": "#ccff04",
+        "terminal.ansiMagenta": "#9933cc",
+        "terminal.ansiRed": "#ff6600",
+        "terminal.ansiWhite": "#f5f5f5",
+        "terminal.ansiYellow": "#ffcc00",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#0000ff",
+        "terminal.ansiBrightCyan": "#00ffff",
+        "terminal.ansiBrightGreen": "#00ff00",
+        "terminal.ansiBrightMagenta": "#ff00ff",
+        "terminal.ansiBrightRed": "#ff0000",
+        "terminal.ansiBrightWhite": "#e5e5e5",
+        "terminal.ansiBrightYellow": "#ffff00"
+    }
+}

--- a/vscode/Violet Dark.json
+++ b/vscode/Violet Dark.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#708284",
+        "terminal.background": "#1c1d1f",
+        "terminal.ansiBlack": "#56595c",
+        "terminal.ansiBlue": "#2e8bce",
+        "terminal.ansiCyan": "#32a198",
+        "terminal.ansiGreen": "#85981c",
+        "terminal.ansiMagenta": "#d13a82",
+        "terminal.ansiRed": "#c94c22",
+        "terminal.ansiWhite": "#c9c6bd",
+        "terminal.ansiYellow": "#b4881d",
+        "terminal.ansiBrightBlack": "#45484b",
+        "terminal.ansiBrightBlue": "#2176c7",
+        "terminal.ansiBrightCyan": "#259286",
+        "terminal.ansiBrightGreen": "#738a04",
+        "terminal.ansiBrightMagenta": "#c61c6f",
+        "terminal.ansiBrightRed": "#bd3613",
+        "terminal.ansiBrightWhite": "#c9c6bd",
+        "terminal.ansiBrightYellow": "#a57705"
+    }
+}

--- a/vscode/Violet Light.json
+++ b/vscode/Violet Light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#536870",
+        "terminal.background": "#fcf4dc",
+        "terminal.ansiBlack": "#56595c",
+        "terminal.ansiBlue": "#2e8bce",
+        "terminal.ansiCyan": "#32a198",
+        "terminal.ansiGreen": "#85981c",
+        "terminal.ansiMagenta": "#d13a82",
+        "terminal.ansiRed": "#c94c22",
+        "terminal.ansiWhite": "#d3d0c9",
+        "terminal.ansiYellow": "#b4881d",
+        "terminal.ansiBrightBlack": "#45484b",
+        "terminal.ansiBrightBlue": "#2176c7",
+        "terminal.ansiBrightCyan": "#259286",
+        "terminal.ansiBrightGreen": "#738a04",
+        "terminal.ansiBrightMagenta": "#c61c6f",
+        "terminal.ansiBrightRed": "#bd3613",
+        "terminal.ansiBrightWhite": "#c9c6bd",
+        "terminal.ansiBrightYellow": "#a57705"
+    }
+}

--- a/vscode/WarmNeon.json
+++ b/vscode/WarmNeon.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#afdab6",
+        "terminal.background": "#404040",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#4261c5",
+        "terminal.ansiCyan": "#2abbd4",
+        "terminal.ansiGreen": "#39b13a",
+        "terminal.ansiMagenta": "#f920fb",
+        "terminal.ansiRed": "#e24346",
+        "terminal.ansiWhite": "#d0b8a3",
+        "terminal.ansiYellow": "#dae145",
+        "terminal.ansiBrightBlack": "#fefcfc",
+        "terminal.ansiBrightBlue": "#7b91d6",
+        "terminal.ansiBrightCyan": "#5ed1e5",
+        "terminal.ansiBrightGreen": "#9cc090",
+        "terminal.ansiBrightMagenta": "#f674ba",
+        "terminal.ansiBrightRed": "#e97071",
+        "terminal.ansiBrightWhite": "#d8c8bb",
+        "terminal.ansiBrightYellow": "#ddda7a"
+    }
+}

--- a/vscode/Wez.json
+++ b/vscode/Wez.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b3b3b3",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#5555cc",
+        "terminal.ansiCyan": "#7acaca",
+        "terminal.ansiGreen": "#55cc55",
+        "terminal.ansiMagenta": "#cc55cc",
+        "terminal.ansiRed": "#cc5555",
+        "terminal.ansiWhite": "#cccccc",
+        "terminal.ansiYellow": "#cdcd55",
+        "terminal.ansiBrightBlack": "#555555",
+        "terminal.ansiBrightBlue": "#5555ff",
+        "terminal.ansiBrightCyan": "#55ffff",
+        "terminal.ansiBrightGreen": "#55ff55",
+        "terminal.ansiBrightMagenta": "#ff55ff",
+        "terminal.ansiBrightRed": "#ff5555",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffff55"
+    }
+}

--- a/vscode/Whimsy.json
+++ b/vscode/Whimsy.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#b3b0d6",
+        "terminal.background": "#29283b",
+        "terminal.ansiBlack": "#535178",
+        "terminal.ansiBlue": "#65aef7",
+        "terminal.ansiCyan": "#43c1be",
+        "terminal.ansiGreen": "#5eca89",
+        "terminal.ansiMagenta": "#aa7ff0",
+        "terminal.ansiRed": "#ef6487",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fdd877",
+        "terminal.ansiBrightBlack": "#535178",
+        "terminal.ansiBrightBlue": "#65aef7",
+        "terminal.ansiBrightCyan": "#43c1be",
+        "terminal.ansiBrightGreen": "#5eca89",
+        "terminal.ansiBrightMagenta": "#aa7ff0",
+        "terminal.ansiBrightRed": "#ef6487",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fdd877"
+    }
+}

--- a/vscode/WildCherry.json
+++ b/vscode/WildCherry.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dafaff",
+        "terminal.background": "#1f1726",
+        "terminal.ansiBlack": "#000507",
+        "terminal.ansiBlue": "#883cdc",
+        "terminal.ansiCyan": "#c1b8b7",
+        "terminal.ansiGreen": "#2ab250",
+        "terminal.ansiMagenta": "#ececec",
+        "terminal.ansiRed": "#d94085",
+        "terminal.ansiWhite": "#fff8de",
+        "terminal.ansiYellow": "#ffd16f",
+        "terminal.ansiBrightBlack": "#009cc9",
+        "terminal.ansiBrightBlue": "#308cba",
+        "terminal.ansiBrightCyan": "#ff919d",
+        "terminal.ansiBrightGreen": "#f4dca5",
+        "terminal.ansiBrightMagenta": "#ae636b",
+        "terminal.ansiBrightRed": "#da6bac",
+        "terminal.ansiBrightWhite": "#e4838d",
+        "terminal.ansiBrightYellow": "#eac066"
+    }
+}

--- a/vscode/Wombat.json
+++ b/vscode/Wombat.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dedacf",
+        "terminal.background": "#171717",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#5da9f6",
+        "terminal.ansiCyan": "#82fff7",
+        "terminal.ansiGreen": "#b1e969",
+        "terminal.ansiMagenta": "#e86aff",
+        "terminal.ansiRed": "#ff615a",
+        "terminal.ansiWhite": "#dedacf",
+        "terminal.ansiYellow": "#ebd99c",
+        "terminal.ansiBrightBlack": "#313131",
+        "terminal.ansiBrightBlue": "#a5c7ff",
+        "terminal.ansiBrightCyan": "#b7fff9",
+        "terminal.ansiBrightGreen": "#ddf88f",
+        "terminal.ansiBrightMagenta": "#ddaaff",
+        "terminal.ansiBrightRed": "#f58c80",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#eee5b2"
+    }
+}

--- a/vscode/Wryan.json
+++ b/vscode/Wryan.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#999993",
+        "terminal.background": "#101010",
+        "terminal.ansiBlack": "#333333",
+        "terminal.ansiBlue": "#395573",
+        "terminal.ansiCyan": "#31658c",
+        "terminal.ansiGreen": "#287373",
+        "terminal.ansiMagenta": "#5e468c",
+        "terminal.ansiRed": "#8c4665",
+        "terminal.ansiWhite": "#899ca1",
+        "terminal.ansiYellow": "#7c7c99",
+        "terminal.ansiBrightBlack": "#3d3d3d",
+        "terminal.ansiBrightBlue": "#477ab3",
+        "terminal.ansiBrightCyan": "#6096bf",
+        "terminal.ansiBrightGreen": "#53a6a6",
+        "terminal.ansiBrightMagenta": "#7e62b3",
+        "terminal.ansiBrightRed": "#bf4d80",
+        "terminal.ansiBrightWhite": "#c0c0c0",
+        "terminal.ansiBrightYellow": "#9e9ecb"
+    }
+}

--- a/vscode/Zenburn.json
+++ b/vscode/Zenburn.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dcdccc",
+        "terminal.background": "#3f3f3f",
+        "terminal.ansiBlack": "#4d4d4d",
+        "terminal.ansiBlue": "#506070",
+        "terminal.ansiCyan": "#8cd0d3",
+        "terminal.ansiGreen": "#60b48a",
+        "terminal.ansiMagenta": "#dc8cc3",
+        "terminal.ansiRed": "#705050",
+        "terminal.ansiWhite": "#dcdccc",
+        "terminal.ansiYellow": "#f0dfaf",
+        "terminal.ansiBrightBlack": "#709080",
+        "terminal.ansiBrightBlue": "#94bff3",
+        "terminal.ansiBrightCyan": "#93e0e3",
+        "terminal.ansiBrightGreen": "#c3bf9f",
+        "terminal.ansiBrightMagenta": "#ec93d3",
+        "terminal.ansiBrightRed": "#dca3a3",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#e0cf9f"
+    }
+}

--- a/vscode/ayu.json
+++ b/vscode/ayu.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e6e1cf",
+        "terminal.background": "#0f1419",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#36a3d9",
+        "terminal.ansiCyan": "#95e6cb",
+        "terminal.ansiGreen": "#b8cc52",
+        "terminal.ansiMagenta": "#f07178",
+        "terminal.ansiRed": "#ff3333",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#e7c547",
+        "terminal.ansiBrightBlack": "#323232",
+        "terminal.ansiBrightBlue": "#68d5ff",
+        "terminal.ansiBrightCyan": "#c7fffd",
+        "terminal.ansiBrightGreen": "#eafe84",
+        "terminal.ansiBrightMagenta": "#ffa3aa",
+        "terminal.ansiBrightRed": "#ff6565",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff779"
+    }
+}

--- a/vscode/ayu_light.json
+++ b/vscode/ayu_light.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#5c6773",
+        "terminal.background": "#fafafa",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#41a6d9",
+        "terminal.ansiCyan": "#4dbf99",
+        "terminal.ansiGreen": "#86b300",
+        "terminal.ansiMagenta": "#f07178",
+        "terminal.ansiRed": "#ff3333",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f29718",
+        "terminal.ansiBrightBlack": "#323232",
+        "terminal.ansiBrightBlue": "#73d8ff",
+        "terminal.ansiBrightCyan": "#7ff1cb",
+        "terminal.ansiBrightGreen": "#b8e532",
+        "terminal.ansiBrightMagenta": "#ffa3aa",
+        "terminal.ansiBrightRed": "#ff6565",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffc94a"
+    }
+}

--- a/vscode/cyberpunk.json
+++ b/vscode/cyberpunk.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e5e5e5",
+        "terminal.background": "#332a57",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#00bfff",
+        "terminal.ansiCyan": "#86cbfe",
+        "terminal.ansiGreen": "#00fbac",
+        "terminal.ansiMagenta": "#df95ff",
+        "terminal.ansiRed": "#ff7092",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fffa6a",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#1bccfd",
+        "terminal.ansiBrightCyan": "#99d6fc",
+        "terminal.ansiBrightGreen": "#21f6bc",
+        "terminal.ansiBrightMagenta": "#e6aefe",
+        "terminal.ansiBrightRed": "#ff8aa4",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fff787"
+    }
+}

--- a/vscode/deep.json
+++ b/vscode/deep.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#cdcdcd",
+        "terminal.background": "#090909",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#5665ff",
+        "terminal.ansiCyan": "#50d2da",
+        "terminal.ansiGreen": "#1cd915",
+        "terminal.ansiMagenta": "#b052da",
+        "terminal.ansiRed": "#d70005",
+        "terminal.ansiWhite": "#e0e0e0",
+        "terminal.ansiYellow": "#d9bd26",
+        "terminal.ansiBrightBlack": "#535353",
+        "terminal.ansiBrightBlue": "#9fa9ff",
+        "terminal.ansiBrightCyan": "#8df9ff",
+        "terminal.ansiBrightGreen": "#22ff18",
+        "terminal.ansiBrightMagenta": "#e09aff",
+        "terminal.ansiBrightRed": "#fb0007",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fedc2b"
+    }
+}

--- a/vscode/idea.json
+++ b/vscode/idea.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#adadad",
+        "terminal.background": "#202020",
+        "terminal.ansiBlack": "#adadad",
+        "terminal.ansiBlue": "#437ee7",
+        "terminal.ansiCyan": "#248887",
+        "terminal.ansiGreen": "#98b61c",
+        "terminal.ansiMagenta": "#9d74b0",
+        "terminal.ansiRed": "#fc5256",
+        "terminal.ansiWhite": "#181818",
+        "terminal.ansiYellow": "#ccb444",
+        "terminal.ansiBrightBlack": "#ffffff",
+        "terminal.ansiBrightBlue": "#6c9ced",
+        "terminal.ansiBrightCyan": "#248887",
+        "terminal.ansiBrightGreen": "#98b61c",
+        "terminal.ansiBrightMagenta": "#fc7eff",
+        "terminal.ansiBrightRed": "#fc7072",
+        "terminal.ansiBrightWhite": "#181818",
+        "terminal.ansiBrightYellow": "#ffff0b"
+    }
+}

--- a/vscode/idleToes.json
+++ b/vscode/idleToes.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#323232",
+        "terminal.ansiBlack": "#323232",
+        "terminal.ansiBlue": "#4099ff",
+        "terminal.ansiCyan": "#bed6ff",
+        "terminal.ansiGreen": "#7fe173",
+        "terminal.ansiMagenta": "#f680ff",
+        "terminal.ansiRed": "#d25252",
+        "terminal.ansiWhite": "#eeeeec",
+        "terminal.ansiYellow": "#ffc66d",
+        "terminal.ansiBrightBlack": "#535353",
+        "terminal.ansiBrightBlue": "#5eb7f7",
+        "terminal.ansiBrightCyan": "#dcf4ff",
+        "terminal.ansiBrightGreen": "#9dff91",
+        "terminal.ansiBrightMagenta": "#ff9dff",
+        "terminal.ansiBrightRed": "#f07070",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffe48b"
+    }
+}

--- a/vscode/lovelace.json
+++ b/vscode/lovelace.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#fdfdfd",
+        "terminal.background": "#1d1f28",
+        "terminal.ansiBlack": "#282a36",
+        "terminal.ansiBlue": "#8897f4",
+        "terminal.ansiCyan": "#79e6f3",
+        "terminal.ansiGreen": "#5adecd",
+        "terminal.ansiMagenta": "#c574dd",
+        "terminal.ansiRed": "#f37f97",
+        "terminal.ansiWhite": "#fdfdfd",
+        "terminal.ansiYellow": "#f2a272",
+        "terminal.ansiBrightBlack": "#414458",
+        "terminal.ansiBrightBlue": "#556fff",
+        "terminal.ansiBrightCyan": "#3fdcee",
+        "terminal.ansiBrightGreen": "#18e3c8",
+        "terminal.ansiBrightMagenta": "#b043d1",
+        "terminal.ansiBrightRed": "#ff4971",
+        "terminal.ansiBrightWhite": "#bebec1",
+        "terminal.ansiBrightYellow": "#ff8037"
+    }
+}

--- a/vscode/midnight-in-mojave.json
+++ b/vscode/midnight-in-mojave.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#1e1e1e",
+        "terminal.ansiBlack": "#1e1e1e",
+        "terminal.ansiBlue": "#0a84ff",
+        "terminal.ansiCyan": "#5ac8fa",
+        "terminal.ansiGreen": "#32d74b",
+        "terminal.ansiMagenta": "#bf5af2",
+        "terminal.ansiRed": "#ff453a",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#ffd60a",
+        "terminal.ansiBrightBlack": "#1e1e1e",
+        "terminal.ansiBrightBlue": "#0a84ff",
+        "terminal.ansiBrightCyan": "#5ac8fa",
+        "terminal.ansiBrightGreen": "#32d74b",
+        "terminal.ansiBrightMagenta": "#bf5af2",
+        "terminal.ansiBrightRed": "#ff453a",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#ffd60a"
+    }
+}

--- a/vscode/primary.json
+++ b/vscode/primary.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#000000",
+        "terminal.background": "#ffffff",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#4285f4",
+        "terminal.ansiCyan": "#4285f4",
+        "terminal.ansiGreen": "#0f9d58",
+        "terminal.ansiMagenta": "#db4437",
+        "terminal.ansiRed": "#db4437",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#f4b400",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#4285f4",
+        "terminal.ansiBrightCyan": "#0f9d58",
+        "terminal.ansiBrightGreen": "#0f9d58",
+        "terminal.ansiBrightMagenta": "#4285f4",
+        "terminal.ansiBrightRed": "#db4437",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f4b400"
+    }
+}

--- a/vscode/purplepeter.json
+++ b/vscode/purplepeter.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ece7fa",
+        "terminal.background": "#2a1a4a",
+        "terminal.ansiBlack": "#0a0520",
+        "terminal.ansiBlue": "#66d9ef",
+        "terminal.ansiCyan": "#ba8cff",
+        "terminal.ansiGreen": "#99b481",
+        "terminal.ansiMagenta": "#e78fcd",
+        "terminal.ansiRed": "#ff796d",
+        "terminal.ansiWhite": "#ffba81",
+        "terminal.ansiYellow": "#efdfac",
+        "terminal.ansiBrightBlack": "#100b23",
+        "terminal.ansiBrightBlue": "#79daed",
+        "terminal.ansiBrightCyan": "#a0a0d6",
+        "terminal.ansiBrightGreen": "#b4be8f",
+        "terminal.ansiBrightMagenta": "#ba91d4",
+        "terminal.ansiBrightRed": "#f99f92",
+        "terminal.ansiBrightWhite": "#b9aed3",
+        "terminal.ansiBrightYellow": "#f2e9bf"
+    }
+}

--- a/vscode/rebecca.json
+++ b/vscode/rebecca.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#e8e6ed",
+        "terminal.background": "#292a44",
+        "terminal.ansiBlack": "#12131e",
+        "terminal.ansiBlue": "#7aa5ff",
+        "terminal.ansiCyan": "#56d3c2",
+        "terminal.ansiGreen": "#04dbb5",
+        "terminal.ansiMagenta": "#bf9cf9",
+        "terminal.ansiRed": "#dd7755",
+        "terminal.ansiWhite": "#e4e3e9",
+        "terminal.ansiYellow": "#f2e7b7",
+        "terminal.ansiBrightBlack": "#666699",
+        "terminal.ansiBrightBlue": "#69c0fa",
+        "terminal.ansiBrightCyan": "#8bfde1",
+        "terminal.ansiBrightGreen": "#01eac0",
+        "terminal.ansiBrightMagenta": "#c17ff8",
+        "terminal.ansiBrightRed": "#ff92cd",
+        "terminal.ansiBrightWhite": "#f4f2f9",
+        "terminal.ansiBrightYellow": "#fffca8"
+    }
+}

--- a/vscode/shades-of-purple.json
+++ b/vscode/shades-of-purple.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#ffffff",
+        "terminal.background": "#1e1d40",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#6943ff",
+        "terminal.ansiCyan": "#00c5c7",
+        "terminal.ansiGreen": "#3ad900",
+        "terminal.ansiMagenta": "#ff2c70",
+        "terminal.ansiRed": "#d90429",
+        "terminal.ansiWhite": "#c7c7c7",
+        "terminal.ansiYellow": "#ffe700",
+        "terminal.ansiBrightBlack": "#686868",
+        "terminal.ansiBrightBlue": "#6871ff",
+        "terminal.ansiBrightCyan": "#79e8fb",
+        "terminal.ansiBrightGreen": "#43d426",
+        "terminal.ansiBrightMagenta": "#ff77ff",
+        "terminal.ansiBrightRed": "#f92a1c",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#f1d000"
+    }
+}

--- a/vscode/synthwave.json
+++ b/vscode/synthwave.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#dad9c7",
+        "terminal.background": "#000000",
+        "terminal.ansiBlack": "#000000",
+        "terminal.ansiBlue": "#2186ec",
+        "terminal.ansiCyan": "#12c3e2",
+        "terminal.ansiGreen": "#1ebb2b",
+        "terminal.ansiMagenta": "#f85a21",
+        "terminal.ansiRed": "#f6188f",
+        "terminal.ansiWhite": "#ffffff",
+        "terminal.ansiYellow": "#fdf834",
+        "terminal.ansiBrightBlack": "#000000",
+        "terminal.ansiBrightBlue": "#2f9ded",
+        "terminal.ansiBrightCyan": "#19cde6",
+        "terminal.ansiBrightGreen": "#25c141",
+        "terminal.ansiBrightMagenta": "#f97137",
+        "terminal.ansiBrightRed": "#f841a0",
+        "terminal.ansiBrightWhite": "#ffffff",
+        "terminal.ansiBrightYellow": "#fdf454"
+    }
+}


### PR DESCRIPTION
This adds generation for terminal themes for visual studio code, a popular IDE. It translates the windows terminal json to the vscode themes, and thus the generator must be run after the windows terminal generator.

The generator is written in powershell and included in the tools folder. The README is also updated with vscode install instructions.