### PR TITLE
Fix link for Ayu Mirage color profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@
 
 <p><img src="https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/screenshots/ayu_light.png" alt="Screenshot"></p>
 
-<p><a href="https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/schemes/Ayu+Mirage.itermcolors"><strong>Ayu Mirage</strong></a></p>
+<p><a href="https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/schemes/Ayu%20Mirage.itermcolors"><strong>Ayu Mirage</strong></a></p>
 
 <p><img src="https://raw.githubusercontent.com/mbadolato/iTerm2-Color-Schemes/master/screenshots/ayu_mirage.png" alt="Screenshot"></p>
 


### PR DESCRIPTION
The previous URL's last component was `Ayu+Mirage.itermcolors`. After manually browsing to the raw color profile ourselves we found that last component was `Ayu%20Mirage.itermcolors` instead.

We have just updated the `href` attribute of the corresponding `<a>` tag so that it points to the URL we're actually seeing when navigating to the raw color scheme.

This PR tries to solve issue #378.
