### PR TITLE
Fix session name for PuTTY

### DIFF
--- a/putty/3024 Day.reg
+++ b/putty/3024 Day.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\3024 Day]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\3024%20Day]
 "Colour2"="247,247,247"
 "Colour3"="247,247,247"
 "Colour0"="74,69,67"

--- a/putty/3024 Night.reg
+++ b/putty/3024 Night.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\3024 Night]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\3024%20Night]
 "Colour2"="9,3,0"
 "Colour3"="9,3,0"
 "Colour0"="165,162,162"

--- a/putty/Banana Blueberry.reg
+++ b/putty/Banana Blueberry.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Banana Blueberry]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Banana%20Blueberry]
 "Colour2"="25,19,35"
 "Colour3"="25,19,35"
 "Colour0"="204,204,204"

--- a/putty/Belafonte Day.reg
+++ b/putty/Belafonte Day.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Belafonte Day]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Belafonte%20Day]
 "Colour2"="213,204,186"
 "Colour3"="213,204,186"
 "Colour0"="69,55,60"

--- a/putty/Belafonte Night.reg
+++ b/putty/Belafonte Night.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Belafonte Night]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Belafonte%20Night]
 "Colour2"="32,17,27"
 "Colour3"="32,17,27"
 "Colour0"="150,140,131"

--- a/putty/Blue Matrix.reg
+++ b/putty/Blue Matrix.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Blue Matrix]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Blue%20Matrix]
 "Colour2"="16,17,22"
 "Colour3"="16,17,22"
 "Colour0"="0,162,255"

--- a/putty/Bright Lights.reg
+++ b/putty/Bright Lights.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Bright Lights]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Bright%20Lights]
 "Colour2"="25,25,25"
 "Colour3"="25,25,25"
 "Colour0"="179,201,215"

--- a/putty/Builtin Dark.reg
+++ b/putty/Builtin Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Dark]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="187,187,187"

--- a/putty/Builtin Light.reg
+++ b/putty/Builtin Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Light]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="0,0,0"

--- a/putty/Builtin Pastel Dark.reg
+++ b/putty/Builtin Pastel Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Pastel Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Pastel%20Dark]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="187,187,187"

--- a/putty/Builtin Solarized Dark.reg
+++ b/putty/Builtin Solarized Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Solarized Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Solarized%20Dark]
 "Colour2"="0,43,54"
 "Colour3"="0,43,54"
 "Colour0"="131,148,150"

--- a/putty/Builtin Solarized Light.reg
+++ b/putty/Builtin Solarized Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Solarized Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Solarized%20Light]
 "Colour2"="253,246,227"
 "Colour3"="253,246,227"
 "Colour0"="101,123,131"

--- a/putty/Builtin Tango Dark.reg
+++ b/putty/Builtin Tango Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Tango Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Tango%20Dark]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="255,255,255"

--- a/putty/Builtin Tango Light.reg
+++ b/putty/Builtin Tango Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin Tango Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Builtin%20Tango%20Light]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="0,0,0"

--- a/putty/Cobalt Neon.reg
+++ b/putty/Cobalt Neon.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Cobalt Neon]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Cobalt%20Neon]
 "Colour2"="20,40,56"
 "Colour3"="20,40,56"
 "Colour0"="143,245,134"

--- a/putty/Dark Pastel.reg
+++ b/putty/Dark Pastel.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dark Pastel]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dark%20Pastel]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="255,255,255"

--- a/putty/Duotone Dark.reg
+++ b/putty/Duotone Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Duotone Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Duotone%20Dark]
 "Colour2"="31,29,39"
 "Colour3"="31,29,39"
 "Colour0"="183,161,255"

--- a/putty/Espresso Libre.reg
+++ b/putty/Espresso Libre.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Espresso Libre]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Espresso%20Libre]
 "Colour2"="42,33,28"
 "Colour3"="42,33,28"
 "Colour0"="184,168,152"

--- a/putty/Gruvbox Dark.reg
+++ b/putty/Gruvbox Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Gruvbox Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Gruvbox%20Dark]
 "Colour2"="30,30,30"
 "Colour3"="30,30,30"
 "Colour0"="230,212,163"

