### PR TITLE
Rebuild putty schemes

### DIFF
--- a/putty/Dark+.reg
+++ b/putty/Dark+.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dark+]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dark%2B]
 "Colour2"="30,30,30"
 "Colour3"="30,30,30"
 "Colour0"="204,204,204"

--- a/putty/Dracula+.reg
+++ b/putty/Dracula+.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dracula+]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Dracula%2B]
 "Colour2"="33,33,33"
 "Colour3"="33,33,33"
 "Colour0"="248,248,242"

--- a/putty/Tinacious Design (Dark).reg
+++ b/putty/Tinacious Design (Dark).reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20(Dark)]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20%28Dark%29]
 "Colour2"="29,29,38"
 "Colour3"="29,29,38"
 "Colour0"="203,203,240"

--- a/putty/Tinacious Design (Light).reg
+++ b/putty/Tinacious Design (Light).reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20(Light)]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Tinacious%20Design%20%28Light%29]
 "Colour2"="248,248,255"
 "Colour3"="248,248,255"
 "Colour0"="29,29,38"


### PR DESCRIPTION
I'm again not sure if it's a bug or intentional change.

Characters `+`, `(` and `)` are now represented as `%2B`, `%28` and `%29`.

I don't have Windows, so can't say which one is correct.

/cc @tehaleph 