### PR TITLE
fixed wezterm/GitHub Dark cursor_fg color

### DIFF
--- a/wezterm/GitHub Dark.toml
+++ b/wezterm/GitHub Dark.toml
@@ -4,7 +4,7 @@ foreground = "#8b949e"
 background = "#101216"
 cursor_bg = "#c9d1d9"
 cursor_border = "#c9d1d9"
-cursor_fg = "#ffffff"
+cursor_fg = "#101216"
 selection_bg = "#3b5070"
 selection_fg = "#ffffff"
 


### PR DESCRIPTION
Currently, it's white on light gray, and therefore barely visible.