--- a/putty/Gruvbox Light.reg
+++ b/putty/Gruvbox Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Gruvbox Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Gruvbox%20Light]
 "Colour2"="251,241,199"
 "Colour3"="251,241,199"
 "Colour0"="40,40,40"

--- a/putty/Hipster Green.reg
+++ b/putty/Hipster Green.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Hipster Green]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Hipster%20Green]
 "Colour2"="16,11,5"
 "Colour3"="16,11,5"
 "Colour0"="132,193,56"

--- a/putty/Jackie Brown.reg
+++ b/putty/Jackie Brown.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Jackie Brown]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Jackie%20Brown]
 "Colour2"="44,29,22"
 "Colour3"="44,29,22"
 "Colour0"="255,204,47"

--- a/putty/JetBrains Darcula.reg
+++ b/putty/JetBrains Darcula.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\JetBrains Darcula]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\JetBrains%20Darcula]
 "Colour2"="32,32,32"
 "Colour3"="32,32,32"
 "Colour0"="173,173,173"

--- a/putty/Lab Fox.reg
+++ b/putty/Lab Fox.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Lab Fox]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Lab%20Fox]
 "Colour2"="46,46,46"
 "Colour3"="46,46,46"
 "Colour0"="255,255,255"

--- a/putty/Later This Evening.reg
+++ b/putty/Later This Evening.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Later This Evening]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Later%20This%20Evening]
 "Colour2"="34,34,34"
 "Colour3"="34,34,34"
 "Colour0"="149,149,149"

--- a/putty/Man Page.reg
+++ b/putty/Man Page.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Man Page]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Man%20Page]
 "Colour2"="254,244,156"
 "Colour3"="254,244,156"
 "Colour0"="0,0,0"

--- a/putty/Monokai Remastered.reg
+++ b/putty/Monokai Remastered.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai Remastered]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai%20Remastered]
 "Colour2"="12,12,12"
 "Colour3"="12,12,12"
 "Colour0"="217,217,217"

--- a/putty/Monokai Soda.reg
+++ b/putty/Monokai Soda.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai Soda]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai%20Soda]
 "Colour2"="26,26,26"
 "Colour3"="26,26,26"
 "Colour0"="196,197,181"

--- a/putty/Monokai Vivid.reg
+++ b/putty/Monokai Vivid.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai Vivid]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Monokai%20Vivid]
 "Colour2"="18,18,18"
 "Colour3"="18,18,18"
 "Colour0"="249,249,249"

--- a/putty/Night Owlish Light.reg
+++ b/putty/Night Owlish Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Night Owlish Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Night%20Owlish%20Light]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="64,63,83"

--- a/putty/NightLion v1.reg
+++ b/putty/NightLion v1.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\NightLion v1]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\NightLion%20v1]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="187,187,187"

--- a/putty/NightLion v2.reg
+++ b/putty/NightLion v2.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\NightLion v2]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\NightLion%20v2]
 "Colour2"="23,23,23"
 "Colour3"="23,23,23"
 "Colour0"="187,187,187"

--- a/putty/Nocturnal Winter.reg
+++ b/putty/Nocturnal Winter.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Nocturnal Winter]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Nocturnal%20Winter]
 "Colour2"="13,13,23"
 "Colour3"="13,13,23"
 "Colour0"="230,229,229"

--- a/putty/Operator Mono Dark.reg
+++ b/putty/Operator Mono Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Operator Mono Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Operator%20Mono%20Dark]
 "Colour2"="25,25,25"
 "Colour3"="25,25,25"
 "Colour0"="195,202,194"

--- a/putty/Overnight Slumber.reg
+++ b/putty/Overnight Slumber.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Overnight Slumber]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Overnight%20Slumber]
 "Colour2"="14,23,41"
 "Colour3"="14,23,41"
 "Colour0"="206,210,214"

--- a/putty/Paraiso Dark.reg
+++ b/putty/Paraiso Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Paraiso Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Paraiso%20Dark]
 "Colour2"="47,30,46"
 "Colour3"="47,30,46"
 "Colour0"="163,158,155"

