### PR TITLE
print scheme names on same line during preview

### DIFF
--- a/tools/preview.rb
+++ b/tools/preview.rb
@@ -24,7 +24,11 @@ preview = files.length > 1
 history = []
 until files.empty?
   file = files.shift
-  print "[#{File.basename file, '.*'}] " if preview
+  if preview
+    puts `tput cup 0 0`       # goto top of screen
+    print "[#{File.basename file, '.*'}] "
+    puts `tput el`            # clear to eol
+  end
   begin
     colors = {}
     root = REXML::Document.new(File.read file).root


### PR DESCRIPTION
## Description

When previewing color schemes,` tools/preview.rb schemes/*`, the name of the each scheme is printed.  As the schemes are reviewed the list of names starts to wrap and scrolls the sample text off the screen.  

My pull request keeps the names of the schemes on the same line on the screen so that the screen does not scroll.

IMHO, this makes previewing the color schemes with some sample text much better.

