### PR TITLE
Correct README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,13 +742,13 @@ It would also be very helpful if you `cd tools/` and run `python3 update_all.py`
 
 ![Screenshot](screenshots/SleepyHollow.png)
 
-### Snazzy
-
-![Screenshot](screenshots/snazzy.png)
-
 ### Smyck
 
 ![Screenshot](screenshots/smyck.png)
+
+### Snazzy
+
+![Screenshot](screenshots/snazzy.png)
 
 ### SoftServer
 


### PR DESCRIPTION
Swap the order of Snazzy and Smyck to keep themes in correct alphabetical order in README.md.