--- a/putty/Parasio Dark.reg
+++ b/putty/Parasio Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Parasio Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Parasio%20Dark]
 "Colour2"="47,30,46"
 "Colour3"="47,30,46"
 "Colour0"="163,158,155"

--- a/putty/Piatto Light.reg
+++ b/putty/Piatto Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Piatto Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Piatto%20Light]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="65,65,65"

--- a/putty/Popping and Locking.reg
+++ b/putty/Popping and Locking.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Popping and Locking]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Popping%20and%20Locking]
 "Colour2"="24,25,33"
 "Colour3"="24,25,33"
 "Colour0"="235,219,178"

--- a/putty/Pro Light.reg
+++ b/putty/Pro Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Pro Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Pro%20Light]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="25,25,25"

--- a/putty/Purple Rain.reg
+++ b/putty/Purple Rain.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Purple Rain]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Purple%20Rain]
 "Colour2"="33,8,74"
 "Colour3"="33,8,74"
 "Colour0"="255,251,246"

--- a/putty/Red Alert.reg
+++ b/putty/Red Alert.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red Alert]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red%20Alert]
 "Colour2"="118,36,35"
 "Colour3"="118,36,35"
 "Colour0"="255,255,255"

--- a/putty/Red Planet.reg
+++ b/putty/Red Planet.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red Planet]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red%20Planet]
 "Colour2"="34,34,34"
 "Colour3"="34,34,34"
 "Colour0"="194,183,144"

--- a/putty/Red Sands.reg
+++ b/putty/Red Sands.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red Sands]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Red%20Sands]
 "Colour2"="122,37,30"
 "Colour3"="122,37,30"
 "Colour0"="215,201,167"

--- a/putty/Rouge 2.reg
+++ b/putty/Rouge 2.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Rouge 2]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Rouge%202]
 "Colour2"="23,24,43"
 "Colour3"="23,24,43"
 "Colour0"="162,163,170"

--- a/putty/Scarlet Protocol.reg
+++ b/putty/Scarlet Protocol.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Scarlet Protocol]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Scarlet%20Protocol]
 "Colour2"="28,21,61"
 "Colour3"="28,21,61"
 "Colour0"="228,25,81"

--- a/putty/Seafoam Pastel.reg
+++ b/putty/Seafoam Pastel.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Seafoam Pastel]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Seafoam%20Pastel]
 "Colour2"="36,52,53"
 "Colour3"="36,52,53"
 "Colour0"="212,231,212"

--- a/putty/Solarized Darcula.reg
+++ b/putty/Solarized Darcula.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized Darcula]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized%20Darcula]
 "Colour2"="61,63,65"
 "Colour3"="61,63,65"
 "Colour0"="210,216,217"

--- a/putty/Solarized Dark - Patched.reg
+++ b/putty/Solarized Dark - Patched.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized Dark - Patched]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized%20Dark%20-%20Patched]
 "Colour2"="0,30,39"
 "Colour3"="0,30,39"
 "Colour0"="112,130,132"

--- a/putty/Solarized Dark Higher Contrast.reg
+++ b/putty/Solarized Dark Higher Contrast.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized Dark Higher Contrast]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Solarized%20Dark%20Higher%20Contrast]
 "Colour2"="0,30,39"
 "Colour3"="0,30,39"
 "Colour0"="156,194,195"

--- a/putty/SpaceGray Eighties Dull.reg
+++ b/putty/SpaceGray Eighties Dull.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\SpaceGray Eighties Dull]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\SpaceGray%20Eighties%20Dull]
 "Colour2"="34,34,34"
 "Colour3"="34,34,34"
 "Colour0"="201,198,188"

--- a/putty/SpaceGray Eighties.reg
+++ b/putty/SpaceGray Eighties.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\SpaceGray Eighties]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\SpaceGray%20Eighties]
 "Colour2"="34,34,34"
 "Colour3"="34,34,34"
 "Colour0"="189,186,174"

