### PR TITLE
removed erroneous character from Sakura.itermcolors

### DIFF
--- a/schemes/Sakura.itermcolors
+++ b/schemes/Sakura.itermcolors
@@ -1,4 +1,4 @@
-∑<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>


### PR DESCRIPTION
There was a rogue character at the beginning of sakura.itemcolors that was causing iTerm2 to throw an error when trying to import it. I am unsure if this problem exists elsewhere.