### PR TITLE
fix: GitHub Dark cursortext was white on light gray

### DIFF
--- a/alacritty/GitHub Dark.yml
+++ b/alacritty/GitHub Dark.yml
@@ -11,7 +11,7 @@ colors:
     yellow: '#e3b341'
   cursor:
     cursor: '#c9d1d9'
-    text: '#ffffff'
+    text: '#101216'
   normal:
     black: '#000000'
     blue: '#6ca4f8'

--- a/alacritty/darkermatrix.yml
+++ b/alacritty/darkermatrix.yml
@@ -1,0 +1,29 @@
+# Colors (darkermatrix)
+colors:
+  bright:
+    black: '#333333'
+    blue: '#00ff87'
+    cyan: '#176c73'
+    green: '#90d762'
+    magenta: '#412a4d'
+    red: '#00381d'
+    white: '#00381e'
+    yellow: '#e2e500'
+  cursor:
+    cursor: '#373a26'
+    text: '#00ff87'
+  normal:
+    black: '#091013'
+    blue: '#00cb6b'
+    cyan: '#125459'
+    green: '#6fa64c'
+    magenta: '#412a4d'
+    red: '#002e18'
+    white: '#002e19'
+    yellow: '#595900'
+  primary:
+    background: '#070c0e'
+    foreground: '#28380d'
+  selection:
+    background: '#0f191c'
+    text: '#00ff87'

--- a/alacritty/darkmatrix.yml
+++ b/alacritty/darkmatrix.yml
@@ -1,0 +1,29 @@
+# Colors (darkmatrix)
+colors:
+  bright:
+    black: '#333333'
+    blue: '#46d8b8'
+    cyan: '#12545a'
+    green: '#90d762'
+    magenta: '#4a3059'
+    red: '#00733d'
+    white: '#006536'
+    yellow: '#e2e500'
+  cursor:
+    cursor: '#9fa86e'
+    text: '#00ff87'
+  normal:
+    black: '#091013'
+    blue: '#2c9a84'
+    cyan: '#114d53'
+    green: '#6fa64c'
+    magenta: '#452d53'
+    red: '#006536'
+    white: '#006536'
+    yellow: '#7e8000'
+  primary:
+    background: '#070c0e'
+    foreground: '#3e5715'
+  selection:
+    background: '#0f191c'
+    text: '#00ff87'

--- a/alacritty/matrix.yml
+++ b/alacritty/matrix.yml
@@ -1,0 +1,29 @@
+# Colors (matrix)
+colors:
+  bright:
+    black: '#688060'
+    blue: '#4f7e7e'
+    cyan: '#c1ff8a'
+    green: '#90d762'
+    magenta: '#11ff25'
+    red: '#2fc079'
+    white: '#678c61'
+    yellow: '#faff00'
+  cursor:
+    cursor: '#384545'
+    text: '#00ff00'
+  normal:
+    black: '#0f191c'
+    blue: '#3f5242'
+    cyan: '#50b45a'
+    green: '#82d967'
+    magenta: '#409931'
+    red: '#23755a'
+    white: '#507350'
+    yellow: '#ffd700'
+  primary:
+    background: '#0f191c'
+    foreground: '#426644'
+  selection:
+    background: '#18282e'
+    text: '#00ff87'

--- a/putty/GitHub Dark.reg
+++ b/putty/GitHub Dark.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour0"="139,148,158"
 "Colour1"="201,209,217"
 "Colour5"="201,209,217"
-"Colour4"="255,255,255"
+"Colour4"="16,18,22"
 "Colour6"="0,0,0"
 "Colour8"="247,129,102"
 "Colour11"="86,211,100"

--- a/remmina/GitHub Dark.colors
+++ b/remmina/GitHub Dark.colors
@@ -1,7 +1,7 @@
 [ssh_colors]
 background = #101216
 cursor = #c9d1d9
-cursor_foreground = #ffffff
+cursor_foreground = #101216
 foreground = #8b949e
 highlight = #3b5070
 highlight_foreground = #ffffff

--- a/schemes/GitHub Dark.itermcolors
+++ b/schemes/GitHub Dark.itermcolors
@@ -280,13 +280,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>1</real>
+		<real>0.086274512112140656</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>1</real>
+		<real>0.070588238537311554</real>
 		<key>Red Component</key>
-		<real>1</real>
+		<real>0.062745101749897003</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>

