### PR TITLE
Fix Gruvbox Dark colors

### DIFF
--- a/schemes/Gruvbox Dark.itermcolors
+++ b/schemes/Gruvbox Dark.itermcolors
@@ -7,91 +7,91 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.097711890935897827</real>
+		<real>0.11759774386882782</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.095032960176467896</real>
+		<real>0.11759573966264725</real>
 		<key>Red Component</key>
-		<real>0.087016984820365906</real>
+		<real>0.11759927868843079</real>
 	</dict>
 	<key>Ansi 1 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.15763583779335022</real>
+		<real>0.090684391558170319</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.18880486488342285</real>
+		<real>0.05879192054271698</real>
 		<key>Red Component</key>
-		<real>0.96744710206985474</real>
+		<real>0.74529051780700684</real>
 	</dict>
 	<key>Ansi 10 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.082894742488861084</real>
+		<real>0.11661489307880402</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.53061914443969727</real>
+		<real>0.69061970710754395</real>
 		<key>Red Component</key>
-		<real>0.52591603994369507</real>
+		<real>0.66574931144714355</real>
 	</dict>
 	<key>Ansi 11 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.10328958928585052</real>
+		<real>0.1444794088602066</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.53254079818725586</real>
+		<real>0.6926688551902771</real>
 		<key>Red Component</key>
-		<real>0.80126690864562988</real>
+		<real>0.96949708461761475</real>
 	</dict>
 	<key>Ansi 12 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.4586675763130188</real>
+		<real>0.52537077665328979</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.45008346438407898</real>
+		<real>0.58534377813339233</real>
 		<key>Red Component</key>
-		<real>0.21694663166999817</real>
+		<real>0.44289660453796387</real>
 	</dict>
 	<key>Ansi 13 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.45103743672370911</real>
+		<real>0.53848373889923096</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.29604318737983704</real>
+		<real>0.43883562088012695</real>
 		<key>Red Component</key>
-		<real>0.62685638666152954</real>
+		<real>0.78096956014633179</real>
 	</dict>
 	<key>Ansi 14 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.34128850698471069</real>
+		<real>0.41142863035202026</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.55607825517654419</real>
+		<real>0.71257460117340088</real>
 		<key>Red Component</key>
-		<real>0.34054014086723328</real>
+		<real>0.49072420597076416</real>
 	</dict>
 	<key>Ansi 15 Color</key>
 	<dict>
@@ -111,78 +111,78 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.11661489307880402</real>
+		<real>0.082894742488861084</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.69061970710754395</real>
+		<real>0.53061914443969727</real>
 		<key>Red Component</key>
-		<real>0.66574931144714355</real>
+		<real>0.52591603994369507</real>
 	</dict>
 	<key>Ansi 3 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.1444794088602066</real>
+		<real>0.10328958928585052</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.6926688551902771</real>
+		<real>0.53254079818725586</real>
 		<key>Red Component</key>
-		<real>0.96949708461761475</real>
+		<real>0.80126690864562988</real>
 	</dict>
 	<key>Ansi 4 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.52537077665328979</real>
+		<real>0.4586675763130188</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.58534377813339233</real>
+		<real>0.45008346438407898</real>
 		<key>Red Component</key>
-		<real>0.44289660453796387</real>
+		<real>0.21694663166999817</real>
 	</dict>
 	<key>Ansi 5 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.53848373889923096</real>
+		<real>0.45103743672370911</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.43883562088012695</real>
+		<real>0.29604318737983704</real>
 		<key>Red Component</key>
-		<real>0.78096956014633179</real>
+		<real>0.62685638666152954</real>
 	</dict>
 	<key>Ansi 6 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.41142863035202026</real>
+		<real>0.34128850698471069</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.71257460117340088</real>
+		<real>0.55607825517654419</real>
 		<key>Red Component</key>
-		<real>0.49072420597076416</real>
+		<real>0.34054014086723328</real>
 	</dict>
 	<key>Ansi 7 Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.73338055610656738</real>
+		<real>0.44320183992385864</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.93639552593231201</real>
+		<real>0.5310559868812561</real>
 		<key>Red Component</key>
-		<real>0.97939503192901611</real>
+		<real>0.5926094651222229</real>
 	</dict>
 	<key>Ansi 8 Color</key>
 	<dict>
@@ -202,13 +202,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.090684391558170319</real>
+		<real>0.15763583779335022</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.05879192054271698</real>
+		<real>0.18880486488342285</real>
 		<key>Red Component</key>
-		<real>0.74529051780700684</real>
+		<real>0.96744710206985474</real>
 	</dict>
 	<key>Background Color</key>
 	<dict>
@@ -228,65 +228,65 @@
 		<key>Alpha Component</key>
 		<real>0.5</real>
 		<key>Blue Component</key>
-		<real>0.0</real>
+		<real>0.056549370288848877</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.0</real>
+		<real>0.28100395202636719</real>
 		<key>Red Component</key>
-		<real>1</real>
+		<real>0.7928692102432251</real>
 	</dict>
 	<key>Bold Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.44320183992385864</real>
+		<real>1</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.5310559868812561</real>
+		<real>1</real>
 		<key>Red Component</key>
-		<real>0.5926094651222229</real>
+		<real>1</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.73299998044967651</real>
+		<real>0.63873869180679321</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.73299998044967651</real>
+		<real>0.82989895343780518</real>
 		<key>Red Component</key>
-		<real>0.73299998044967651</real>
+		<real>0.90061241388320923</real>
 	</dict>
 	<key>Cursor Guide Color</key>
 	<dict>
 		<key>Alpha Component</key>
-		<real>0.25</real>
-		<key>Blue Component</key>
 		<real>1</real>
+		<key>Blue Component</key>
+		<real>0.15993706881999969</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.9100000262260437</real>
+		<real>0.16613791882991791</real>
 		<key>Red Component</key>
-		<real>0.64999997615814209</real>
+		<real>0.17867125570774078</real>
 	</dict>
 	<key>Cursor Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.11759774386882782</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>1</real>
+		<real>0.11759573966264725</real>
 		<key>Red Component</key>
-		<real>1</real>
+		<real>0.11759927868843079</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>
@@ -306,39 +306,39 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.67799997329711914</real>
+		<real>0.056549370288848877</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.27000001072883606</real>
+		<real>0.28100395202636719</real>
 		<key>Red Component</key>
-		<real>0.023000000044703484</real>
+		<real>0.7928692102432251</real>
 	</dict>
 	<key>Selected Text Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.44320183992385864</real>
+		<real>0.26041668653488159</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.5310559868812561</real>
+		<real>0.2891082763671875</real>
 		<key>Red Component</key>
-		<real>0.5926094651222229</real>
+		<real>0.32501408457756042</real>
 	</dict>
 	<key>Selection Color</key>
 	<dict>
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.31861674785614014</real>
+		<real>0.63873869180679321</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.360250324010849</real>
+		<real>0.82989895343780518</real>
 		<key>Red Component</key>
-		<real>0.40959125757217407</real>
+		<real>0.90061241388320923</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Changing Gruvbox dark to match the file at https://github.com/morhetz/gruvbox-contrib/blob/master/iterm2/gruvbox-dark.itermcolors. I'm not sure why there are so many differences. It seems like the "bright" and "normal" colors are swapped for one thing.