### PR TITLE
Add missing comma in vscode script

### DIFF
--- a/tools/windowsterminal2vscode.ps1
+++ b/tools/windowsterminal2vscode.ps1
@@ -24,8 +24,8 @@ Get-Item ../WindowsTerminal/*.json | Foreach-Object {
         "terminal.ansiBrightRed": "$($theme.brightRed)",
         "terminal.ansiBrightWhite": "$($theme.brightWhite)",
         "terminal.ansiBrightYellow": "$($theme.brightYellow)",
-        "terminal.selectionBackground": "$($theme.selectionBackground)"
-        "terminalCursor.foreground": "$($theme.cursorColor)",
+        "terminal.selectionBackground": "$($theme.selectionBackground)",
+        "terminalCursor.foreground": "$($theme.cursorColor)"
     }
 }
 "@ > "../vscode/$($PSItem.Name)"


### PR DESCRIPTION
Fix the vscode generation script with the missing comma

The vscode schemes themselves were fixed in https://github.com/mbadolato/iTerm2-Color-Schemes/pull/281