--- a/vscode/darkermatrix.json
+++ b/vscode/darkermatrix.json
@@ -1,0 +1,24 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#28380d",
+        "terminal.background": "#070c0e",
+        "terminal.ansiBlack": "#091013",
+        "terminal.ansiBlue": "#00cb6b",
+        "terminal.ansiCyan": "#125459",
+        "terminal.ansiGreen": "#6fa64c",
+        "terminal.ansiMagenta": "#412a4d",
+        "terminal.ansiRed": "#002e18",
+        "terminal.ansiWhite": "#002e19",
+        "terminal.ansiYellow": "#595900",
+        "terminal.ansiBrightBlack": "#333333",
+        "terminal.ansiBrightBlue": "#00ff87",
+        "terminal.ansiBrightCyan": "#176c73",
+        "terminal.ansiBrightGreen": "#90d762",
+        "terminal.ansiBrightMagenta": "#412a4d",
+        "terminal.ansiBrightRed": "#00381d",
+        "terminal.ansiBrightWhite": "#00381e",
+        "terminal.ansiBrightYellow": "#e2e500",
+        "terminal.selectionBackground": "#0f191c",
+        "terminalCursor.foreground": "#373a26"
+    }
+}

--- a/vscode/darkmatrix.json
+++ b/vscode/darkmatrix.json
@@ -1,0 +1,24 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#3e5715",
+        "terminal.background": "#070c0e",
+        "terminal.ansiBlack": "#091013",
+        "terminal.ansiBlue": "#2c9a84",
+        "terminal.ansiCyan": "#114d53",
+        "terminal.ansiGreen": "#6fa64c",
+        "terminal.ansiMagenta": "#452d53",
+        "terminal.ansiRed": "#006536",
+        "terminal.ansiWhite": "#006536",
+        "terminal.ansiYellow": "#7e8000",
+        "terminal.ansiBrightBlack": "#333333",
+        "terminal.ansiBrightBlue": "#46d8b8",
+        "terminal.ansiBrightCyan": "#12545a",
+        "terminal.ansiBrightGreen": "#90d762",
+        "terminal.ansiBrightMagenta": "#4a3059",
+        "terminal.ansiBrightRed": "#00733d",
+        "terminal.ansiBrightWhite": "#006536",
+        "terminal.ansiBrightYellow": "#e2e500",
+        "terminal.selectionBackground": "#0f191c",
+        "terminalCursor.foreground": "#9fa86e"
+    }
+}

--- a/vscode/matrix.json
+++ b/vscode/matrix.json
@@ -1,0 +1,24 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.foreground": "#426644",
+        "terminal.background": "#0f191c",
+        "terminal.ansiBlack": "#0f191c",
+        "terminal.ansiBlue": "#3f5242",
+        "terminal.ansiCyan": "#50b45a",
+        "terminal.ansiGreen": "#82d967",
+        "terminal.ansiMagenta": "#409931",
+        "terminal.ansiRed": "#23755a",
+        "terminal.ansiWhite": "#507350",
+        "terminal.ansiYellow": "#ffd700",
+        "terminal.ansiBrightBlack": "#688060",
+        "terminal.ansiBrightBlue": "#4f7e7e",
+        "terminal.ansiBrightCyan": "#c1ff8a",
+        "terminal.ansiBrightGreen": "#90d762",
+        "terminal.ansiBrightMagenta": "#11ff25",
+        "terminal.ansiBrightRed": "#2fc079",
+        "terminal.ansiBrightWhite": "#678c61",
+        "terminal.ansiBrightYellow": "#faff00",
+        "terminal.selectionBackground": "#18282e",
+        "terminalCursor.foreground": "#384545"
+    }
+}

--- a/wezterm/GitHub Dark.toml
+++ b/wezterm/GitHub Dark.toml
@@ -4,7 +4,7 @@ foreground = "#8b949e"
 background = "#101216"
 cursor_bg = "#c9d1d9"
 cursor_border = "#c9d1d9"
-cursor_fg = "#ffffff"
+cursor_fg = "#101216"
 selection_bg = "#3b5070"
 selection_fg = "#ffffff"
 

--- a/xrdb/GitHub Dark.xrdb
+++ b/xrdb/GitHub Dark.xrdb
@@ -19,7 +19,7 @@
 #define Bold_Color #c9d1d9
 #define Cursor_Color #c9d1d9
 #define Cursor_Guide_Color #b3ecff
-#define Cursor_Text_Color #ffffff
+#define Cursor_Text_Color #101216
 #define Foreground_Color #8b949e
 #define Link_Color #58a6ff
 #define Selected_Text_Color #ffffff


### PR DESCRIPTION
## Description

Fix cursortext color in GitHub Dark

### Theme Submission Checklist

<!-- If your pull request is to submit a new theme, or to update an existing one, please ensure all the steps in the checklist have been completed. If it is not a theme submission, you can delete the section below. -->

- [x] Included theme in iTerm2 format
- [x] Ran `tools/update_all.py` to generate themes in all formats