--- a/putty/Tango Adapted.reg
+++ b/putty/Tango Adapted.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tango Adapted]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tango%20Adapted]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="0,0,0"

--- a/putty/Tango Half Adapted.reg
+++ b/putty/Tango Half Adapted.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tango Half Adapted]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tango%20Half%20Adapted]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="0,0,0"

--- a/putty/Terminal Basic.reg
+++ b/putty/Terminal Basic.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Terminal Basic]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Terminal%20Basic]
 "Colour2"="255,255,255"
 "Colour3"="255,255,255"
 "Colour0"="0,0,0"

--- a/putty/Thayer Bright.reg
+++ b/putty/Thayer Bright.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Thayer Bright]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Thayer%20Bright]
 "Colour2"="27,29,30"
 "Colour3"="27,29,30"
 "Colour0"="248,248,248"

--- a/putty/The Hulk.reg
+++ b/putty/The Hulk.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\The Hulk]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\The%20Hulk]
 "Colour2"="27,29,30"
 "Colour3"="27,29,30"
 "Colour0"="181,181,181"

--- a/putty/Tinacious Design (Dark).reg
+++ b/putty/Tinacious Design (Dark).reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious Design (Dark)]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20(Dark)]
 "Colour2"="29,29,38"
 "Colour3"="29,29,38"
 "Colour0"="203,203,240"

--- a/putty/Tinacious Design (Light).reg
+++ b/putty/Tinacious Design (Light).reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious Design (Light)]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20(Light)]
 "Colour2"="248,248,255"
 "Colour3"="248,248,255"
 "Colour0"="29,29,38"

--- a/putty/Tomorrow Night Blue.reg
+++ b/putty/Tomorrow Night Blue.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow Night Blue]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow%20Night%20Blue]
 "Colour2"="0,36,81"
 "Colour3"="0,36,81"
 "Colour0"="255,255,255"

--- a/putty/Tomorrow Night Bright.reg
+++ b/putty/Tomorrow Night Bright.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow Night Bright]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow%20Night%20Bright]
 "Colour2"="0,0,0"
 "Colour3"="0,0,0"
 "Colour0"="234,234,234"

--- a/putty/Tomorrow Night Burns.reg
+++ b/putty/Tomorrow Night Burns.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow Night Burns]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow%20Night%20Burns]
 "Colour2"="21,21,21"
 "Colour3"="21,21,21"
 "Colour0"="161,176,184"

--- a/putty/Tomorrow Night Eighties.reg
+++ b/putty/Tomorrow Night Eighties.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow Night Eighties]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow%20Night%20Eighties]
 "Colour2"="45,45,45"
 "Colour3"="45,45,45"
 "Colour0"="204,204,204"

--- a/putty/Tomorrow Night.reg
+++ b/putty/Tomorrow Night.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow Night]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tomorrow%20Night]
 "Colour2"="29,31,33"
 "Colour3"="29,31,33"
 "Colour0"="197,200,198"

--- a/putty/Violet Dark.reg
+++ b/putty/Violet Dark.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Violet Dark]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Violet%20Dark]
 "Colour2"="28,29,31"
 "Colour3"="28,29,31"
 "Colour0"="112,130,132"

--- a/putty/Violet Light.reg
+++ b/putty/Violet Light.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Violet Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Violet%20Light]
 "Colour2"="252,244,220"
 "Colour3"="252,244,220"
 "Colour0"="83,104,112"

--- a/tools/xrdb2putty.py
+++ b/tools/xrdb2putty.py
@@ -53,7 +53,7 @@ def main(xrdb_path, output_path=None):
 			output.write('\n%s:\n' % name)
 
 		# Emit header
-		output.write("Windows Registry Editor Version 5.00\n\n[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\%s]\n" % name)
+		output.write("Windows Registry Editor Version 5.00\n\n[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\%s]\n" % name.replace(' ', '%20'))
 
 		# Emit background color
 		bg_color = hex_to_rgb(bg_regex.search(xrdb_data).group(1))


### PR DESCRIPTION
When PuTTY saves a session, spaces of its name are replaced with `%20`.