### PR TITLE
Link to vscode / windows terminal docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   - [Previewing color schemes](#previewing-color-schemes)
   - [MobaXterm color schemes](#mobaxterm-color-schemes)
   - [LXTerminal color schemes](#lxterminal-color-schemes)
+  - [Visual Studio Code color schemes](#visual-studio-code-color-schemes)
+  - [Windows Terminal color schemes](#windows-terminal-color-schemes)
 
 ## Intro
 
@@ -1382,7 +1384,7 @@ Copy the theme content from `mobaxterm/` and paste the content to your `MobaXter
 
 Copy the theme content from `lxterminal/` and paste the content to your `lxterminal` in the corresponding place (`[general]`).
 
-### Visual Studio Code (vscode) color schemes
+### Visual Studio Code color schemes
 
 Copy the theme content from `vscode/` and paste the content to your [UserSettings.json](https://code.visualstudio.com/docs/getstarted/settings).
 


### PR DESCRIPTION
Add links to installation instructions to match other supported terminals.

Note: I had to rename the Visual Studio Code entry as "(vscode)" breaks the markdown links as they are specified using parens.