### PR TITLE
Add Chrome Secure Shell palette hex color conversion 

### DIFF
--- a/tools/iterm2chromessh.py
+++ b/tools/iterm2chromessh.py
@@ -1,0 +1,42 @@
+import plistlib
+from argparse import ArgumentParser
+
+
+__author__ = 'junhan'
+RED = 'Red Component'
+GREEN = 'Green Component'
+BLUE = 'Blue Component'
+
+
+def color_to_hex(color):
+    # Not sure about the exact conversion from real (0-1?) to integer
+    return '%02x' % int(256 * color)
+
+
+def itermcolors_to_palette(iterm_colorscheme_file):
+    with open(iterm_colorscheme_file, 'rb') as fd:
+        content = plistlib.load(fd)
+
+    palette = []
+    for color_index in range(16):
+        key = f'Ansi {color_index} Color'
+        red_hex = color_to_hex(content[key][RED])
+        green_hex = color_to_hex(content[key][GREEN])
+        blue_hex = color_to_hex(content[key][BLUE])
+
+        palette.append(f'  "{color_index}": "#{red_hex}{green_hex}{blue_hex}"')
+
+    print('{')
+    print(",\n".join(palette))
+    print('}')
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('itermcolors', help='.itermcolros file path.')
+    args = parser.parse_args()
+
+    itermcolors_to_palette(args.itermcolors)
+
+
+


### PR DESCRIPTION
A simple script to read from the color scheme from .itermcolors file and convert it into a map of Ansi color index to hex colors.

Example: Atom theme

Outputs
```
{
  "0": "#000000",
  "1": "#fd5ff1",
  "2": "#87c38a",
  "3": "#100d7b1",
  "4": "#85befe",
  "5": "#bab6fd",
  "6": "#85befe",
  "7": "#e0e0e0",
  "8": "#000000",
  "9": "#fd5ff1",
  "10": "#94fa36",
  "11": "#f6100a8",
  "12": "#96cbfe",
  "13": "#bab6fd",
  "14": "#85befe",
  "15": "#e0e0e0"
}
```