### PR TITLE
Add themes/template for Termux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [Visual Studio Code color schemes](#visual-studio-code-color-schemes)
   - [Windows Terminal color schemes](#windows-terminal-color-schemes)
   - [Alacritty color schemes](#alacritty-color-schemes)
+  - [Termux color schemes](#termux-color-schemes)
 
 ## Intro
 
@@ -1542,6 +1543,9 @@ Copy the theme content from `windowsterminal/` and paste the content to your `pr
 ### Alacritty color schemes
 
 Copy the theme content from `alacritty/` and paste the content to your [alacritty config file](https://github.com/alacritty/alacritty/blob/master/alacritty.yml).
+
+### Termux color schemes
+Copy the theme content from `termux/` and paste the content to `~/.termux` directory as `~/.termux/colors.properties` file and run `termux-reload-settings` to apply the theme.
 
 ### Previewing color schemes
 

--- a/termux/3024 Day.properties
+++ b/termux/3024 Day.properties
@@ -1,0 +1,22 @@
+# 3024 Day
+foreground=#4a4543
+background=#f7f7f7
+cursor=#4a4543
+
+color0=#090300
+color1=#db2d20
+color2=#01a252
+color3=#fded02
+color4=#01a0e4
+color5=#a16a94
+color6=#b5e4f4
+color7=#a5a2a2
+
+color8=#5c5855
+color9=#e8bbd0
+color10=#3a3432
+color11=#4a4543
+color12=#807d7c
+color13=#d6d5d4
+color14=#cdab53
+color15=#f7f7f7

--- a/termux/3024 Night.properties
+++ b/termux/3024 Night.properties
@@ -1,0 +1,22 @@
+# 3024 Night
+foreground=#a5a2a2
+background=#090300
+cursor=#a5a2a2
+
+color0=#090300
+color1=#db2d20
+color2=#01a252
+color3=#fded02
+color4=#01a0e4
+color5=#a16a94
+color6=#b5e4f4
+color7=#a5a2a2
+
+color8=#5c5855
+color9=#e8bbd0
+color10=#3a3432
+color11=#4a4543
+color12=#807d7c
+color13=#d6d5d4
+color14=#cdab53
+color15=#f7f7f7

--- a/termux/Abernathy.properties
+++ b/termux/Abernathy.properties
@@ -1,0 +1,22 @@
+# Abernathy
+foreground=#eeeeec
+background=#111416
+cursor=#bbbbbb
+
+color0=#000000
+color1=#cd0000
+color2=#00cd00
+color3=#cdcd00
+color4=#1093f5
+color5=#cd00cd
+color6=#00cdcd
+color7=#faebd7
+
+color8=#404040
+color9=#ff0000
+color10=#00ff00
+color11=#ffff00
+color12=#11b5f6
+color13=#ff00ff
+color14=#00ffff
+color15=#ffffff

--- a/termux/Adventure.properties
+++ b/termux/Adventure.properties
@@ -1,0 +1,22 @@
+# Adventure
+foreground=#feffff
+background=#040404
+cursor=#feffff
+
+color0=#040404
+color1=#d84a33
+color2=#5da602
+color3=#eebb6e
+color4=#417ab3
+color5=#e5c499
+color6=#bdcfe5
+color7=#dbded8
+
+color8=#685656
+color9=#d76b42
+color10=#99b52c
+color11=#ffb670
+color12=#97d7ef
+color13=#aa7900
+color14=#bdcfe5
+color15=#e4d5c7

--- a/termux/AdventureTime.properties
+++ b/termux/AdventureTime.properties
@@ -1,0 +1,22 @@
+# AdventureTime
+foreground=#f8dcc0
+background=#1f1d45
+cursor=#efbf38
+
+color0=#050404
+color1=#bd0013
+color2=#4ab118
+color3=#e7741e
+color4=#0f4ac6
+color5=#665993
+color6=#70a598
+color7=#f8dcc0
+
+color8=#4e7cbf
+color9=#fc5f5a
+color10=#9eff6e
+color11=#efc11a
+color12=#1997c6
+color13=#9b5953
+color14=#c8faf4
+color15=#f6f5fb

--- a/termux/Afterglow.properties
+++ b/termux/Afterglow.properties
@@ -1,0 +1,22 @@
+# Afterglow
+foreground=#d0d0d0
+background=#212121
+cursor=#d0d0d0
+
+color0=#151515
+color1=#ac4142
+color2=#7e8e50
+color3=#e5b567
+color4=#6c99bb
+color5=#9f4e85
+color6=#7dd6cf
+color7=#d0d0d0
+
+color8=#505050
+color9=#ac4142
+color10=#7e8e50
+color11=#e5b567
+color12=#6c99bb
+color13=#9f4e85
+color14=#7dd6cf
+color15=#f5f5f5

--- a/termux/Alabaster.properties
+++ b/termux/Alabaster.properties
@@ -1,0 +1,22 @@
+# Alabaster
+foreground=#000000
+background=#f7f7f7
+cursor=#007acc
+
+color0=#000000
+color1=#aa3731
+color2=#448c27
+color3=#cb9000
+color4=#325cc0
+color5=#7a3e9d
+color6=#0083b2
+color7=#f7f7f7
+
+color8=#777777
+color9=#f05050
+color10=#60cb00
+color11=#ffbc5d
+color12=#007acc
+color13=#e64ce6
+color14=#00aacb
+color15=#f7f7f7

--- a/termux/AlienBlood.properties
+++ b/termux/AlienBlood.properties
@@ -1,0 +1,22 @@
+# AlienBlood
+foreground=#637d75
+background=#0f1610
+cursor=#73fa91
+
+color0=#112616
+color1=#7f2b27
+color2=#2f7e25
+color3=#717f24
+color4=#2f6a7f
+color5=#47587f
+color6=#327f77
+color7=#647d75
+
+color8=#3c4812
+color9=#e08009
+color10=#18e000
+color11=#bde000
+color12=#00aae0
+color13=#0058e0
+color14=#00e0c4
+color15=#73fa91

--- a/termux/Andromeda.properties
+++ b/termux/Andromeda.properties
@@ -1,0 +1,22 @@
+# Andromeda
+foreground=#e5e5e5
+background=#262a33
+cursor=#f8f8f0
+
+color0=#000000
+color1=#cd3131
+color2=#05bc79
+color3=#e5e512
+color4=#2472c8
+color5=#bc3fbc
+color6=#0fa8cd
+color7=#e5e5e5
+
+color8=#666666
+color9=#cd3131
+color10=#05bc79
+color11=#e5e512
+color12=#2472c8
+color13=#bc3fbc
+color14=#0fa8cd
+color15=#e5e5e5

--- a/termux/Apple Classic.properties
+++ b/termux/Apple Classic.properties
@@ -1,0 +1,22 @@
+# Apple Classic
+foreground=#d5a200
+background=#2c2b2b
+cursor=#c7c7c7
+
+color0=#000000
+color1=#c91b00
+color2=#00c200
+color3=#c7c400
+color4=#0225c7
+color5=#ca30c7
+color6=#00c5c7
+color7=#c7c7c7
+
+color8=#686868
+color9=#ff6e67
+color10=#5ffa68
+color11=#fffc67
+color12=#6871ff
+color13=#ff77ff
+color14=#60fdff
+color15=#ffffff

--- a/termux/Argonaut.properties
+++ b/termux/Argonaut.properties
@@ -1,0 +1,22 @@
+# Argonaut
+foreground=#fffaf4
+background=#0e1019
+cursor=#ff0018
+
+color0=#232323
+color1=#ff000f
+color2=#8ce10b
+color3=#ffb900
+color4=#008df8
+color5=#6d43a6
+color6=#00d8eb
+color7=#ffffff
+
+color8=#444444
+color9=#ff2740
+color10=#abe15b
+color11=#ffd242
+color12=#0092ff
+color13=#9a5feb
+color14=#67fff0
+color15=#ffffff

--- a/termux/Arthur.properties
+++ b/termux/Arthur.properties
@@ -1,0 +1,22 @@
+# Arthur
+foreground=#ddeedd
+background=#1c1c1c
+cursor=#e2bbef
+
+color0=#3d352a
+color1=#cd5c5c
+color2=#86af80
+color3=#e8ae5b
+color4=#6495ed
+color5=#deb887
+color6=#b0c4de
+color7=#bbaa99
+
+color8=#554444
+color9=#cc5533
+color10=#88aa22
+color11=#ffa75d
+color12=#87ceeb
+color13=#996600
+color14=#b0c4de
+color15=#ddccbb

--- a/termux/AtelierSulphurpool.properties
+++ b/termux/AtelierSulphurpool.properties
@@ -1,0 +1,22 @@
+# AtelierSulphurpool
+foreground=#979db4
+background=#202746
+cursor=#979db4
+
+color0=#202746
+color1=#c94922
+color2=#ac9739
+color3=#c08b30
+color4=#3d8fd1
+color5=#6679cc
+color6=#22a2c9
+color7=#979db4
+
+color8=#6b7394
+color9=#c76b29
+color10=#293256
+color11=#5e6687
+color12=#898ea4
+color13=#dfe2f1
+color14=#9c637a
+color15=#f5f7ff

--- a/termux/Atom.properties
+++ b/termux/Atom.properties
@@ -1,0 +1,22 @@
+# Atom
+foreground=#c5c8c6
+background=#161719
+cursor=#d0d0d0
+
+color0=#000000
+color1=#fd5ff1
+color2=#87c38a
+color3=#ffd7b1
+color4=#85befd
+color5=#b9b6fc
+color6=#85befd
+color7=#e0e0e0
+
+color8=#000000
+color9=#fd5ff1
+color10=#94fa36
+color11=#f5ffa8
+color12=#96cbfe
+color13=#b9b6fc
+color14=#85befd
+color15=#e0e0e0

--- a/termux/AtomOneLight.properties
+++ b/termux/AtomOneLight.properties
@@ -1,0 +1,22 @@
+# AtomOneLight
+foreground=#2a2c33
+background=#f9f9f9
+cursor=#bbbbbb
+
+color0=#000000
+color1=#de3e35
+color2=#3f953a
+color3=#d2b67c
+color4=#2f5af3
+color5=#950095
+color6=#3f953a
+color7=#bbbbbb
+
+color8=#000000
+color9=#de3e35
+color10=#3f953a
+color11=#d2b67c
+color12=#2f5af3
+color13=#a00095
+color14=#3f953a
+color15=#ffffff

--- a/termux/Aurora.properties
+++ b/termux/Aurora.properties
@@ -1,0 +1,22 @@
+# Aurora
+foreground=#ffca28
+background=#23262e
+cursor=#ee5d43
+
+color0=#23262e
+color1=#f0266f
+color2=#8fd46d
+color3=#ffe66d
+color4=#0321d7
+color5=#ee5d43
+color6=#03d6b8
+color7=#c74ded
+
+color8=#292e38
+color9=#f92672
+color10=#8fd46d
+color11=#ffe66d
+color12=#03d6b8
+color13=#ee5d43
+color14=#03d6b8
+color15=#c74ded

--- a/termux/Ayu Mirage.properties
+++ b/termux/Ayu Mirage.properties
@@ -1,0 +1,22 @@
+# Ayu Mirage
+foreground=#cbccc6
+background=#1f2430
+cursor=#ffcc66
+
+color0=#191e2a
+color1=#ed8274
+color2=#a6cc70
+color3=#fad07b
+color4=#6dcbfa
+color5=#cfbafa
+color6=#90e1c6
+color7=#c7c7c7
+
+color8=#686868
+color9=#f28779
+color10=#bae67e
+color11=#ffd580
+color12=#73d0ff
+color13=#d4bfff
+color14=#95e6cb
+color15=#ffffff

--- a/termux/Banana Blueberry.properties
+++ b/termux/Banana Blueberry.properties
@@ -1,0 +1,22 @@
+# Banana Blueberry
+foreground=#cccccc
+background=#191323
+cursor=#e07d13
+
+color0=#17141f
+color1=#ff6b7f
+color2=#00bd9c
+color3=#e6c62f
+color4=#22e8df
+color5=#dc396a
+color6=#56b6c2
+color7=#f1f1f1
+
+color8=#495162
+color9=#fe9ea1
+color10=#98c379
+color11=#f9e46b
+color12=#91fff4
+color13=#da70d6
+color14=#bcf3ff
+color15=#ffffff

--- a/termux/Batman.properties
+++ b/termux/Batman.properties
@@ -1,0 +1,22 @@
+# Batman
+foreground=#6f6f6f
+background=#1b1d1e
+cursor=#fcef0c
+
+color0=#1b1d1e
+color1=#e6dc44
+color2=#c8be46
+color3=#f4fd22
+color4=#737174
+color5=#747271
+color6=#62605f
+color7=#c6c5bf
+
+color8=#505354
+color9=#fff78e
+color10=#fff27d
+color11=#feed6c
+color12=#919495
+color13=#9a9a9d
+color14=#a3a3a6
+color15=#dadbd6

--- a/termux/Belafonte Day.properties
+++ b/termux/Belafonte Day.properties
@@ -1,0 +1,22 @@
+# Belafonte Day
+foreground=#45373c
+background=#d5ccba
+cursor=#45373c
+
+color0=#20111b
+color1=#be100e
+color2=#858162
+color3=#eaa549
+color4=#426a79
+color5=#97522c
+color6=#989a9c
+color7=#968c83
+
+color8=#5e5252
+color9=#be100e
+color10=#858162
+color11=#eaa549
+color12=#426a79
+color13=#97522c
+color14=#989a9c
+color15=#d5ccba

--- a/termux/Belafonte Night.properties
+++ b/termux/Belafonte Night.properties
@@ -1,0 +1,22 @@
+# Belafonte Night
+foreground=#968c83
+background=#20111b
+cursor=#968c83
+
+color0=#20111b
+color1=#be100e
+color2=#858162
+color3=#eaa549
+color4=#426a79
+color5=#97522c
+color6=#989a9c
+color7=#968c83
+
+color8=#5e5252
+color9=#be100e
+color10=#858162
+color11=#eaa549
+color12=#426a79
+color13=#97522c
+color14=#989a9c
+color15=#d5ccba

--- a/termux/BirdsOfParadise.properties
+++ b/termux/BirdsOfParadise.properties
@@ -1,0 +1,22 @@
+# BirdsOfParadise
+foreground=#e0dbb7
+background=#2a1f1d
+cursor=#573d26
+
+color0=#573d26
+color1=#be2d26
+color2=#6ba18a
+color3=#e99d2a
+color4=#5a86ad
+color5=#ac80a6
+color6=#74a6ad
+color7=#e0dbb7
+
+color8=#9b6c4a
+color9=#e84627
+color10=#95d8ba
+color11=#d0d150
+color12=#b8d3ed
+color13=#d19ecb
+color14=#93cfd7
+color15=#fff9d5

--- a/termux/Blazer.properties
+++ b/termux/Blazer.properties
@@ -1,0 +1,22 @@
+# Blazer
+foreground=#d9e6f2
+background=#0d1926
+cursor=#d9e6f2
+
+color0=#000000
+color1=#b87a7a
+color2=#7ab87a
+color3=#b8b87a
+color4=#7a7ab8
+color5=#b87ab8
+color6=#7ab8b8
+color7=#d9d9d9
+
+color8=#262626
+color9=#dbbdbd
+color10=#bddbbd
+color11=#dbdbbd
+color12=#bdbddb
+color13=#dbbddb
+color14=#bddbdb
+color15=#ffffff

--- a/termux/Blue Matrix.properties
+++ b/termux/Blue Matrix.properties
@@ -1,0 +1,22 @@
+# Blue Matrix
+foreground=#00a2ff
+background=#101116
+cursor=#76ff9f
+
+color0=#101116
+color1=#ff5680
+color2=#00ff9c
+color3=#fffc58
+color4=#00b0ff
+color5=#d57bff
+color6=#76c1ff
+color7=#c7c7c7
+
+color8=#686868
+color9=#ff6e67
+color10=#5ffa68
+color11=#fffc67
+color12=#6871ff
+color13=#d682ec
+color14=#60fdff
+color15=#ffffff

--- a/termux/BlueBerryPie.properties
+++ b/termux/BlueBerryPie.properties
@@ -1,0 +1,22 @@
+# BlueBerryPie
+foreground=#babab9
+background=#1c0c28
+cursor=#fcfad6
+
+color0=#0a4c62
+color1=#99246e
+color2=#5cb1b3
+color3=#eab9a8
+color4=#90a5bd
+color5=#9d54a7
+color6=#7e83cc
+color7=#f0e8d6
+
+color8=#201637
+color9=#c87272
+color10=#0a6c7e
+color11=#7a3188
+color12=#39173d
+color13=#bc94b7
+color14=#5e6071
+color15=#0a6c7e

--- a/termux/BlueDolphin.properties
+++ b/termux/BlueDolphin.properties
@@ -1,0 +1,22 @@
+# BlueDolphin
+foreground=#c5f2ff
+background=#006984
+cursor=#ffcc00
+
+color0=#292d3e
+color1=#ff8288
+color2=#b4e88d
+color3=#f4d69f
+color4=#82aaff
+color5=#e9c1ff
+color6=#89ebff
+color7=#d0d0d0
+
+color8=#434758
+color9=#ff8b92
+color10=#ddffa7
+color11=#ffe585
+color12=#9cc4ff
+color13=#ddb0f6
+color14=#a3f7ff
+color15=#ffffff

--- a/termux/BlulocoDark.properties
+++ b/termux/BlulocoDark.properties
@@ -1,0 +1,22 @@
+# BlulocoDark
+foreground=#b9c0cb
+background=#282c34
+cursor=#ffcc00
+
+color0=#41444d
+color1=#fc2f52
+color2=#25a45c
+color3=#ff936a
+color4=#3476ff
+color5=#7a82da
+color6=#4483aa
+color7=#cdd4e0
+
+color8=#8f9aae
+color9=#ff6480
+color10=#3fc56b
+color11=#f9c859
+color12=#10b1fe
+color13=#ff78f8
+color14=#5fb9bc
+color15=#ffffff

--- a/termux/BlulocoLight.properties
+++ b/termux/BlulocoLight.properties
@@ -1,0 +1,22 @@
+# BlulocoLight
+foreground=#373a41
+background=#f9f9f9
+cursor=#f32759
+
+color0=#373a41
+color1=#d52753
+color2=#23974a
+color3=#df631c
+color4=#275fe4
+color5=#823ff1
+color6=#27618d
+color7=#babbc2
+
+color8=#676a77
+color9=#ff6480
+color10=#3cbc66
+color11=#c5a332
+color12=#0099e1
+color13=#ce33c0
+color14=#6d93bb
+color15=#d3d3d3

--- a/termux/Borland.properties
+++ b/termux/Borland.properties
@@ -1,0 +1,22 @@
+# Borland
+foreground=#ffff4e
+background=#0000a4
+cursor=#ffa560
+
+color0=#4f4f4f
+color1=#ff6c60
+color2=#a8ff60
+color3=#ffffb6
+color4=#96cbfe
+color5=#ff73fd
+color6=#c6c5fe
+color7=#eeeeee
+
+color8=#7c7c7c
+color9=#ffb6b0
+color10=#ceffac
+color11=#ffffcc
+color12=#b5dcff
+color13=#ff9cfe
+color14=#dfdffe
+color15=#ffffff

--- a/termux/Breeze.properties
+++ b/termux/Breeze.properties
@@ -1,0 +1,22 @@
+# Breeze
+foreground=#eff0f1
+background=#31363b
+cursor=#eff0f1
+
+color0=#31363b
+color1=#ed1515
+color2=#11d116
+color3=#f67400
+color4=#1d99f3
+color5=#9b59b6
+color6=#1abc9c
+color7=#eff0f1
+
+color8=#7f8c8d
+color9=#c0392b
+color10=#1cdc9a
+color11=#fdbc4b
+color12=#3daee9
+color13=#8e44ad
+color14=#16a085
+color15=#fcfcfc

--- a/termux/Bright Lights.properties
+++ b/termux/Bright Lights.properties
@@ -1,0 +1,22 @@
+# Bright Lights
+foreground=#b3c9d7
+background=#191919
+cursor=#f34b00
+
+color0=#191919
+color1=#ff355b
+color2=#b7e876
+color3=#ffc251
+color4=#76d4ff
+color5=#ba76e7
+color6=#6cbfb5
+color7=#c2c8d7
+
+color8=#191919
+color9=#ff355b
+color10=#b7e876
+color11=#ffc251
+color12=#76d5ff
+color13=#ba76e7
+color14=#6cbfb5
+color15=#c2c8d7

--- a/termux/Broadcast.properties
+++ b/termux/Broadcast.properties
@@ -1,0 +1,22 @@
+# Broadcast
+foreground=#e6e1dc
+background=#2b2b2b
+cursor=#ffffff
+
+color0=#000000
+color1=#da4939
+color2=#519f50
+color3=#ffd24a
+color4=#6d9cbe
+color5=#d0d0ff
+color6=#6e9cbe
+color7=#ffffff
+
+color8=#323232
+color9=#ff7b6b
+color10=#83d182
+color11=#ffff7c
+color12=#9fcef0
+color13=#ffffff
+color14=#a0cef0
+color15=#ffffff

--- a/termux/Brogrammer.properties
+++ b/termux/Brogrammer.properties
@@ -1,0 +1,22 @@
+# Brogrammer
+foreground=#d6dbe5
+background=#131313
+cursor=#b9b9b9
+
+color0=#1f1f1f
+color1=#f81118
+color2=#2dc55e
+color3=#ecba0f
+color4=#2a84d2
+color5=#4e5ab7
+color6=#1081d6
+color7=#d6dbe5
+
+color8=#d6dbe5
+color9=#de352e
+color10=#1dd361
+color11=#f3bd09
+color12=#1081d6
+color13=#5350b9
+color14=#0f7ddb
+color15=#ffffff

--- a/termux/Builtin Dark.properties
+++ b/termux/Builtin Dark.properties
@@ -1,0 +1,22 @@
+# Builtin Dark
+foreground=#bbbbbb
+background=#000000
+cursor=#bbbbbb
+
+color0=#000000
+color1=#bb0000
+color2=#00bb00
+color3=#bbbb00
+color4=#0000bb
+color5=#bb00bb
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Builtin Light.properties
+++ b/termux/Builtin Light.properties
@@ -1,0 +1,22 @@
+# Builtin Light
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#bb0000
+color2=#00bb00
+color3=#bbbb00
+color4=#0000bb
+color5=#bb00bb
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Builtin Pastel Dark.properties
+++ b/termux/Builtin Pastel Dark.properties
@@ -1,0 +1,22 @@
+# Builtin Pastel Dark
+foreground=#bbbbbb
+background=#000000
+cursor=#ffa560
+
+color0=#4f4f4f
+color1=#ff6c60
+color2=#a8ff60
+color3=#ffffb6
+color4=#96cbfe
+color5=#ff73fd
+color6=#c6c5fe
+color7=#eeeeee
+
+color8=#7c7c7c
+color9=#ffb6b0
+color10=#ceffac
+color11=#ffffcc
+color12=#b5dcff
+color13=#ff9cfe
+color14=#dfdffe
+color15=#ffffff

--- a/termux/Builtin Solarized Dark.properties
+++ b/termux/Builtin Solarized Dark.properties
@@ -1,0 +1,22 @@
+# Builtin Solarized Dark
+foreground=#839496
+background=#002b36
+cursor=#839496
+
+color0=#073642
+color1=#dc322f
+color2=#859900
+color3=#b58900
+color4=#268bd2
+color5=#d33682
+color6=#2aa198
+color7=#eee8d5
+
+color8=#002b36
+color9=#cb4b16
+color10=#586e75
+color11=#657b83
+color12=#839496
+color13=#6c71c4
+color14=#93a1a1
+color15=#fdf6e3

--- a/termux/Builtin Solarized Light.properties
+++ b/termux/Builtin Solarized Light.properties
@@ -1,0 +1,22 @@
+# Builtin Solarized Light
+foreground=#657b83
+background=#fdf6e3
+cursor=#657b83
+
+color0=#073642
+color1=#dc322f
+color2=#859900
+color3=#b58900
+color4=#268bd2
+color5=#d33682
+color6=#2aa198
+color7=#eee8d5
+
+color8=#002b36
+color9=#cb4b16
+color10=#586e75
+color11=#657b83
+color12=#839496
+color13=#6c71c4
+color14=#93a1a1
+color15=#fdf6e3

--- a/termux/Builtin Tango Dark.properties
+++ b/termux/Builtin Tango Dark.properties
@@ -1,0 +1,22 @@
+# Builtin Tango Dark
+foreground=#ffffff
+background=#000000
+cursor=#ffffff
+
+color0=#000000
+color1=#cc0000
+color2=#4e9a06
+color3=#c4a000
+color4=#3465a4
+color5=#75507b
+color6=#06989a
+color7=#d3d7cf
+
+color8=#555753
+color9=#ef2929
+color10=#8ae234
+color11=#fce94f
+color12=#729fcf
+color13=#ad7fa8
+color14=#34e2e2
+color15=#eeeeec

--- a/termux/Builtin Tango Light.properties
+++ b/termux/Builtin Tango Light.properties
@@ -1,0 +1,22 @@
+# Builtin Tango Light
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#cc0000
+color2=#4e9a06
+color3=#c4a000
+color4=#3465a4
+color5=#75507b
+color6=#06989a
+color7=#d3d7cf
+
+color8=#555753
+color9=#ef2929
+color10=#8ae234
+color11=#fce94f
+color12=#729fcf
+color13=#ad7fa8
+color14=#34e2e2
+color15=#eeeeec

--- a/termux/C64.properties
+++ b/termux/C64.properties
@@ -1,0 +1,22 @@
+# C64
+foreground=#7869c4
+background=#40318d
+cursor=#7869c4
+
+color0=#090300
+color1=#883932
+color2=#55a049
+color3=#bfce72
+color4=#40318d
+color5=#8b3f96
+color6=#67b6bd
+color7=#ffffff
+
+color8=#000000
+color9=#883932
+color10=#55a049
+color11=#bfce72
+color12=#40318d
+color13=#8b3f96
+color14=#67b6bd
+color15=#f7f7f7

--- a/termux/CGA.properties
+++ b/termux/CGA.properties
@@ -1,0 +1,22 @@
+# CGA
+foreground=#aaaaaa
+background=#000000
+cursor=#b8b8b8
+
+color0=#000000
+color1=#aa0000
+color2=#00aa00
+color3=#aa5500
+color4=#0000aa
+color5=#aa00aa
+color6=#00aaaa
+color7=#aaaaaa
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/CLRS.properties
+++ b/termux/CLRS.properties
@@ -1,0 +1,22 @@
+# CLRS
+foreground=#262626
+background=#ffffff
+cursor=#6fd3fc
+
+color0=#000000
+color1=#f8282a
+color2=#328a5d
+color3=#fa701d
+color4=#135cd0
+color5=#9f00bd
+color6=#33c3c1
+color7=#b3b3b3
+
+color8=#555753
+color9=#fb0416
+color10=#2cc631
+color11=#fdd727
+color12=#1670ff
+color13=#e900b0
+color14=#3ad5ce
+color15=#eeeeec

--- a/termux/Calamity.properties
+++ b/termux/Calamity.properties
@@ -1,0 +1,22 @@
+# Calamity
+foreground=#d5ced9
+background=#2f2833
+cursor=#d5ced9
+
+color0=#2f2833
+color1=#fc644d
+color2=#a5f69c
+color3=#e9d7a5
+color4=#3b79c7
+color5=#f92672
+color6=#74d3de
+color7=#d5ced9
+
+color8=#7e6c88
+color9=#fc644d
+color10=#a5f69c
+color11=#e9d7a5
+color12=#3b79c7
+color13=#f92672
+color14=#74d3de
+color15=#ffffff

--- a/termux/Chalk.properties
+++ b/termux/Chalk.properties
@@ -1,0 +1,22 @@
+# Chalk
+foreground=#d2d8d9
+background=#2b2d2e
+cursor=#708284
+
+color0=#7d8b8f
+color1=#b23a52
+color2=#789b6a
+color3=#b9ac4a
+color4=#2a7fac
+color5=#bd4f5a
+color6=#44a799
+color7=#d2d8d9
+
+color8=#888888
+color9=#f24840
+color10=#80c470
+color11=#ffeb62
+color12=#4196ff
+color13=#fc5275
+color14=#53cdbd
+color15=#d2d8d9

--- a/termux/Chalkboard.properties
+++ b/termux/Chalkboard.properties
@@ -1,0 +1,22 @@
+# Chalkboard
+foreground=#d9e6f2
+background=#29262f
+cursor=#d9e6f2
+
+color0=#000000
+color1=#c37372
+color2=#72c373
+color3=#c2c372
+color4=#7372c3
+color5=#c372c2
+color6=#72c2c3
+color7=#d9d9d9
+
+color8=#323232
+color9=#dbaaaa
+color10=#aadbaa
+color11=#dadbaa
+color12=#aaaadb
+color13=#dbaada
+color14=#aadadb
+color15=#ffffff

--- a/termux/ChallengerDeep.properties
+++ b/termux/ChallengerDeep.properties
@@ -1,0 +1,22 @@
+# ChallengerDeep
+foreground=#cbe1e7
+background=#1e1c31
+cursor=#fbfcfc
+
+color0=#141228
+color1=#ff5458
+color2=#62d196
+color3=#ffb378
+color4=#65b2ff
+color5=#906cff
+color6=#63f2f1
+color7=#a6b3cc
+
+color8=#565575
+color9=#ff8080
+color10=#95ffa4
+color11=#ffe9aa
+color12=#91ddff
+color13=#c991e1
+color14=#aaffe4
+color15=#cbe3e7

--- a/termux/Chester.properties
+++ b/termux/Chester.properties
@@ -1,0 +1,22 @@
+# Chester
+foreground=#ffffff
+background=#2c3643
+cursor=#b4b1b1
+
+color0=#080200
+color1=#fa5e5b
+color2=#16c98d
+color3=#ffc83f
+color4=#288ad6
+color5=#d34590
+color6=#28ddde
+color7=#e7e7e7
+
+color8=#6f6b68
+color9=#fa5e5b
+color10=#16c98d
+color11=#feef6d
+color12=#278ad6
+color13=#d34590
+color14=#27dede
+color15=#ffffff

--- a/termux/Ciapre.properties
+++ b/termux/Ciapre.properties
@@ -1,0 +1,22 @@
+# Ciapre
+foreground=#aea47a
+background=#191c27
+cursor=#92805b
+
+color0=#181818
+color1=#810009
+color2=#48513b
+color3=#cc8b3f
+color4=#576d8c
+color5=#724d7c
+color6=#5c4f4b
+color7=#aea47f
+
+color8=#555555
+color9=#ac3835
+color10=#a6a75d
+color11=#dcdf7c
+color12=#3097c6
+color13=#d33061
+color14=#f3dbb2
+color15=#f4f4f4

--- a/termux/Cobalt Neon.properties
+++ b/termux/Cobalt Neon.properties
@@ -1,0 +1,22 @@
+# Cobalt Neon
+foreground=#8ff586
+background=#142838
+cursor=#c4206f
+
+color0=#142631
+color1=#ff2320
+color2=#3ba5ff
+color3=#e9e75c
+color4=#8ff586
+color5=#781aa0
+color6=#8ff586
+color7=#ba46b2
+
+color8=#fff688
+color9=#d4312e
+color10=#8ff586
+color11=#e9f06d
+color12=#3c7dd2
+color13=#8230a7
+color14=#6cbc67
+color15=#8ff586

--- a/termux/Cobalt2.properties
+++ b/termux/Cobalt2.properties
@@ -1,0 +1,22 @@
+# Cobalt2
+foreground=#ffffff
+background=#132738
+cursor=#f0cc09
+
+color0=#000000
+color1=#ff0000
+color2=#38de21
+color3=#ffe50a
+color4=#1460d2
+color5=#ff005d
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#f40e17
+color10=#3bd01d
+color11=#edc809
+color12=#5555ff
+color13=#ff55ff
+color14=#6ae3fa
+color15=#ffffff

--- a/termux/CrayonPonyFish.properties
+++ b/termux/CrayonPonyFish.properties
@@ -1,0 +1,22 @@
+# CrayonPonyFish
+foreground=#68525a
+background=#150707
+cursor=#68525a
+
+color0=#2b1b1d
+color1=#91002b
+color2=#579524
+color3=#ab311b
+color4=#8c87b0
+color5=#692f50
+color6=#e8a866
+color7=#68525a
+
+color8=#3d2b2e
+color9=#c5255d
+color10=#8dff57
+color11=#c8381d
+color12=#cfc9ff
+color13=#fc6cba
+color14=#ffceaf
+color15=#b0949d

--- a/termux/Cyberdyne.properties
+++ b/termux/Cyberdyne.properties
@@ -1,0 +1,22 @@
+# Cyberdyne
+foreground=#00ff92
+background=#151144
+cursor=#00ff9c
+
+color0=#080808
+color1=#ff8373
+color2=#00c172
+color3=#d2a700
+color4=#0071cf
+color5=#ff90fe
+color6=#6bffdd
+color7=#f1f1f1
+
+color8=#2e2e2e
+color9=#ffc4be
+color10=#d6fcba
+color11=#fffed5
+color12=#c2e3ff
+color13=#ffb2fe
+color14=#e6e7fe
+color15=#ffffff

--- a/termux/Dark Pastel.properties
+++ b/termux/Dark Pastel.properties
@@ -1,0 +1,22 @@
+# Dark Pastel
+foreground=#ffffff
+background=#000000
+cursor=#bbbbbb
+
+color0=#000000
+color1=#ff5555
+color2=#55ff55
+color3=#ffff55
+color4=#5555ff
+color5=#ff55ff
+color6=#55ffff
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Dark+.properties
+++ b/termux/Dark+.properties
@@ -1,0 +1,22 @@
+# Dark+
+foreground=#cccccc
+background=#1e1e1e
+cursor=#ffffff
+
+color0=#000000
+color1=#cd3131
+color2=#0dbc79
+color3=#e5e510
+color4=#2472c8
+color5=#bc3fbc
+color6=#11a8cd
+color7=#e5e5e5
+
+color8=#666666
+color9=#f14c4c
+color10=#23d18b
+color11=#f5f543
+color12=#3b8eea
+color13=#d670d6
+color14=#29b8db
+color15=#e5e5e5

--- a/termux/Darkside.properties
+++ b/termux/Darkside.properties
@@ -1,0 +1,22 @@
+# Darkside
+foreground=#bababa
+background=#222324
+cursor=#bbbbbb
+
+color0=#000000
+color1=#e8341c
+color2=#68c256
+color3=#f2d42c
+color4=#1c98e8
+color5=#8e69c9
+color6=#1c98e8
+color7=#bababa
+
+color8=#000000
+color9=#e05a4f
+color10=#77b869
+color11=#efd64b
+color12=#387cd3
+color13=#957bbe
+color14=#3d97e2
+color15=#bababa

--- a/termux/Desert.properties
+++ b/termux/Desert.properties
@@ -1,0 +1,22 @@
+# Desert
+foreground=#ffffff
+background=#333333
+cursor=#00ff00
+
+color0=#4d4d4d
+color1=#ff2b2b
+color2=#98fb98
+color3=#f0e68c
+color4=#cd853f
+color5=#ffdead
+color6=#ffa0a0
+color7=#f5deb3
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#87ceff
+color13=#ff55ff
+color14=#ffd700
+color15=#ffffff

--- a/termux/DimmedMonokai.properties
+++ b/termux/DimmedMonokai.properties
@@ -1,0 +1,22 @@
+# DimmedMonokai
+foreground=#b9bcba
+background=#1f1f1f
+cursor=#f83e19
+
+color0=#3a3d43
+color1=#be3f48
+color2=#879a3b
+color3=#c5a635
+color4=#4f76a1
+color5=#855c8d
+color6=#578fa4
+color7=#b9bcba
+
+color8=#888987
+color9=#fb001f
+color10=#0f722f
+color11=#c47033
+color12=#186de3
+color13=#fb0067
+color14=#2e706d
+color15=#fdffb9

--- a/termux/Django.properties
+++ b/termux/Django.properties
@@ -1,0 +1,22 @@
+# Django
+foreground=#f8f8f8
+background=#0b2f20
+cursor=#336442
+
+color0=#000000
+color1=#fd6209
+color2=#41a83e
+color3=#ffe862
+color4=#245032
+color5=#f8f8f8
+color6=#9df39f
+color7=#ffffff
+
+color8=#323232
+color9=#ff943b
+color10=#73da70
+color11=#ffff94
+color12=#568264
+color13=#ffffff
+color14=#cfffd1
+color15=#ffffff

--- a/termux/DjangoRebornAgain.properties
+++ b/termux/DjangoRebornAgain.properties
@@ -1,0 +1,22 @@
+# DjangoRebornAgain
+foreground=#dadedc
+background=#051f14
+cursor=#ffcc00
+
+color0=#000000
+color1=#fd6209
+color2=#41a83e
+color3=#ffe862
+color4=#245032
+color5=#f8f8f8
+color6=#9df39f
+color7=#ffffff
+
+color8=#323232
+color9=#ff943b
+color10=#73da70
+color11=#ffff94
+color12=#568264
+color13=#ffffff
+color14=#cfffd1
+color15=#ffffff

--- a/termux/DjangoSmooth.properties
+++ b/termux/DjangoSmooth.properties
@@ -1,0 +1,22 @@
+# DjangoSmooth
+foreground=#f8f8f8
+background=#245032
+cursor=#336442
+
+color0=#000000
+color1=#fd6209
+color2=#41a83e
+color3=#ffe862
+color4=#989898
+color5=#f8f8f8
+color6=#9df39f
+color7=#e8e8e7
+
+color8=#323232
+color9=#ff943b
+color10=#73da70
+color11=#ffff94
+color12=#cacaca
+color13=#ffffff
+color14=#cfffd1
+color15=#ffffff

--- a/termux/Doom Peacock.properties
+++ b/termux/Doom Peacock.properties
@@ -1,0 +1,22 @@
+# Doom Peacock
+foreground=#ede0ce
+background=#2b2a27
+cursor=#9c9c9d
+
+color0=#1c1f24
+color1=#cb4b16
+color2=#26a6a6
+color3=#bcd42a
+color4=#2a6cc6
+color5=#a9a1e1
+color6=#5699af
+color7=#ede0ce
+
+color8=#2b2a27
+color9=#ff5d38
+color10=#98be65
+color11=#e6f972
+color12=#51afef
+color13=#c678dd
+color14=#46d9ff
+color15=#dfdfdf

--- a/termux/DoomOne.properties
+++ b/termux/DoomOne.properties
@@ -1,0 +1,22 @@
+# DoomOne
+foreground=#bbc2cf
+background=#282c34
+cursor=#51afef
+
+color0=#000000
+color1=#ff6c6b
+color2=#98be65
+color3=#ecbe7b
+color4=#a9a1e1
+color5=#c678dd
+color6=#51afef
+color7=#bbc2cf
+
+color8=#000000
+color9=#ff6655
+color10=#99bb66
+color11=#ecbe7b
+color12=#a9a1e1
+color13=#c678dd
+color14=#51afef
+color15=#bfbfbf

--- a/termux/DotGov.properties
+++ b/termux/DotGov.properties
@@ -1,0 +1,22 @@
+# DotGov
+foreground=#ebebeb
+background=#262c35
+cursor=#d9002f
+
+color0=#191919
+color1=#bf091d
+color2=#3d9751
+color3=#f6bb34
+color4=#17b2e0
+color5=#7830b0
+color6=#8bd2ed
+color7=#ffffff
+
+color8=#191919
+color9=#bf091d
+color10=#3d9751
+color11=#f6bb34
+color12=#17b2e0
+color13=#7830b0
+color14=#8bd2ed
+color15=#ffffff

--- a/termux/Dracula+.properties
+++ b/termux/Dracula+.properties
@@ -1,0 +1,22 @@
+# Dracula+
+foreground=#f8f8f2
+background=#212121
+cursor=#eceff4
+
+color0=#21222c
+color1=#ff5555
+color2=#50fa7b
+color3=#ffcb6b
+color4=#82aaff
+color5=#c792ea
+color6=#8be9fd
+color7=#f8f8f2
+
+color8=#545454
+color9=#ff6e6e
+color10=#69ff94
+color11=#ffcb6b
+color12=#d6acff
+color13=#ff92df
+color14=#a4ffff
+color15=#f8f8f2

--- a/termux/Dracula.properties
+++ b/termux/Dracula.properties
@@ -1,0 +1,22 @@
+# Dracula
+foreground=#f8f8f2
+background=#1e1f29
+cursor=#bbbbbb
+
+color0=#000000
+color1=#ff5555
+color2=#50fa7b
+color3=#f1fa8c
+color4=#bd93f9
+color5=#ff79c6
+color6=#8be9fd
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#50fa7b
+color11=#f1fa8c
+color12=#bd93f9
+color13=#ff79c6
+color14=#8be9fd
+color15=#ffffff

--- a/termux/Duotone Dark.properties
+++ b/termux/Duotone Dark.properties
@@ -1,0 +1,22 @@
+# Duotone Dark
+foreground=#b7a1ff
+background=#1f1d27
+cursor=#ff9839
+
+color0=#1f1d27
+color1=#d9393e
+color2=#2dcd73
+color3=#d9b76e
+color4=#ffc284
+color5=#de8d40
+color6=#2488ff
+color7=#b7a1ff
+
+color8=#353147
+color9=#d9393e
+color10=#2dcd73
+color11=#d9b76e
+color12=#ffc284
+color13=#de8d40
+color14=#2488ff
+color15=#eae5ff

--- a/termux/ENCOM.properties
+++ b/termux/ENCOM.properties
@@ -1,0 +1,22 @@
+# ENCOM
+foreground=#00a595
+background=#000000
+cursor=#bbbbbb
+
+color0=#000000
+color1=#9f0000
+color2=#008b00
+color3=#ffd000
+color4=#0081ff
+color5=#bc00ca
+color6=#008b8b
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff0000
+color10=#00ee00
+color11=#ffff00
+color12=#0000ff
+color13=#ff00ff
+color14=#00cdcd
+color15=#ffffff

--- a/termux/Earthsong.properties
+++ b/termux/Earthsong.properties
@@ -1,0 +1,22 @@
+# Earthsong
+foreground=#e5c7a9
+background=#292520
+cursor=#f6f7ec
+
+color0=#121418
+color1=#c94234
+color2=#85c54c
+color3=#f5ae2e
+color4=#1398b9
+color5=#d0633d
+color6=#509552
+color7=#e5c6aa
+
+color8=#675f54
+color9=#ff645a
+color10=#98e036
+color11=#e0d561
+color12=#5fdaff
+color13=#ff9269
+color14=#84f088
+color15=#f6f7ec

--- a/termux/Elemental.properties
+++ b/termux/Elemental.properties
@@ -1,0 +1,22 @@
+# Elemental
+foreground=#807a74
+background=#22211d
+cursor=#facb80
+
+color0=#3c3c30
+color1=#98290f
+color2=#479a43
+color3=#7f7111
+color4=#497f7d
+color5=#7f4e2f
+color6=#387f58
+color7=#807974
+
+color8=#555445
+color9=#e0502a
+color10=#61e070
+color11=#d69927
+color12=#79d9d9
+color13=#cd7c54
+color14=#59d599
+color15=#fff1e9

--- a/termux/Elementary.properties
+++ b/termux/Elementary.properties
@@ -1,0 +1,22 @@
+# Elementary
+foreground=#efefef
+background=#181818
+cursor=#bbbbbb
+
+color0=#242424
+color1=#d71c15
+color2=#5aa513
+color3=#fdb40c
+color4=#063b8c
+color5=#e40038
+color6=#2595e1
+color7=#efefef
+
+color8=#4b4b4b
+color9=#fc1c18
+color10=#6bc219
+color11=#fec80e
+color12=#0955ff
+color13=#fb0050
+color14=#3ea8fc
+color15=#8c00ec

--- a/termux/Espresso Libre.properties
+++ b/termux/Espresso Libre.properties
@@ -1,0 +1,22 @@
+# Espresso Libre
+foreground=#b8a898
+background=#2a211c
+cursor=#ffffff
+
+color0=#000000
+color1=#cc0000
+color2=#1a921c
+color3=#f0e53a
+color4=#0066ff
+color5=#c5656b
+color6=#06989a
+color7=#d3d7cf
+
+color8=#555753
+color9=#ef2929
+color10=#9aff87
+color11=#fffb5c
+color12=#43a8ed
+color13=#ff818a
+color14=#34e2e2
+color15=#eeeeec

--- a/termux/Espresso.properties
+++ b/termux/Espresso.properties
@@ -1,0 +1,22 @@
+# Espresso
+foreground=#ffffff
+background=#323232
+cursor=#d6d6d6
+
+color0=#353535
+color1=#d25252
+color2=#a5c261
+color3=#ffc66d
+color4=#6c99bb
+color5=#d197d9
+color6=#bed6ff
+color7=#eeeeec
+
+color8=#535353
+color9=#f00c0c
+color10=#c2e075
+color11=#e1e48b
+color12=#8ab7d9
+color13=#efb5f7
+color14=#dcf4ff
+color15=#ffffff

--- a/termux/Everblush.properties
+++ b/termux/Everblush.properties
@@ -1,0 +1,22 @@
+# Everblush
+foreground=#dadada
+background=#141b1e
+cursor=#dadada
+
+color0=#232a2d
+color1=#e57474
+color2=#8ccf7e
+color3=#e5c76b
+color4=#67b0e8
+color5=#c47fd5
+color6=#6cbfbf
+color7=#b3b9b8
+
+color8=#2d3437
+color9=#ef7e7e
+color10=#96d988
+color11=#f4d67a
+color12=#71baf2
+color13=#ce89df
+color14=#67cbe7
+color15=#bdc3c2

--- a/termux/Fahrenheit.properties
+++ b/termux/Fahrenheit.properties
@@ -1,0 +1,22 @@
+# Fahrenheit
+foreground=#ffffce
+background=#000000
+cursor=#bbbbbb
+
+color0=#1d1d1d
+color1=#cda074
+color2=#9e744d
+color3=#fecf75
+color4=#720102
+color5=#734c4d
+color6=#979797
+color7=#ffffce
+
+color8=#000000
+color9=#fecea0
+color10=#cc734d
+color11=#fd9f4d
+color12=#cb4a05
+color13=#4e739f
+color14=#fed04d
+color15=#ffffff

--- a/termux/Fairyfloss.properties
+++ b/termux/Fairyfloss.properties
@@ -1,0 +1,22 @@
+# Fairyfloss
+foreground=#f8f8f2
+background=#5a5475
+cursor=#f8f8f0
+
+color0=#040303
+color1=#f92672
+color2=#c2ffdf
+color3=#e6c000
+color4=#c2ffdf
+color5=#ffb8d1
+color6=#c5a3ff
+color7=#f8f8f0
+
+color8=#6090cb
+color9=#ff857f
+color10=#c2ffdf
+color11=#ffea00
+color12=#c2ffdf
+color13=#ffb8d1
+color14=#c5a3ff
+color15=#f8f8f0

--- a/termux/Fideloper.properties
+++ b/termux/Fideloper.properties
@@ -1,0 +1,22 @@
+# Fideloper
+foreground=#dbdae0
+background=#292f33
+cursor=#d4605a
+
+color0=#292f33
+color1=#cb1e2d
+color2=#edb8ac
+color3=#b7ab9b
+color4=#2e78c2
+color5=#c0236f
+color6=#309186
+color7=#eae3ce
+
+color8=#092028
+color9=#d4605a
+color10=#d4605a
+color11=#a86671
+color12=#7c85c4
+color13=#5c5db2
+color14=#819090
+color15=#fcf4df

--- a/termux/FirefoxDev.properties
+++ b/termux/FirefoxDev.properties
@@ -1,0 +1,22 @@
+# FirefoxDev
+foreground=#7c8fa4
+background=#0e1011
+cursor=#708284
+
+color0=#002831
+color1=#e63853
+color2=#5eb83c
+color3=#a57706
+color4=#359ddf
+color5=#d75cff
+color6=#4b73a2
+color7=#dcdcdc
+
+color8=#001e27
+color9=#e1003f
+color10=#1d9000
+color11=#cd9409
+color12=#006fc0
+color13=#a200da
+color14=#005794
+color15=#e2e2e2

--- a/termux/Firewatch.properties
+++ b/termux/Firewatch.properties
@@ -1,0 +1,22 @@
+# Firewatch
+foreground=#9ba2b2
+background=#1e2027
+cursor=#f6f7ec
+
+color0=#585f6d
+color1=#d95360
+color2=#5ab977
+color3=#dfb563
+color4=#4d89c4
+color5=#d55119
+color6=#44a8b6
+color7=#e6e5ff
+
+color8=#585f6d
+color9=#d95360
+color10=#5ab977
+color11=#dfb563
+color12=#4c89c5
+color13=#d55119
+color14=#44a8b6
+color15=#e6e5ff

--- a/termux/FishTank.properties
+++ b/termux/FishTank.properties
@@ -1,0 +1,22 @@
+# FishTank
+foreground=#ecf0fe
+background=#232537
+cursor=#fecd5e
+
+color0=#03073c
+color1=#c6004a
+color2=#acf157
+color3=#fecd5e
+color4=#525fb8
+color5=#986f82
+color6=#968763
+color7=#ecf0fc
+
+color8=#6c5b30
+color9=#da4b8a
+color10=#dbffa9
+color11=#fee6a9
+color12=#b2befa
+color13=#fda5cd
+color14=#a5bd86
+color15=#f6ffec

--- a/termux/Flat.properties
+++ b/termux/Flat.properties
@@ -1,0 +1,22 @@
+# Flat
+foreground=#2cc55d
+background=#002240
+cursor=#e5be0c
+
+color0=#222d3f
+color1=#a82320
+color2=#32a548
+color3=#e58d11
+color4=#3167ac
+color5=#781aa0
+color6=#2c9370
+color7=#b0b6ba
+
+color8=#212c3c
+color9=#d4312e
+color10=#2d9440
+color11=#e5be0c
+color12=#3c7dd2
+color13=#8230a7
+color14=#35b387
+color15=#e7eced

--- a/termux/Flatland.properties
+++ b/termux/Flatland.properties
@@ -1,0 +1,22 @@
+# Flatland
+foreground=#b8dbef
+background=#1d1f21
+cursor=#708284
+
+color0=#1d1d19
+color1=#f18339
+color2=#9fd364
+color3=#f4ef6d
+color4=#5096be
+color5=#695abc
+color6=#d63865
+color7=#ffffff
+
+color8=#1d1d19
+color9=#d22a24
+color10=#a7d42c
+color11=#ff8949
+color12=#61b9d0
+color13=#695abc
+color14=#d63865
+color15=#ffffff

--- a/termux/Floraverse.properties
+++ b/termux/Floraverse.properties
@@ -1,0 +1,22 @@
+# Floraverse
+foreground=#dbd1b9
+background=#0e0d15
+cursor=#bbbbbb
+
+color0=#08002e
+color1=#64002c
+color2=#5d731a
+color3=#cd751c
+color4=#1d6da1
+color5=#b7077e
+color6=#42a38c
+color7=#f3e0b8
+
+color8=#331e4d
+color9=#d02063
+color10=#b4ce59
+color11=#fac357
+color12=#40a4cf
+color13=#f12aae
+color14=#62caa8
+color15=#fff5db

--- a/termux/ForestBlue.properties
+++ b/termux/ForestBlue.properties
@@ -1,0 +1,22 @@
+# ForestBlue
+foreground=#e2d8cd
+background=#051519
+cursor=#9e9ecb
+
+color0=#333333
+color1=#f8818e
+color2=#92d3a2
+color3=#1a8e63
+color4=#8ed0ce
+color5=#5e468c
+color6=#31658c
+color7=#e2d8cd
+
+color8=#3d3d3d
+color9=#fb3d66
+color10=#6bb48d
+color11=#30c85a
+color12=#39a7a2
+color13=#7e62b3
+color14=#6096bf
+color15=#e2d8cd

--- a/termux/Framer.properties
+++ b/termux/Framer.properties
@@ -1,0 +1,22 @@
+# Framer
+foreground=#777777
+background=#111111
+cursor=#fcdc08
+
+color0=#141414
+color1=#ff5555
+color2=#98ec65
+color3=#ffcc33
+color4=#00aaff
+color5=#aa88ff
+color6=#88ddff
+color7=#cccccc
+
+color8=#414141
+color9=#ff8888
+color10=#b6f292
+color11=#ffd966
+color12=#33bbff
+color13=#cebbff
+color14=#bbecff
+color15=#ffffff

--- a/termux/FrontEndDelight.properties
+++ b/termux/FrontEndDelight.properties
@@ -1,0 +1,22 @@
+# FrontEndDelight
+foreground=#adadad
+background=#1b1c1d
+cursor=#cdcdcd
+
+color0=#242526
+color1=#f8511b
+color2=#565747
+color3=#fa771d
+color4=#2c70b7
+color5=#f02e4f
+color6=#3ca1a6
+color7=#adadad
+
+color8=#5fac6d
+color9=#f74319
+color10=#74ec4c
+color11=#fdc325
+color12=#3393ca
+color13=#e75e4f
+color14=#4fbce6
+color15=#8c735b

--- a/termux/FunForrest.properties
+++ b/termux/FunForrest.properties
@@ -1,0 +1,22 @@
+# FunForrest
+foreground=#dec165
+background=#251200
+cursor=#e5591c
+
+color0=#000000
+color1=#d6262b
+color2=#919c00
+color3=#be8a13
+color4=#4699a3
+color5=#8d4331
+color6=#da8213
+color7=#ddc265
+
+color8=#7f6a55
+color9=#e55a1c
+color10=#bfc65a
+color11=#ffcb1b
+color12=#7cc9cf
+color13=#d26349
+color14=#e6a96b
+color15=#ffeaa3

--- a/termux/Galaxy.properties
+++ b/termux/Galaxy.properties
@@ -1,0 +1,22 @@
+# Galaxy
+foreground=#ffffff
+background=#1d2837
+cursor=#bbbbbb
+
+color0=#000000
+color1=#f9555f
+color2=#21b089
+color3=#fef02a
+color4=#589df6
+color5=#944d95
+color6=#1f9ee7
+color7=#bbbbbb
+
+color8=#555555
+color9=#fa8c8f
+color10=#35bb9a
+color11=#ffff55
+color12=#589df6
+color13=#e75699
+color14=#3979bc
+color15=#ffffff

--- a/termux/Galizur.properties
+++ b/termux/Galizur.properties
@@ -1,0 +1,22 @@
+# Galizur
+foreground=#ddeeff
+background=#071317
+cursor=#ddeeff
+
+color0=#223344
+color1=#aa1122
+color2=#33aa11
+color3=#ccaa22
+color4=#2255cc
+color5=#7755aa
+color6=#22bbdd
+color7=#8899aa
+
+color8=#556677
+color9=#ff1133
+color10=#33ff11
+color11=#ffdd33
+color12=#3377ff
+color13=#aa77ff
+color14=#33ddff
+color15=#bbccdd

--- a/termux/GitHub Dark.properties
+++ b/termux/GitHub Dark.properties
@@ -1,0 +1,22 @@
+# GitHub Dark
+foreground=#8b949e
+background=#101216
+cursor=#c9d1d9
+
+color0=#000000
+color1=#f78166
+color2=#56d364
+color3=#e3b341
+color4=#6ca4f8
+color5=#db61a2
+color6=#2b7489
+color7=#ffffff
+
+color8=#4d4d4d
+color9=#f78166
+color10=#56d364
+color11=#e3b341
+color12=#6ca4f8
+color13=#db61a2
+color14=#2b7489
+color15=#ffffff

--- a/termux/Github.properties
+++ b/termux/Github.properties
@@ -1,0 +1,22 @@
+# Github
+foreground=#3e3e3e
+background=#f4f4f4
+cursor=#3f3f3f
+
+color0=#3e3e3e
+color1=#970b16
+color2=#07962a
+color3=#f8eec7
+color4=#003e8a
+color5=#e94691
+color6=#89d1ec
+color7=#ffffff
+
+color8=#666666
+color9=#de0000
+color10=#87d5a2
+color11=#f1d007
+color12=#2e6cba
+color13=#ffa29f
+color14=#1cfafe
+color15=#ffffff

--- a/termux/Glacier.properties
+++ b/termux/Glacier.properties
@@ -1,0 +1,22 @@
+# Glacier
+foreground=#ffffff
+background=#0c1115
+cursor=#6c6c6c
+
+color0=#2e343c
+color1=#bd0f2f
+color2=#35a770
+color3=#fb9435
+color4=#1f5872
+color5=#bd2523
+color6=#778397
+color7=#ffffff
+
+color8=#404a55
+color9=#bd0f2f
+color10=#49e998
+color11=#fddf6e
+color12=#2a8bc1
+color13=#ea4727
+color14=#a0b6d3
+color15=#ffffff

--- a/termux/Grape.properties
+++ b/termux/Grape.properties
@@ -1,0 +1,22 @@
+# Grape
+foreground=#9f9fa1
+background=#171423
+cursor=#a288f7
+
+color0=#2d283f
+color1=#ed2261
+color2=#1fa91b
+color3=#8ddc20
+color4=#487df4
+color5=#8d35c9
+color6=#3bdeed
+color7=#9e9ea0
+
+color8=#59516a
+color9=#f0729a
+color10=#53aa5e
+color11=#b2dc87
+color12=#a9bcec
+color13=#ad81c2
+color14=#9de3eb
+color15=#a288f7

--- a/termux/Grass.properties
+++ b/termux/Grass.properties
@@ -1,0 +1,22 @@
+# Grass
+foreground=#fff0a5
+background=#13773d
+cursor=#8c2800
+
+color0=#000000
+color1=#bb0000
+color2=#00bb00
+color3=#e7b000
+color4=#0000a3
+color5=#950062
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#bb0000
+color10=#00bb00
+color11=#e7b000
+color12=#0000bb
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Grey-green.properties
+++ b/termux/Grey-green.properties
@@ -1,0 +1,22 @@
+# Grey-green
+foreground=#ffffff
+background=#002a1a
+cursor=#fff400
+
+color0=#000000
+color1=#fe1414
+color2=#74ff00
+color3=#f1ff01
+color4=#00deff
+color5=#ff00f0
+color6=#00ffbc
+color7=#ffffff
+
+color8=#666666
+color9=#ff3939
+color10=#00ff44
+color11=#ffd100
+color12=#00afff
+color13=#ff008a
+color14=#00ffd3
+color15=#f5ecec

--- a/termux/Gruvbox Light.properties
+++ b/termux/Gruvbox Light.properties
@@ -1,0 +1,22 @@
+# Gruvbox Light
+foreground=#282828
+background=#fbf1c7
+cursor=#282828
+
+color0=#fbf1c7
+color1=#9d0006
+color2=#79740e
+color3=#b57614
+color4=#076678
+color5=#8f3f71
+color6=#427b58
+color7=#3c3836
+
+color8=#9d8374
+color9=#cc241d
+color10=#98971a
+color11=#d79921
+color12=#458588
+color13=#b16186
+color14=#689d69
+color15=#7c6f64

--- a/termux/GruvboxDark.properties
+++ b/termux/GruvboxDark.properties
@@ -1,0 +1,22 @@
+# GruvboxDark
+foreground=#ebdbb2
+background=#282828
+cursor=#ebdbb2
+
+color0=#282828
+color1=#cc241d
+color2=#98971a
+color3=#d79921
+color4=#458588
+color5=#b16286
+color6=#689d6a
+color7=#a89984
+
+color8=#928374
+color9=#fb4934
+color10=#b8bb26
+color11=#fabd2f
+color12=#83a598
+color13=#d3869b
+color14=#8ec07c
+color15=#ebdbb2

--- a/termux/GruvboxDarkHard.properties
+++ b/termux/GruvboxDarkHard.properties
@@ -1,0 +1,22 @@
+# GruvboxDarkHard
+foreground=#ebdbb2
+background=#1b1b1b
+cursor=#ebdbb2
+
+color0=#1b1b1b
+color1=#cc241d
+color2=#98971a
+color3=#d79921
+color4=#458588
+color5=#b16286
+color6=#689d6a
+color7=#a89984
+
+color8=#928374
+color9=#fb4934
+color10=#b8bb26
+color11=#fabd2f
+color12=#83a598
+color13=#d3869b
+color14=#8ec07c
+color15=#ebdbb2

--- a/termux/Guezwhoz.properties
+++ b/termux/Guezwhoz.properties
@@ -1,0 +1,22 @@
+# Guezwhoz
+foreground=#d0d0d0
+background=#1c1c1c
+cursor=#eeeeee
+
+color0=#080808
+color1=#ff5f5f
+color2=#87d7af
+color3=#d7d787
+color4=#5fafd7
+color5=#afafff
+color6=#5fd7d7
+color7=#dadada
+
+color8=#8a8a8a
+color9=#d75f5f
+color10=#afd7af
+color11=#d7d7af
+color12=#87afd7
+color13=#afafd7
+color14=#87d7d7
+color15=#dadada

--- a/termux/HaX0R_BLUE.properties
+++ b/termux/HaX0R_BLUE.properties
@@ -1,0 +1,22 @@
+# HaX0R_BLUE
+foreground=#11b7ff
+background=#010515
+cursor=#10b6ff
+
+color0=#010921
+color1=#10b6ff
+color2=#10b6ff
+color3=#10b6ff
+color4=#10b6ff
+color5=#10b6ff
+color6=#10b6ff
+color7=#fafafa
+
+color8=#080117
+color9=#00b3f7
+color10=#00b3f7
+color11=#00b3f7
+color12=#00b3f7
+color13=#00b3f7
+color14=#00b3f7
+color15=#fefefe

--- a/termux/HaX0R_GR33N.properties
+++ b/termux/HaX0R_GR33N.properties
@@ -1,0 +1,22 @@
+# HaX0R_GR33N
+foreground=#16b10e
+background=#020f01
+cursor=#15d00d
+
+color0=#001f0b
+color1=#15d00d
+color2=#15d00d
+color3=#15d00d
+color4=#15d00d
+color5=#15d00d
+color6=#15d00d
+color7=#fafafa
+
+color8=#001510
+color9=#19e20e
+color10=#19e20e
+color11=#19e20e
+color12=#19e20e
+color13=#19e20e
+color14=#19e20e
+color15=#fefefe

--- a/termux/HaX0R_R3D.properties
+++ b/termux/HaX0R_R3D.properties
@@ -1,0 +1,22 @@
+# HaX0R_R3D
+foreground=#b10e0e
+background=#200101
+cursor=#b00d0d
+
+color0=#1f0000
+color1=#b00d0d
+color2=#b00d0d
+color3=#b00d0d
+color4=#b00d0d
+color5=#b00d0d
+color6=#b00d0d
+color7=#fafafa
+
+color8=#150000
+color9=#ff1111
+color10=#ff1010
+color11=#ff1010
+color12=#ff1010
+color13=#ff1010
+color14=#ff1010
+color15=#fefefe

--- a/termux/Hacktober.properties
+++ b/termux/Hacktober.properties
@@ -1,0 +1,22 @@
+# Hacktober
+foreground=#c9c9c9
+background=#141414
+cursor=#c9c9c9
+
+color0=#191918
+color1=#b34538
+color2=#587744
+color3=#d08949
+color4=#206ec5
+color5=#864651
+color6=#ac9166
+color7=#f1eee7
+
+color8=#2c2b2a
+color9=#b33323
+color10=#42824a
+color11=#c75a22
+color12=#5389c5
+color13=#e795a5
+color14=#ebc587
+color15=#ffffff

--- a/termux/Hardcore.properties
+++ b/termux/Hardcore.properties
@@ -1,0 +1,22 @@
+# Hardcore
+foreground=#a0a0a0
+background=#121212
+cursor=#bbbbbb
+
+color0=#1b1d1e
+color1=#f92672
+color2=#a6e22e
+color3=#fd971f
+color4=#66d9ef
+color5=#9e6ffe
+color6=#5e7175
+color7=#ccccc6
+
+color8=#505354
+color9=#ff669d
+color10=#beed5f
+color11=#e6db74
+color12=#66d9ef
+color13=#9e6ffe
+color14=#a3babf
+color15=#f8f8f2

--- a/termux/Harper.properties
+++ b/termux/Harper.properties
@@ -1,0 +1,22 @@
+# Harper
+foreground=#a8a49d
+background=#010101
+cursor=#a8a49d
+
+color0=#010101
+color1=#f8b63f
+color2=#7fb5e1
+color3=#d6da25
+color4=#489e48
+color5=#b296c6
+color6=#f5bfd7
+color7=#a8a49d
+
+color8=#726e6a
+color9=#f8b63f
+color10=#7fb5e1
+color11=#d6da25
+color12=#489e48
+color13=#b296c6
+color14=#f5bfd7
+color15=#fefbea

--- a/termux/Highway.properties
+++ b/termux/Highway.properties
@@ -1,0 +1,22 @@
+# Highway
+foreground=#ededed
+background=#222225
+cursor=#e0d9b9
+
+color0=#000000
+color1=#d00e18
+color2=#138034
+color3=#ffcb3e
+color4=#006bb3
+color5=#6b2775
+color6=#384564
+color7=#ededed
+
+color8=#5d504a
+color9=#f07e18
+color10=#b1d130
+color11=#fff120
+color12=#4fc2fd
+color13=#de0071
+color14=#5d504a
+color15=#ffffff

--- a/termux/Hipster Green.properties
+++ b/termux/Hipster Green.properties
@@ -1,0 +1,22 @@
+# Hipster Green
+foreground=#84c138
+background=#100b05
+cursor=#23ff18
+
+color0=#000000
+color1=#b6214a
+color2=#00a600
+color3=#bfbf00
+color4=#246eb2
+color5=#b200b2
+color6=#00a6b2
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#86a93e
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Hivacruz.properties
+++ b/termux/Hivacruz.properties
@@ -1,0 +1,22 @@
+# Hivacruz
+foreground=#ede4e4
+background=#132638
+cursor=#979db4
+
+color0=#202746
+color1=#c94922
+color2=#ac9739
+color3=#c08b30
+color4=#3d8fd1
+color5=#6679cc
+color6=#22a2c9
+color7=#979db4
+
+color8=#6b7394
+color9=#c76b29
+color10=#73ad43
+color11=#5e6687
+color12=#898ea4
+color13=#dfe2f1
+color14=#9c637a
+color15=#f5f7ff

--- a/termux/Homebrew.properties
+++ b/termux/Homebrew.properties
@@ -1,0 +1,22 @@
+# Homebrew
+foreground=#00ff00
+background=#000000
+cursor=#23ff18
+
+color0=#000000
+color1=#990000
+color2=#00a600
+color3=#999900
+color4=#0000b2
+color5=#b200b2
+color6=#00a6b2
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#00d900
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Hopscotch.256.properties
+++ b/termux/Hopscotch.256.properties
@@ -1,0 +1,22 @@
+# Hopscotch.256
+foreground=#b9b5b8
+background=#322931
+cursor=#b9b5b8
+
+color0=#322931
+color1=#dd464c
+color2=#8fc13e
+color3=#fdcc59
+color4=#1290bf
+color5=#c85e7c
+color6=#149b93
+color7=#b9b5b8
+
+color8=#797379
+color9=#dd464c
+color10=#8fc13e
+color11=#fdcc59
+color12=#1290bf
+color13=#c85e7c
+color14=#149b93
+color15=#ffffff

--- a/termux/Hopscotch.properties
+++ b/termux/Hopscotch.properties
@@ -1,0 +1,22 @@
+# Hopscotch
+foreground=#b9b5b8
+background=#322931
+cursor=#b9b5b8
+
+color0=#322931
+color1=#dd464c
+color2=#8fc13e
+color3=#fdcc59
+color4=#1290bf
+color5=#c85e7c
+color6=#149b93
+color7=#b9b5b8
+
+color8=#797379
+color9=#fd8b19
+color10=#433b42
+color11=#5c545b
+color12=#989498
+color13=#d5d3d5
+color14=#b33508
+color15=#ffffff

--- a/termux/Hurtado.properties
+++ b/termux/Hurtado.properties
@@ -1,0 +1,22 @@
+# Hurtado
+foreground=#dbdbdb
+background=#000000
+cursor=#bbbbbb
+
+color0=#575757
+color1=#ff1b00
+color2=#a5e055
+color3=#fbe74a
+color4=#496487
+color5=#fd5ff1
+color6=#86e9fe
+color7=#cbcccb
+
+color8=#262626
+color9=#d51d00
+color10=#a5df55
+color11=#fbe84a
+color12=#89beff
+color13=#c001c1
+color14=#86eafe
+color15=#dbdbdb

--- a/termux/Hybrid.properties
+++ b/termux/Hybrid.properties
@@ -1,0 +1,22 @@
+# Hybrid
+foreground=#b7bcba
+background=#161719
+cursor=#b7bcba
+
+color0=#2a2e33
+color1=#b84d51
+color2=#b3bf5a
+color3=#e4b55e
+color4=#6e90b0
+color5=#a17eac
+color6=#7fbfb4
+color7=#b5b9b6
+
+color8=#1d1f22
+color9=#8d2e32
+color10=#798431
+color11=#e58a50
+color12=#4b6b88
+color13=#6e5079
+color14=#4d7b74
+color15=#5a626a

--- a/termux/IC_Green_PPL.properties
+++ b/termux/IC_Green_PPL.properties
@@ -1,0 +1,22 @@
+# IC_Green_PPL
+foreground=#e0f1dc
+background=#2c2c2c
+cursor=#47fa6b
+
+color0=#014401
+color1=#ff2736
+color2=#41a638
+color3=#76a831
+color4=#2ec3b9
+color5=#50a096
+color6=#3ca078
+color7=#e6fef2
+
+color8=#035c03
+color9=#b4fa5c
+color10=#aefb86
+color11=#dafa87
+color12=#2efaeb
+color13=#50fafa
+color14=#3cfac8
+color15=#e0f1dc

--- a/termux/IC_Orange_PPL.properties
+++ b/termux/IC_Orange_PPL.properties
@@ -1,0 +1,22 @@
+# IC_Orange_PPL
+foreground=#ffcb83
+background=#262626
+cursor=#fc531d
+
+color0=#000000
+color1=#c13900
+color2=#a4a900
+color3=#caaf00
+color4=#bd6d00
+color5=#fc5e00
+color6=#f79500
+color7=#ffc88a
+
+color8=#6a4f2a
+color9=#ff8c68
+color10=#f6ff40
+color11=#ffe36e
+color12=#ffbe55
+color13=#fc874f
+color14=#c69752
+color15=#fafaff

--- a/termux/IR_Black.properties
+++ b/termux/IR_Black.properties
@@ -1,0 +1,22 @@
+# IR_Black
+foreground=#f1f1f1
+background=#000000
+cursor=#808080
+
+color0=#4f4f4f
+color1=#fa6c60
+color2=#a8ff60
+color3=#fffeb7
+color4=#96cafe
+color5=#fa73fd
+color6=#c6c5fe
+color7=#efedef
+
+color8=#7b7b7b
+color9=#fcb6b0
+color10=#cfffab
+color11=#ffffcc
+color12=#b5dcff
+color13=#fb9cfe
+color14=#e0e0fe
+color15=#ffffff

--- a/termux/Jackie Brown.properties
+++ b/termux/Jackie Brown.properties
@@ -1,0 +1,22 @@
+# Jackie Brown
+foreground=#ffcc2f
+background=#2c1d16
+cursor=#23ff18
+
+color0=#2c1d16
+color1=#ef5734
+color2=#2baf2b
+color3=#bebf00
+color4=#246eb2
+color5=#d05ec1
+color6=#00acee
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#86a93e
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Japanesque.properties
+++ b/termux/Japanesque.properties
@@ -1,0 +1,22 @@
+# Japanesque
+foreground=#f7f6ec
+background=#1e1e1e
+cursor=#edcf4f
+
+color0=#343935
+color1=#cf3f61
+color2=#7bb75b
+color3=#e9b32a
+color4=#4c9ad4
+color5=#a57fc4
+color6=#389aad
+color7=#fafaf6
+
+color8=#595b59
+color9=#d18fa6
+color10=#767f2c
+color11=#78592f
+color12=#135979
+color13=#604291
+color14=#76bbca
+color15=#b2b5ae

--- a/termux/Jellybeans.properties
+++ b/termux/Jellybeans.properties
@@ -1,0 +1,22 @@
+# Jellybeans
+foreground=#dedede
+background=#121212
+cursor=#ffa560
+
+color0=#929292
+color1=#e27373
+color2=#94b979
+color3=#ffba7b
+color4=#97bedc
+color5=#e1c0fa
+color6=#00988e
+color7=#dedede
+
+color8=#bdbdbd
+color9=#ffa1a1
+color10=#bddeab
+color11=#ffdca0
+color12=#b1d8f6
+color13=#fbdaff
+color14=#1ab2a8
+color15=#ffffff

--- a/termux/JetBrains Darcula.properties
+++ b/termux/JetBrains Darcula.properties
@@ -1,0 +1,22 @@
+# JetBrains Darcula
+foreground=#adadad
+background=#202020
+cursor=#ffffff
+
+color0=#000000
+color1=#fa5355
+color2=#126e00
+color3=#c2c300
+color4=#4581eb
+color5=#fa54ff
+color6=#33c2c1
+color7=#adadad
+
+color8=#555555
+color9=#fb7172
+color10=#67ff4f
+color11=#ffff00
+color12=#6d9df1
+color13=#fb82ff
+color14=#60d3d1
+color15=#eeeeee

--- a/termux/Kibble.properties
+++ b/termux/Kibble.properties
@@ -1,0 +1,22 @@
+# Kibble
+foreground=#f7f7f7
+background=#0e100a
+cursor=#9fda9c
+
+color0=#4d4d4d
+color1=#c70031
+color2=#29cf13
+color3=#d8e30e
+color4=#3449d1
+color5=#8400ff
+color6=#0798ab
+color7=#e2d1e3
+
+color8=#5a5a5a
+color9=#f01578
+color10=#6ce05c
+color11=#f3f79e
+color12=#97a4f7
+color13=#c495f0
+color14=#68f2e0
+color15=#ffffff

--- a/termux/Kolorit.properties
+++ b/termux/Kolorit.properties
@@ -1,0 +1,22 @@
+# Kolorit
+foreground=#efecec
+background=#1d1a1e
+cursor=#c7c7c7
+
+color0=#1d1a1e
+color1=#ff5b82
+color2=#47d7a1
+color3=#e8e562
+color4=#5db4ee
+color5=#da6cda
+color6=#57e9eb
+color7=#ededed
+
+color8=#1d1a1e
+color9=#ff5b82
+color10=#47d7a1
+color11=#e8e562
+color12=#5db4ee
+color13=#da6cda
+color14=#57e9eb
+color15=#ededed

--- a/termux/Konsolas.properties
+++ b/termux/Konsolas.properties
@@ -1,0 +1,22 @@
+# Konsolas
+foreground=#c8c1c1
+background=#060606
+cursor=#c8c1c1
+
+color0=#000000
+color1=#aa1717
+color2=#18b218
+color3=#ebae1f
+color4=#2323a5
+color5=#ad1edc
+color6=#42b0c8
+color7=#c8c1c1
+
+color8=#7b716e
+color9=#ff4141
+color10=#5fff5f
+color11=#ffff55
+color12=#4b4bff
+color13=#ff54ff
+color14=#69ffff
+color15=#ffffff

--- a/termux/Lab Fox.properties
+++ b/termux/Lab Fox.properties
@@ -1,0 +1,22 @@
+# Lab Fox
+foreground=#ffffff
+background=#2e2e2e
+cursor=#7f7f7f
+
+color0=#2e2e2e
+color1=#fc6d26
+color2=#3eb383
+color3=#fca121
+color4=#db3b21
+color5=#380d75
+color6=#6e49cb
+color7=#ffffff
+
+color8=#464646
+color9=#ff6517
+color10=#53eaa8
+color11=#fca013
+color12=#db501f
+color13=#441090
+color14=#7d53e7
+color15=#ffffff

--- a/termux/Laser.properties
+++ b/termux/Laser.properties
@@ -1,0 +1,22 @@
+# Laser
+foreground=#f106e3
+background=#030d18
+cursor=#00ff9c
+
+color0=#626262
+color1=#ff8373
+color2=#b4fb73
+color3=#09b4bd
+color4=#fed300
+color5=#ff90fe
+color6=#d1d1fe
+color7=#f1f1f1
+
+color8=#8f8f8f
+color9=#ffc4be
+color10=#d6fcba
+color11=#fffed5
+color12=#f92883
+color13=#ffb2fe
+color14=#e6e7fe
+color15=#ffffff

--- a/termux/Later This Evening.properties
+++ b/termux/Later This Evening.properties
@@ -1,0 +1,22 @@
+# Later This Evening
+foreground=#959595
+background=#222222
+cursor=#424242
+
+color0=#2b2b2b
+color1=#d45a60
+color2=#afba67
+color3=#e5d289
+color4=#a0bad6
+color5=#c092d6
+color6=#91bfb7
+color7=#3c3d3d
+
+color8=#454747
+color9=#d3232f
+color10=#aabb39
+color11=#e5be39
+color12=#6699d6
+color13=#ab53d6
+color14=#5fc0ae
+color15=#c1c2c2

--- a/termux/Lavandula.properties
+++ b/termux/Lavandula.properties
@@ -1,0 +1,22 @@
+# Lavandula
+foreground=#736e7d
+background=#050014
+cursor=#8c91fa
+
+color0=#230046
+color1=#7d1625
+color2=#337e6f
+color3=#7f6f49
+color4=#4f4a7f
+color5=#5a3f7f
+color6=#58777f
+color7=#736e7d
+
+color8=#372d46
+color9=#e05167
+color10=#52e0c4
+color11=#e0c386
+color12=#8e87e0
+color13=#a776e0
+color14=#9ad4e0
+color15=#8c91fa

--- a/termux/LiquidCarbon.properties
+++ b/termux/LiquidCarbon.properties
@@ -1,0 +1,22 @@
+# LiquidCarbon
+foreground=#afc2c2
+background=#303030
+cursor=#ffffff
+
+color0=#000000
+color1=#ff3030
+color2=#559a70
+color3=#ccac00
+color4=#0099cc
+color5=#cc69c8
+color6=#7ac4cc
+color7=#bccccc
+
+color8=#000000
+color9=#ff3030
+color10=#559a70
+color11=#ccac00
+color12=#0099cc
+color13=#cc69c8
+color14=#7ac4cc
+color15=#bccccc

--- a/termux/LiquidCarbonTransparent.properties
+++ b/termux/LiquidCarbonTransparent.properties
@@ -1,0 +1,22 @@
+# LiquidCarbonTransparent
+foreground=#afc2c2
+background=#000000
+cursor=#ffffff
+
+color0=#000000
+color1=#ff3030
+color2=#559a70
+color3=#ccac00
+color4=#0099cc
+color5=#cc69c8
+color6=#7ac4cc
+color7=#bccccc
+
+color8=#000000
+color9=#ff3030
+color10=#559a70
+color11=#ccac00
+color12=#0099cc
+color13=#cc69c8
+color14=#7ac4cc
+color15=#bccccc

--- a/termux/LiquidCarbonTransparentInverse.properties
+++ b/termux/LiquidCarbonTransparentInverse.properties
@@ -1,0 +1,22 @@
+# LiquidCarbonTransparentInverse
+foreground=#afc2c2
+background=#000000
+cursor=#ffffff
+
+color0=#bccccd
+color1=#ff3030
+color2=#559a70
+color3=#ccac00
+color4=#0099cc
+color5=#cc69c8
+color6=#7ac4cc
+color7=#000000
+
+color8=#ffffff
+color9=#ff3030
+color10=#559a70
+color11=#ccac00
+color12=#0099cc
+color13=#cc69c8
+color14=#7ac4cc
+color15=#000000

--- a/termux/Man Page.properties
+++ b/termux/Man Page.properties
@@ -1,0 +1,22 @@
+# Man Page
+foreground=#000000
+background=#fef49c
+cursor=#7f7f7f
+
+color0=#000000
+color1=#cc0000
+color2=#00a600
+color3=#999900
+color4=#0000b2
+color5=#b200b2
+color6=#00a6b2
+color7=#cccccc
+
+color8=#666666
+color9=#e50000
+color10=#00d900
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Mariana.properties
+++ b/termux/Mariana.properties
@@ -1,0 +1,22 @@
+# Mariana
+foreground=#d8dee9
+background=#343d46
+cursor=#fcbb6a
+
+color0=#000000
+color1=#ec5f66
+color2=#99c794
+color3=#f9ae58
+color4=#6699cc
+color5=#c695c6
+color6=#5fb4b4
+color7=#f7f7f7
+
+color8=#333333
+color9=#f97b58
+color10=#acd1a8
+color11=#fac761
+color12=#85add6
+color13=#d8b6d8
+color14=#82c4c4
+color15=#ffffff

--- a/termux/Material.properties
+++ b/termux/Material.properties
@@ -1,0 +1,22 @@
+# Material
+foreground=#232322
+background=#eaeaea
+cursor=#16afca
+
+color0=#212121
+color1=#b7141f
+color2=#457b24
+color3=#f6981e
+color4=#134eb2
+color5=#560088
+color6=#0e717c
+color7=#efefef
+
+color8=#424242
+color9=#e83b3f
+color10=#7aba3a
+color11=#ffea2e
+color12=#54a4f3
+color13=#aa4dbc
+color14=#26bbd1
+color15=#d9d9d9

--- a/termux/MaterialDark.properties
+++ b/termux/MaterialDark.properties
@@ -1,0 +1,22 @@
+# MaterialDark
+foreground=#e5e5e5
+background=#232322
+cursor=#16afca
+
+color0=#212121
+color1=#b7141f
+color2=#457b24
+color3=#f6981e
+color4=#134eb2
+color5=#560088
+color6=#0e717c
+color7=#efefef
+
+color8=#424242
+color9=#e83b3f
+color10=#7aba3a
+color11=#ffea2e
+color12=#54a4f3
+color13=#aa4dbc
+color14=#26bbd1
+color15=#d9d9d9

--- a/termux/MaterialDarker.properties
+++ b/termux/MaterialDarker.properties
@@ -1,0 +1,22 @@
+# MaterialDarker
+foreground=#eeffff
+background=#212121
+cursor=#ffffff
+
+color0=#000000
+color1=#ff5370
+color2=#c3e88d
+color3=#ffcb6b
+color4=#82aaff
+color5=#c792ea
+color6=#89ddff
+color7=#ffffff
+
+color8=#545454
+color9=#ff5370
+color10=#c3e88d
+color11=#ffcb6b
+color12=#82aaff
+color13=#c792ea
+color14=#89ddff
+color15=#ffffff

--- a/termux/MaterialDesignColors.properties
+++ b/termux/MaterialDesignColors.properties
@@ -1,0 +1,22 @@
+# MaterialDesignColors
+foreground=#e7ebed
+background=#1d262a
+cursor=#eaeaea
+
+color0=#435b67
+color1=#fc3841
+color2=#5cf19e
+color3=#fed032
+color4=#37b6ff
+color5=#fc226e
+color6=#59ffd1
+color7=#ffffff
+
+color8=#a1b0b8
+color9=#fc746d
+color10=#adf7be
+color11=#fee16c
+color12=#70cfff
+color13=#fc669b
+color14=#9affe6
+color15=#ffffff

--- a/termux/MaterialOcean.properties
+++ b/termux/MaterialOcean.properties
@@ -1,0 +1,22 @@
+# MaterialOcean
+foreground=#8f93a2
+background=#0f111a
+cursor=#ffcc00
+
+color0=#546e7a
+color1=#ff5370
+color2=#c3e88d
+color3=#ffcb6b
+color4=#82aaff
+color5=#c792ea
+color6=#89ddff
+color7=#ffffff
+
+color8=#546e7a
+color9=#ff5370
+color10=#c3e88d
+color11=#ffcb6b
+color12=#82aaff
+color13=#c792ea
+color14=#89ddff
+color15=#ffffff

--- a/termux/Mathias.properties
+++ b/termux/Mathias.properties
@@ -1,0 +1,22 @@
+# Mathias
+foreground=#bbbbbb
+background=#000000
+cursor=#bbbbbb
+
+color0=#000000
+color1=#e52222
+color2=#a6e32d
+color3=#fc951e
+color4=#c48dff
+color5=#fa2573
+color6=#67d9f0
+color7=#f2f2f2
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Medallion.properties
+++ b/termux/Medallion.properties
@@ -1,0 +1,22 @@
+# Medallion
+foreground=#cac296
+background=#1d1908
+cursor=#d3ba30
+
+color0=#000000
+color1=#b64c00
+color2=#7c8b16
+color3=#d3bd26
+color4=#616bb0
+color5=#8c5a90
+color6=#916c25
+color7=#cac29a
+
+color8=#5e5219
+color9=#ff9149
+color10=#b2ca3b
+color11=#ffe54a
+color12=#acb8ff
+color13=#ffa0ff
+color14=#ffbc51
+color15=#fed698

--- a/termux/Mirage.properties
+++ b/termux/Mirage.properties
@@ -1,0 +1,22 @@
+# Mirage
+foreground=#a6b2c0
+background=#1b2738
+cursor=#ddb3ff
+
+color0=#011627
+color1=#ff9999
+color2=#85cc95
+color3=#ffd700
+color4=#7fb5ff
+color5=#ddb3ff
+color6=#21c7a8
+color7=#ffffff
+
+color8=#575656
+color9=#ff9999
+color10=#85cc95
+color11=#ffd700
+color12=#7fb5ff
+color13=#ddb3ff
+color14=#85cc95
+color15=#ffffff

--- a/termux/Misterioso.properties
+++ b/termux/Misterioso.properties
@@ -1,0 +1,22 @@
+# Misterioso
+foreground=#e1e1e0
+background=#2d3743
+cursor=#000000
+
+color0=#000000
+color1=#ff4242
+color2=#74af68
+color3=#ffad29
+color4=#338f86
+color5=#9414e6
+color6=#23d7d7
+color7=#e1e1e0
+
+color8=#555555
+color9=#ff3242
+color10=#74cd68
+color11=#ffb929
+color12=#23d7d7
+color13=#ff37ff
+color14=#00ede1
+color15=#ffffff

--- a/termux/Molokai.properties
+++ b/termux/Molokai.properties
@@ -1,0 +1,22 @@
+# Molokai
+foreground=#bbbbbb
+background=#121212
+cursor=#bbbbbb
+
+color0=#121212
+color1=#fa2573
+color2=#98e123
+color3=#dfd460
+color4=#1080d0
+color5=#8700ff
+color6=#43a8d0
+color7=#bbbbbb
+
+color8=#555555
+color9=#f6669d
+color10=#b1e05f
+color11=#fff26d
+color12=#00afff
+color13=#af87ff
+color14=#51ceff
+color15=#ffffff

--- a/termux/MonaLisa.properties
+++ b/termux/MonaLisa.properties
@@ -1,0 +1,22 @@
+# MonaLisa
+foreground=#f7d66a
+background=#120b0d
+cursor=#c46c32
+
+color0=#351b0e
+color1=#9b291c
+color2=#636232
+color3=#c36e28
+color4=#515c5d
+color5=#9b1d29
+color6=#588056
+color7=#f7d75c
+
+color8=#874228
+color9=#ff4331
+color10=#b4b264
+color11=#ff9566
+color12=#9eb2b4
+color13=#ff5b6a
+color14=#8acd8f
+color15=#ffe598

--- a/termux/Monokai Remastered.properties
+++ b/termux/Monokai Remastered.properties
@@ -1,0 +1,22 @@
+# Monokai Remastered
+foreground=#d9d9d9
+background=#0c0c0c
+cursor=#fc971f
+
+color0=#1a1a1a
+color1=#f4005f
+color2=#98e024
+color3=#fd971f
+color4=#9d65ff
+color5=#f4005f
+color6=#58d1eb
+color7=#c4c5b5
+
+color8=#625e4c
+color9=#f4005f
+color10=#98e024
+color11=#e0d561
+color12=#9d65ff
+color13=#f4005f
+color14=#58d1eb
+color15=#f6f6ef

--- a/termux/Monokai Soda.properties
+++ b/termux/Monokai Soda.properties
@@ -1,0 +1,22 @@
+# Monokai Soda
+foreground=#c4c5b5
+background=#1a1a1a
+cursor=#f6f7ec
+
+color0=#1a1a1a
+color1=#f4005f
+color2=#98e024
+color3=#fa8419
+color4=#9d65ff
+color5=#f4005f
+color6=#58d1eb
+color7=#c4c5b5
+
+color8=#625e4c
+color9=#f4005f
+color10=#98e024
+color11=#e0d561
+color12=#9d65ff
+color13=#f4005f
+color14=#58d1eb
+color15=#f6f6ef

--- a/termux/Monokai Vivid.properties
+++ b/termux/Monokai Vivid.properties
@@ -1,0 +1,22 @@
+# Monokai Vivid
+foreground=#f9f9f9
+background=#121212
+cursor=#fb0007
+
+color0=#121212
+color1=#fa2934
+color2=#98e123
+color3=#fff30a
+color4=#0443ff
+color5=#f800f8
+color6=#01b6ed
+color7=#ffffff
+
+color8=#838383
+color9=#f6669d
+color10=#b1e05f
+color11=#fff26d
+color12=#0443ff
+color13=#f200f6
+color14=#51ceff
+color15=#ffffff

--- a/termux/N0tch2k.properties
+++ b/termux/N0tch2k.properties
@@ -1,0 +1,22 @@
+# N0tch2k
+foreground=#a0a0a0
+background=#222222
+cursor=#aa9175
+
+color0=#383838
+color1=#a95551
+color2=#666666
+color3=#a98051
+color4=#657d3e
+color5=#767676
+color6=#c9c9c9
+color7=#d0b8a3
+
+color8=#474747
+color9=#a97775
+color10=#8c8c8c
+color11=#a99175
+color12=#98bd5e
+color13=#a3a3a3
+color14=#dcdcdc
+color15=#d8c8bb

--- a/termux/Neon.properties
+++ b/termux/Neon.properties
@@ -1,0 +1,22 @@
+# Neon
+foreground=#00fffc
+background=#14161a
+cursor=#c7c7c7
+
+color0=#000000
+color1=#ff3045
+color2=#5ffa74
+color3=#fffc7e
+color4=#0208cb
+color5=#f924e7
+color6=#00fffc
+color7=#c7c7c7
+
+color8=#686868
+color9=#ff5a5a
+color10=#75ff88
+color11=#fffd96
+color12=#3c40cb
+color13=#f15be5
+color14=#88fffe
+color15=#ffffff

--- a/termux/Neopolitan.properties
+++ b/termux/Neopolitan.properties
@@ -1,0 +1,22 @@
+# Neopolitan
+foreground=#ffffff
+background=#271f19
+cursor=#ffffff
+
+color0=#000000
+color1=#800000
+color2=#61ce3c
+color3=#fbde2d
+color4=#253b76
+color5=#ff0080
+color6=#8da6ce
+color7=#f8f8f8
+
+color8=#000000
+color9=#800000
+color10=#61ce3c
+color11=#fbde2d
+color12=#253b76
+color13=#ff0080
+color14=#8da6ce
+color15=#f8f8f8

--- a/termux/Neutron.properties
+++ b/termux/Neutron.properties
@@ -1,0 +1,22 @@
+# Neutron
+foreground=#e6e8ef
+background=#1c1e22
+cursor=#f6f7ec
+
+color0=#23252b
+color1=#b54036
+color2=#5ab977
+color3=#deb566
+color4=#6a7c93
+color5=#a4799d
+color6=#3f94a8
+color7=#e6e8ef
+
+color8=#23252b
+color9=#b54036
+color10=#5ab977
+color11=#deb566
+color12=#6a7c93
+color13=#a4799d
+color14=#3f94a8
+color15=#ebedf2

--- a/termux/Night Owlish Light.properties
+++ b/termux/Night Owlish Light.properties
@@ -1,0 +1,22 @@
+# Night Owlish Light
+foreground=#403f53
+background=#ffffff
+cursor=#403f53
+
+color0=#011627
+color1=#d3423e
+color2=#2aa298
+color3=#daaa01
+color4=#4876d6
+color5=#403f53
+color6=#08916a
+color7=#7a8181
+
+color8=#7a8181
+color9=#f76e6e
+color10=#49d0c5
+color11=#dac26b
+color12=#5ca7e4
+color13=#697098
+color14=#00c990
+color15=#989fb1

--- a/termux/NightLion v1.properties
+++ b/termux/NightLion v1.properties
@@ -1,0 +1,22 @@
+# NightLion v1
+foreground=#bbbbbb
+background=#000000
+cursor=#bbbbbb
+
+color0=#4c4c4c
+color1=#bb0000
+color2=#5fde8f
+color3=#f3f167
+color4=#276bd8
+color5=#bb00bb
+color6=#00dadf
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/NightLion v2.properties
+++ b/termux/NightLion v2.properties
@@ -1,0 +1,22 @@
+# NightLion v2
+foreground=#bbbbbb
+background=#171717
+cursor=#bbbbbb
+
+color0=#4c4c4c
+color1=#bb0000
+color2=#04f623
+color3=#f3f167
+color4=#64d0f0
+color5=#ce6fdb
+color6=#00dadf
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff5555
+color10=#7df71d
+color11=#ffff55
+color12=#62cbe8
+color13=#ff9bf5
+color14=#00ccd8
+color15=#ffffff

--- a/termux/Nocturnal Winter.properties
+++ b/termux/Nocturnal Winter.properties
@@ -1,0 +1,22 @@
+# Nocturnal Winter
+foreground=#e6e5e5
+background=#0d0d17
+cursor=#e6e5e5
+
+color0=#4d4d4d
+color1=#f12d52
+color2=#09cd7e
+color3=#f5f17a
+color4=#3182e0
+color5=#ff2b6d
+color6=#09c87a
+color7=#fcfcfc
+
+color8=#808080
+color9=#f16d86
+color10=#0ae78d
+color11=#fffc67
+color12=#6096ff
+color13=#ff78a2
+color14=#0ae78d
+color15=#ffffff

--- a/termux/Novel.properties
+++ b/termux/Novel.properties
@@ -1,0 +1,22 @@
+# Novel
+foreground=#3b2322
+background=#dfdbc3
+cursor=#73635a
+
+color0=#000000
+color1=#cc0000
+color2=#009600
+color3=#d06b00
+color4=#0000cc
+color5=#cc00cc
+color6=#0087cc
+color7=#cccccc
+
+color8=#808080
+color9=#cc0000
+color10=#009600
+color11=#d06b00
+color12=#0000cc
+color13=#cc00cc
+color14=#0087cc
+color15=#ffffff

--- a/termux/Obsidian.properties
+++ b/termux/Obsidian.properties
@@ -1,0 +1,22 @@
+# Obsidian
+foreground=#cdcdcd
+background=#283033
+cursor=#c0cad0
+
+color0=#000000
+color1=#a60001
+color2=#00bb00
+color3=#fecd22
+color4=#3a9bdb
+color5=#bb00bb
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#ff0003
+color10=#93c863
+color11=#fef874
+color12=#a1d7ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Ocean.properties
+++ b/termux/Ocean.properties
@@ -1,0 +1,22 @@
+# Ocean
+foreground=#ffffff
+background=#224fbc
+cursor=#7f7f7f
+
+color0=#000000
+color1=#990000
+color2=#00a600
+color3=#999900
+color4=#0000b2
+color5=#b200b2
+color6=#00a6b2
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#00d900
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Oceanic-Next.properties
+++ b/termux/Oceanic-Next.properties
@@ -1,0 +1,22 @@
+# Oceanic-Next
+foreground=#b3b8c3
+background=#121b21
+cursor=#b3b8c3
+
+color0=#121c21
+color1=#e44754
+color2=#89bd82
+color3=#f7bd51
+color4=#5486c0
+color5=#b77eb8
+color6=#50a5a4
+color7=#ffffff
+
+color8=#52606b
+color9=#e44754
+color10=#89bd82
+color11=#f7bd51
+color12=#5486c0
+color13=#b77eb8
+color14=#50a5a4
+color15=#ffffff

--- a/termux/OceanicMaterial.properties
+++ b/termux/OceanicMaterial.properties
@@ -1,0 +1,22 @@
+# OceanicMaterial
+foreground=#c2c8d7
+background=#1c262b
+cursor=#b3b8c3
+
+color0=#000000
+color1=#ee2b2a
+color2=#40a33f
+color3=#ffea2e
+color4=#1e80f0
+color5=#8800a0
+color6=#16afca
+color7=#a4a4a4
+
+color8=#777777
+color9=#dc5c60
+color10=#70be71
+color11=#fff163
+color12=#54a4f3
+color13=#aa4dbc
+color14=#42c7da
+color15=#ffffff

--- a/termux/Ollie.properties
+++ b/termux/Ollie.properties
@@ -1,0 +1,22 @@
+# Ollie
+foreground=#8a8dae
+background=#222125
+cursor=#5b6ea7
+
+color0=#000000
+color1=#ac2e31
+color2=#31ac61
+color3=#ac4300
+color4=#2d57ac
+color5=#b08528
+color6=#1fa6ac
+color7=#8a8eac
+
+color8=#5b3725
+color9=#ff3d48
+color10=#3bff99
+color11=#ff5e1e
+color12=#4488ff
+color13=#ffc21d
+color14=#1ffaff
+color15=#5b6ea7

--- a/termux/OneHalfDark.properties
+++ b/termux/OneHalfDark.properties
@@ -1,0 +1,22 @@
+# OneHalfDark
+foreground=#dcdfe4
+background=#282c34
+cursor=#a3b3cc
+
+color0=#282c34
+color1=#e06c75
+color2=#98c379
+color3=#e5c07b
+color4=#61afef
+color5=#c678dd
+color6=#56b6c2
+color7=#dcdfe4
+
+color8=#282c34
+color9=#e06c75
+color10=#98c379
+color11=#e5c07b
+color12=#61afef
+color13=#c678dd
+color14=#56b6c2
+color15=#dcdfe4

--- a/termux/OneHalfLight.properties
+++ b/termux/OneHalfLight.properties
@@ -1,0 +1,22 @@
+# OneHalfLight
+foreground=#383a42
+background=#fafafa
+cursor=#bfceff
+
+color0=#383a42
+color1=#e45649
+color2=#50a14f
+color3=#c18401
+color4=#0184bc
+color5=#a626a4
+color6=#0997b3
+color7=#fafafa
+
+color8=#4f525e
+color9=#e06c75
+color10=#98c379
+color11=#e5c07b
+color12=#61afef
+color13=#c678dd
+color14=#56b6c2
+color15=#ffffff

--- a/termux/Operator Mono Dark.properties
+++ b/termux/Operator Mono Dark.properties
@@ -1,0 +1,22 @@
+# Operator Mono Dark
+foreground=#c3cac2
+background=#191919
+cursor=#fcdc08
+
+color0=#5a5a5a
+color1=#ca372d
+color2=#4d7b3a
+color3=#d4d697
+color4=#4387cf
+color5=#b86cb4
+color6=#72d5c6
+color7=#ced4cd
+
+color8=#9a9b99
+color9=#c37d62
+color10=#83d0a2
+color11=#fdfdc5
+color12=#89d3f6
+color13=#ff2c7a
+color14=#82eada
+color15=#fdfdf6

--- a/termux/Overnight Slumber.properties
+++ b/termux/Overnight Slumber.properties
@@ -1,0 +1,22 @@
+# Overnight Slumber
+foreground=#ced2d6
+background=#0e1729
+cursor=#ffa7c4
+
+color0=#0a1222
+color1=#ffa7c4
+color2=#85cc95
+color3=#ffcb8b
+color4=#8dabe1
+color5=#c792eb
+color6=#78ccf0
+color7=#ffffff
+
+color8=#575656
+color9=#ffa7c4
+color10=#85cc95
+color11=#ffcb8b
+color12=#8dabe1
+color13=#c792eb
+color14=#ffa7c4
+color15=#ffffff

--- a/termux/PaleNightHC.properties
+++ b/termux/PaleNightHC.properties
@@ -1,0 +1,22 @@
+# PaleNightHC
+foreground=#cccccc
+background=#3e4251
+cursor=#ffcb6b
+
+color0=#000000
+color1=#f07178
+color2=#c3e88d
+color3=#ffcb6b
+color4=#82aaff
+color5=#c792ea
+color6=#89ddff
+color7=#ffffff
+
+color8=#666666
+color9=#f6a9ae
+color10=#dbf1ba
+color11=#ffdfa6
+color12=#b4ccff
+color13=#ddbdf2
+color14=#b8eaff
+color15=#999999

--- a/termux/Pandora.properties
+++ b/termux/Pandora.properties
@@ -1,0 +1,22 @@
+# Pandora
+foreground=#e1e1e1
+background=#141e43
+cursor=#43d58e
+
+color0=#000000
+color1=#ff4242
+color2=#74af68
+color3=#ffad29
+color4=#338f86
+color5=#9414e6
+color6=#23d7d7
+color7=#e2e2e2
+
+color8=#3f5648
+color9=#ff3242
+color10=#74cd68
+color11=#ffb929
+color12=#23d7d7
+color13=#ff37ff
+color14=#00ede1
+color15=#ffffff

--- a/termux/Paraiso Dark.properties
+++ b/termux/Paraiso Dark.properties
@@ -1,0 +1,22 @@
+# Paraiso Dark
+foreground=#a39e9b
+background=#2f1e2e
+cursor=#a39e9b
+
+color0=#2f1e2e
+color1=#ef6155
+color2=#48b685
+color3=#fec418
+color4=#06b6ef
+color5=#815ba4
+color6=#5bc4bf
+color7=#a39e9b
+
+color8=#776e71
+color9=#ef6155
+color10=#48b685
+color11=#fec418
+color12=#06b6ef
+color13=#815ba4
+color14=#5bc4bf
+color15=#e7e9db

--- a/termux/PaulMillr.properties
+++ b/termux/PaulMillr.properties
@@ -1,0 +1,22 @@
+# PaulMillr
+foreground=#f2f2f2
+background=#000000
+cursor=#4d4d4d
+
+color0=#2a2a2a
+color1=#ff0000
+color2=#79ff0f
+color3=#e7bf00
+color4=#396bd7
+color5=#b449be
+color6=#66ccff
+color7=#bbbbbb
+
+color8=#666666
+color9=#ff0080
+color10=#66ff66
+color11=#f3d64e
+color12=#709aed
+color13=#db67e6
+color14=#7adff2
+color15=#ffffff

--- a/termux/PencilDark.properties
+++ b/termux/PencilDark.properties
@@ -1,0 +1,22 @@
+# PencilDark
+foreground=#f1f1f1
+background=#212121
+cursor=#20bbfc
+
+color0=#212121
+color1=#c30771
+color2=#10a778
+color3=#a89c14
+color4=#008ec4
+color5=#523c79
+color6=#20a5ba
+color7=#d9d9d9
+
+color8=#424242
+color9=#fb007a
+color10=#5fd7af
+color11=#f3e430
+color12=#20bbfc
+color13=#6855de
+color14=#4fb8cc
+color15=#f1f1f1

--- a/termux/PencilLight.properties
+++ b/termux/PencilLight.properties
@@ -1,0 +1,22 @@
+# PencilLight
+foreground=#424242
+background=#f1f1f1
+cursor=#20bbfc
+
+color0=#212121
+color1=#c30771
+color2=#10a778
+color3=#a89c14
+color4=#008ec4
+color5=#523c79
+color6=#20a5ba
+color7=#d9d9d9
+
+color8=#424242
+color9=#fb007a
+color10=#5fd7af
+color11=#f3e430
+color12=#20bbfc
+color13=#6855de
+color14=#4fb8cc
+color15=#f1f1f1

--- a/termux/Peppermint.properties
+++ b/termux/Peppermint.properties
@@ -1,0 +1,22 @@
+# Peppermint
+foreground=#c8c8c8
+background=#000000
+cursor=#bbbbbb
+
+color0=#353535
+color1=#e74669
+color2=#89d287
+color3=#dab853
+color4=#449fd0
+color5=#da62dc
+color6=#65aaaf
+color7=#b4b4b4
+
+color8=#535353
+color9=#e4859b
+color10=#a3cca2
+color11=#e1e487
+color12=#6fbce2
+color13=#e586e7
+color14=#96dcdb
+color15=#dfdfdf

--- a/termux/Piatto Light.properties
+++ b/termux/Piatto Light.properties
@@ -1,0 +1,22 @@
+# Piatto Light
+foreground=#414141
+background=#ffffff
+cursor=#5e77c8
+
+color0=#414141
+color1=#b23771
+color2=#66781e
+color3=#cd6f34
+color4=#3c5ea8
+color5=#a454b2
+color6=#66781e
+color7=#ffffff
+
+color8=#3f3f3f
+color9=#db3365
+color10=#829429
+color11=#cd6f34
+color12=#3c5ea8
+color13=#a454b2
+color14=#829429
+color15=#f2f2f2

--- a/termux/Pnevma.properties
+++ b/termux/Pnevma.properties
@@ -1,0 +1,22 @@
+# Pnevma
+foreground=#d0d0d0
+background=#1c1c1c
+cursor=#e4c9af
+
+color0=#2f2e2d
+color1=#a36666
+color2=#90a57d
+color3=#d7af87
+color4=#7fa5bd
+color5=#c79ec4
+color6=#8adbb4
+color7=#d0d0d0
+
+color8=#4a4845
+color9=#d78787
+color10=#afbea2
+color11=#e4c9af
+color12=#a1bdce
+color13=#d7beda
+color14=#b1e7dd
+color15=#efefef

--- a/termux/Popping and Locking.properties
+++ b/termux/Popping and Locking.properties
@@ -1,0 +1,22 @@
+# Popping and Locking
+foreground=#ebdbb2
+background=#181921
+cursor=#c7c7c7
+
+color0=#1d2021
+color1=#cc241d
+color2=#98971a
+color3=#d79921
+color4=#458588
+color5=#b16286
+color6=#689d6a
+color7=#a89984
+
+color8=#928374
+color9=#f42c3e
+color10=#b8bb26
+color11=#fabd2f
+color12=#99c6ca
+color13=#d3869b
+color14=#7ec16e
+color15=#ebdbb2

--- a/termux/Pro Light.properties
+++ b/termux/Pro Light.properties
@@ -1,0 +1,22 @@
+# Pro Light
+foreground=#191919
+background=#ffffff
+cursor=#4d4d4d
+
+color0=#000000
+color1=#e5492b
+color2=#50d148
+color3=#c6c440
+color4=#3b75ff
+color5=#ed66e8
+color6=#4ed2de
+color7=#dcdcdc
+
+color8=#9f9f9f
+color9=#ff6640
+color10=#61ef57
+color11=#f2f156
+color12=#0082ff
+color13=#ff7eff
+color14=#61f7f8
+color15=#f2f2f2

--- a/termux/Pro.properties
+++ b/termux/Pro.properties
@@ -1,0 +1,22 @@
+# Pro
+foreground=#f2f2f2
+background=#000000
+cursor=#4d4d4d
+
+color0=#000000
+color1=#990000
+color2=#00a600
+color3=#999900
+color4=#2009db
+color5=#b200b2
+color6=#00a6b2
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#00d900
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Purple Rain.properties
+++ b/termux/Purple Rain.properties
@@ -1,0 +1,22 @@
+# Purple Rain
+foreground=#fffbf6
+background=#21084a
+cursor=#ff271d
+
+color0=#000000
+color1=#ff260e
+color2=#9be205
+color3=#ffc400
+color4=#00a2fa
+color5=#815bb5
+color6=#00deef
+color7=#ffffff
+
+color8=#565656
+color9=#ff4250
+color10=#b8e36e
+color11=#ffd852
+color12=#00a6ff
+color13=#ac7bf0
+color14=#74fdf3
+color15=#ffffff

--- a/termux/Rapture.properties
+++ b/termux/Rapture.properties
@@ -1,0 +1,22 @@
+# Rapture
+foreground=#c0c9e5
+background=#111e2a
+cursor=#ffffff
+
+color0=#000000
+color1=#fc644d
+color2=#7afde1
+color3=#fff09b
+color4=#6c9bf5
+color5=#ff4fa1
+color6=#64e0ff
+color7=#c0c9e5
+
+color8=#304b66
+color9=#fc644d
+color10=#7afde1
+color11=#fff09b
+color12=#6c9bf5
+color13=#ff4fa1
+color14=#64e0ff
+color15=#ffffff

--- a/termux/Raycast_Dark.properties
+++ b/termux/Raycast_Dark.properties
@@ -1,0 +1,22 @@
+# Raycast_Dark
+foreground=#ffffff
+background=#1a1a1a
+cursor=#cccccc
+
+color0=#000000
+color1=#ff5360
+color2=#59d499
+color3=#ffc531
+color4=#56c2ff
+color5=#cf2f98
+color6=#52eee5
+color7=#ffffff
+
+color8=#000000
+color9=#ff6363
+color10=#59d499
+color11=#ffc531
+color12=#56c2ff
+color13=#cf2f98
+color14=#52eee5
+color15=#ffffff

--- a/termux/Raycast_Light.properties
+++ b/termux/Raycast_Light.properties
@@ -1,0 +1,22 @@
+# Raycast_Light
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#b12424
+color2=#006b4f
+color3=#f8a300
+color4=#138af2
+color5=#9a1b6e
+color6=#3eb8bf
+color7=#ffffff
+
+color8=#000000
+color9=#b12424
+color10=#006b4f
+color11=#f8a300
+color12=#138af2
+color13=#9a1b6e
+color14=#3eb8bf
+color15=#ffffff

--- a/termux/Red Alert.properties
+++ b/termux/Red Alert.properties
@@ -1,0 +1,22 @@
+# Red Alert
+foreground=#ffffff
+background=#762423
+cursor=#ffffff
+
+color0=#000000
+color1=#d62e4e
+color2=#71be6b
+color3=#beb86b
+color4=#489bee
+color5=#e979d7
+color6=#6bbeb8
+color7=#d6d6d6
+
+color8=#262626
+color9=#e02553
+color10=#aff08c
+color11=#dfddb7
+color12=#65aaf1
+color13=#ddb7df
+color14=#b7dfdd
+color15=#ffffff

--- a/termux/Red Planet.properties
+++ b/termux/Red Planet.properties
@@ -1,0 +1,22 @@
+# Red Planet
+foreground=#c2b790
+background=#222222
+cursor=#c2b790
+
+color0=#202020
+color1=#8c3432
+color2=#728271
+color3=#e8bf6a
+color4=#69819e
+color5=#896492
+color6=#5b8390
+color7=#b9aa99
+
+color8=#676767
+color9=#b55242
+color10=#869985
+color11=#ebeb91
+color12=#60827e
+color13=#de4974
+color14=#38add8
+color15=#d6bfb8

--- a/termux/Red Sands.properties
+++ b/termux/Red Sands.properties
@@ -1,0 +1,22 @@
+# Red Sands
+foreground=#d7c9a7
+background=#7a251e
+cursor=#ffffff
+
+color0=#000000
+color1=#ff3f00
+color2=#00bb00
+color3=#e7b000
+color4=#0072ff
+color5=#bb00bb
+color6=#00bbbb
+color7=#bbbbbb
+
+color8=#555555
+color9=#bb0000
+color10=#00bb00
+color11=#e7b000
+color12=#0072ae
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Relaxed.properties
+++ b/termux/Relaxed.properties
@@ -1,0 +1,22 @@
+# Relaxed
+foreground=#d9d9d9
+background=#353a44
+cursor=#d9d9d9
+
+color0=#151515
+color1=#bc5653
+color2=#909d63
+color3=#ebc17a
+color4=#6a8799
+color5=#b06698
+color6=#c9dfff
+color7=#d9d9d9
+
+color8=#636363
+color9=#bc5653
+color10=#a0ac77
+color11=#ebc17a
+color12=#7eaac7
+color13=#b06698
+color14=#acbbd0
+color15=#f7f7f7

--- a/termux/Retro.properties
+++ b/termux/Retro.properties
@@ -1,0 +1,22 @@
+# Retro
+foreground=#13a10e
+background=#000000
+cursor=#13a10e
+
+color0=#13a10e
+color1=#13a10e
+color2=#13a10e
+color3=#13a10e
+color4=#13a10e
+color5=#13a10e
+color6=#13a10e
+color7=#13a10e
+
+color8=#16ba10
+color9=#16ba10
+color10=#16ba10
+color11=#16ba10
+color12=#16ba10
+color13=#16ba10
+color14=#16ba10
+color15=#16ba10

--- a/termux/Rippedcasts.properties
+++ b/termux/Rippedcasts.properties
@@ -1,0 +1,22 @@
+# Rippedcasts
+foreground=#ffffff
+background=#2b2b2b
+cursor=#7f7f7f
+
+color0=#000000
+color1=#cdaf95
+color2=#a8ff60
+color3=#bfbb1f
+color4=#75a5b0
+color5=#ff73fd
+color6=#5a647e
+color7=#bfbfbf
+
+color8=#666666
+color9=#eecbad
+color10=#bcee68
+color11=#e5e500
+color12=#86bdc9
+color13=#e500e5
+color14=#8c9bc4
+color15=#e5e5e5

--- a/termux/Rouge 2.properties
+++ b/termux/Rouge 2.properties
@@ -1,0 +1,22 @@
+# Rouge 2
+foreground=#a2a3aa
+background=#17182b
+cursor=#969e92
+
+color0=#5d5d6b
+color1=#c6797e
+color2=#969e92
+color3=#dbcdab
+color4=#6e94b9
+color5=#4c4e78
+color6=#8ab6c1
+color7=#e8e8ea
+
+color8=#616274
+color9=#c6797e
+color10=#e6dcc4
+color11=#e6dcc4
+color12=#98b3cd
+color13=#8283a1
+color14=#abcbd3
+color15=#e8e8ea

--- a/termux/Royal.properties
+++ b/termux/Royal.properties
@@ -1,0 +1,22 @@
+# Royal
+foreground=#514968
+background=#100815
+cursor=#524966
+
+color0=#241f2b
+color1=#91284c
+color2=#23801c
+color3=#b49d27
+color4=#6580b0
+color5=#674d96
+color6=#8aaabe
+color7=#524966
+
+color8=#312d3d
+color9=#d5356c
+color10=#2cd946
+color11=#fde83b
+color12=#90baf9
+color13=#a479e3
+color14=#acd4eb
+color15=#9e8cbd

--- a/termux/Ryuuko.properties
+++ b/termux/Ryuuko.properties
@@ -1,0 +1,22 @@
+# Ryuuko
+foreground=#ececec
+background=#2c3941
+cursor=#ececec
+
+color0=#2c3941
+color1=#865f5b
+color2=#66907d
+color3=#b1a990
+color4=#6a8e95
+color5=#b18a73
+color6=#88b2ac
+color7=#ececec
+
+color8=#5d7079
+color9=#865f5b
+color10=#66907d
+color11=#b1a990
+color12=#6a8e95
+color13=#b18a73
+color14=#88b2ac
+color15=#ececec

--- a/termux/Sakura.properties
+++ b/termux/Sakura.properties
@@ -1,0 +1,22 @@
+# Sakura
+foreground=#dd7bdc
+background=#18131e
+cursor=#ff65fd
+
+color0=#000000
+color1=#d52370
+color2=#41af1a
+color3=#bc7053
+color4=#6964ab
+color5=#c71fbf
+color6=#939393
+color7=#998eac
+
+color8=#786d69
+color9=#f41d99
+color10=#22e529
+color11=#f59574
+color12=#9892f1
+color13=#e90cdd
+color14=#eeeeee
+color15=#cbb6ff

--- a/termux/Scarlet Protocol.properties
+++ b/termux/Scarlet Protocol.properties
@@ -1,0 +1,22 @@
+# Scarlet Protocol
+foreground=#e41951
+background=#1c153d
+cursor=#76ff9f
+
+color0=#101116
+color1=#ff0051
+color2=#00dc84
+color3=#faf945
+color4=#0271b6
+color5=#ca30c7
+color6=#00c5c7
+color7=#c7c7c7
+
+color8=#686868
+color9=#ff6e67
+color10=#5ffa68
+color11=#fffc67
+color12=#6871ff
+color13=#bd35ec
+color14=#60fdff
+color15=#ffffff

--- a/termux/SeaShells.properties
+++ b/termux/SeaShells.properties
@@ -1,0 +1,22 @@
+# SeaShells
+foreground=#deb88d
+background=#09141b
+cursor=#fca02f
+
+color0=#17384c
+color1=#d15123
+color2=#027c9b
+color3=#fca02f
+color4=#1e4950
+color5=#68d4f1
+color6=#50a3b5
+color7=#deb88d
+
+color8=#434b53
+color9=#d48678
+color10=#628d98
+color11=#fdd39f
+color12=#1bbcdd
+color13=#bbe3ee
+color14=#87acb4
+color15=#fee4ce

--- a/termux/Seafoam Pastel.properties
+++ b/termux/Seafoam Pastel.properties
@@ -1,0 +1,22 @@
+# Seafoam Pastel
+foreground=#d4e7d4
+background=#243435
+cursor=#57647a
+
+color0=#757575
+color1=#825d4d
+color2=#728c62
+color3=#ada16d
+color4=#4d7b82
+color5=#8a7267
+color6=#729494
+color7=#e0e0e0
+
+color8=#8a8a8a
+color9=#cf937a
+color10=#98d9aa
+color11=#fae79d
+color12=#7ac3cf
+color13=#d6b2a1
+color14=#ade0e0
+color15=#e0e0e0

--- a/termux/Seti.properties
+++ b/termux/Seti.properties
@@ -1,0 +1,22 @@
+# Seti
+foreground=#cacecd
+background=#111213
+cursor=#e3bf21
+
+color0=#323232
+color1=#c22832
+color2=#8ec43d
+color3=#e0c64f
+color4=#43a5d5
+color5=#8b57b5
+color6=#8ec43d
+color7=#eeeeee
+
+color8=#323232
+color9=#c22832
+color10=#8ec43d
+color11=#e0c64f
+color12=#43a5d5
+color13=#8b57b5
+color14=#8ec43d
+color15=#ffffff

--- a/termux/Shaman.properties
+++ b/termux/Shaman.properties
@@ -1,0 +1,22 @@
+# Shaman
+foreground=#405555
+background=#001015
+cursor=#4afcd6
+
+color0=#012026
+color1=#b2302d
+color2=#00a941
+color3=#5e8baa
+color4=#449a86
+color5=#00599d
+color6=#5d7e19
+color7=#405555
+
+color8=#384451
+color9=#ff4242
+color10=#2aea5e
+color11=#8ed4fd
+color12=#61d5ba
+color13=#1298ff
+color14=#98d028
+color15=#58fbd6

--- a/termux/Slate.properties
+++ b/termux/Slate.properties
@@ -1,0 +1,22 @@
+# Slate
+foreground=#35b1d2
+background=#222222
+cursor=#87d3c4
+
+color0=#222222
+color1=#e2a8bf
+color2=#81d778
+color3=#c4c9c0
+color4=#264b49
+color5=#a481d3
+color6=#15ab9c
+color7=#02c5e0
+
+color8=#ffffff
+color9=#ffcdd9
+color10=#beffa8
+color11=#d0ccca
+color12=#7ab0d2
+color13=#c5a7d9
+color14=#8cdfe0
+color15=#e0e0e0

--- a/termux/SleepyHollow.properties
+++ b/termux/SleepyHollow.properties
@@ -1,0 +1,22 @@
+# SleepyHollow
+foreground=#af9a91
+background=#121214
+cursor=#af9a91
+
+color0=#572100
+color1=#ba3934
+color2=#91773f
+color3=#b55600
+color4=#5f63b4
+color5=#a17c7b
+color6=#8faea9
+color7=#af9a91
+
+color8=#4e4b61
+color9=#d9443f
+color10=#d6b04e
+color11=#f66813
+color12=#8086ef
+color13=#e2c2bb
+color14=#a4dce7
+color15=#d2c7a9

--- a/termux/Smyck.properties
+++ b/termux/Smyck.properties
@@ -1,0 +1,22 @@
+# Smyck
+foreground=#f7f7f7
+background=#1b1b1b
+cursor=#bbbbbb
+
+color0=#000000
+color1=#b84131
+color2=#7da900
+color3=#c4a500
+color4=#62a3c4
+color5=#ba8acc
+color6=#207383
+color7=#a1a1a1
+
+color8=#7a7a7a
+color9=#d6837c
+color10=#c4f137
+color11=#fee14d
+color12=#8dcff0
+color13=#f79aff
+color14=#6ad9cf
+color15=#f7f7f7

--- a/termux/Snazzy.properties
+++ b/termux/Snazzy.properties
@@ -1,0 +1,22 @@
+# Snazzy
+foreground=#ebece6
+background=#1e1f29
+cursor=#e4e4e4
+
+color0=#000000
+color1=#fc4346
+color2=#50fb7c
+color3=#f0fb8c
+color4=#49baff
+color5=#fc4cb4
+color6=#8be9fe
+color7=#ededec
+
+color8=#555555
+color9=#fc4346
+color10=#50fb7c
+color11=#f0fb8c
+color12=#49baff
+color13=#fc4cb4
+color14=#8be9fe
+color15=#ededec

--- a/termux/SoftServer.properties
+++ b/termux/SoftServer.properties
@@ -1,0 +1,22 @@
+# SoftServer
+foreground=#99a3a2
+background=#242626
+cursor=#d2e0de
+
+color0=#000000
+color1=#a2686a
+color2=#9aa56a
+color3=#a3906a
+color4=#6b8fa3
+color5=#6a71a3
+color6=#6ba58f
+color7=#99a3a2
+
+color8=#666c6c
+color9=#dd5c60
+color10=#bfdf55
+color11=#deb360
+color12=#62b1df
+color13=#606edf
+color14=#64e39c
+color15=#d2e0de

--- a/termux/Solarized Darcula.properties
+++ b/termux/Solarized Darcula.properties
@@ -1,0 +1,22 @@
+# Solarized Darcula
+foreground=#d2d8d9
+background=#3d3f41
+cursor=#708284
+
+color0=#25292a
+color1=#f24840
+color2=#629655
+color3=#b68800
+color4=#2075c7
+color5=#797fd4
+color6=#15968d
+color7=#d2d8d9
+
+color8=#25292a
+color9=#f24840
+color10=#629655
+color11=#b68800
+color12=#2075c7
+color13=#797fd4
+color14=#15968d
+color15=#d2d8d9

--- a/termux/Solarized Dark - Patched.properties
+++ b/termux/Solarized Dark - Patched.properties
@@ -1,0 +1,22 @@
+# Solarized Dark - Patched
+foreground=#708284
+background=#001e27
+cursor=#708284
+
+color0=#002831
+color1=#d11c24
+color2=#738a05
+color3=#a57706
+color4=#2176c7
+color5=#c61c6f
+color6=#259286
+color7=#eae3cb
+
+color8=#475b62
+color9=#bd3613
+color10=#475b62
+color11=#536870
+color12=#708284
+color13=#5956ba
+color14=#819090
+color15=#fcf4dc

--- a/termux/Solarized Dark Higher Contrast.properties
+++ b/termux/Solarized Dark Higher Contrast.properties
@@ -1,0 +1,22 @@
+# Solarized Dark Higher Contrast
+foreground=#9cc2c3
+background=#001e27
+cursor=#f34b00
+
+color0=#002831
+color1=#d11c24
+color2=#6cbe6c
+color3=#a57706
+color4=#2176c7
+color5=#c61c6f
+color6=#259286
+color7=#eae3cb
+
+color8=#006488
+color9=#f5163b
+color10=#51ef84
+color11=#b27e28
+color12=#178ec8
+color13=#e24d8e
+color14=#00b39e
+color15=#fcf4dc

--- a/termux/SpaceGray Eighties Dull.properties
+++ b/termux/SpaceGray Eighties Dull.properties
@@ -1,0 +1,22 @@
+# SpaceGray Eighties Dull
+foreground=#c9c6bc
+background=#222222
+cursor=#bbbbbb
+
+color0=#15171c
+color1=#b24a56
+color2=#92b477
+color3=#c6735a
+color4=#7c8fa5
+color5=#a5789e
+color6=#80cdcb
+color7=#b3b8c3
+
+color8=#555555
+color9=#ec5f67
+color10=#89e986
+color11=#fec254
+color12=#5486c0
+color13=#bf83c1
+color14=#58c2c1
+color15=#ffffff

--- a/termux/SpaceGray Eighties.properties
+++ b/termux/SpaceGray Eighties.properties
@@ -1,0 +1,22 @@
+# SpaceGray Eighties
+foreground=#bdbaae
+background=#222222
+cursor=#bbbbbb
+
+color0=#15171c
+color1=#ec5f67
+color2=#81a764
+color3=#fec254
+color4=#5486c0
+color5=#bf83c1
+color6=#57c2c1
+color7=#efece7
+
+color8=#555555
+color9=#ff6973
+color10=#93d493
+color11=#ffd256
+color12=#4d84d1
+color13=#ff55ff
+color14=#83e9e4
+color15=#ffffff

--- a/termux/SpaceGray.properties
+++ b/termux/SpaceGray.properties
@@ -1,0 +1,22 @@
+# SpaceGray
+foreground=#b3b8c3
+background=#20242d
+cursor=#b3b8c3
+
+color0=#000000
+color1=#b04b57
+color2=#87b379
+color3=#e5c179
+color4=#7d8fa4
+color5=#a47996
+color6=#85a7a5
+color7=#b3b8c3
+
+color8=#000000
+color9=#b04b57
+color10=#87b379
+color11=#e5c179
+color12=#7d8fa4
+color13=#a47996
+color14=#85a7a5
+color15=#ffffff

--- a/termux/Spacedust.properties
+++ b/termux/Spacedust.properties
@@ -1,0 +1,22 @@
+# Spacedust
+foreground=#ecf0c1
+background=#0a1e24
+cursor=#708284
+
+color0=#6e5346
+color1=#e35b00
+color2=#5cab96
+color3=#e3cd7b
+color4=#0f548b
+color5=#e35b00
+color6=#06afc7
+color7=#f0f1ce
+
+color8=#684c31
+color9=#ff8a3a
+color10=#aecab8
+color11=#ffc878
+color12=#67a0ce
+color13=#ff8a3a
+color14=#83a7b4
+color15=#fefff1

--- a/termux/Spiderman.properties
+++ b/termux/Spiderman.properties
@@ -1,0 +1,22 @@
+# Spiderman
+foreground=#e3e3e3
+background=#1b1d1e
+cursor=#2c3fff
+
+color0=#1b1d1e
+color1=#e60813
+color2=#e22928
+color3=#e24756
+color4=#2c3fff
+color5=#2435db
+color6=#3256ff
+color7=#fffef6
+
+color8=#505354
+color9=#ff0325
+color10=#ff3338
+color11=#fe3a35
+color12=#1d50ff
+color13=#747cff
+color14=#6184ff
+color15=#fffff9

--- a/termux/Spring.properties
+++ b/termux/Spring.properties
@@ -1,0 +1,22 @@
+# Spring
+foreground=#4d4d4c
+background=#ffffff
+cursor=#4d4d4c
+
+color0=#000000
+color1=#ff4d83
+color2=#1f8c3b
+color3=#1fc95b
+color4=#1dd3ee
+color5=#8959a8
+color6=#3e999f
+color7=#ffffff
+
+color8=#000000
+color9=#ff0021
+color10=#1fc231
+color11=#d5b807
+color12=#15a9fd
+color13=#8959a8
+color14=#3e999f
+color15=#ffffff

--- a/termux/Square.properties
+++ b/termux/Square.properties
@@ -1,0 +1,22 @@
+# Square
+foreground=#acacab
+background=#1a1a1a
+cursor=#fcfbcc
+
+color0=#050505
+color1=#e9897c
+color2=#b6377d
+color3=#ecebbe
+color4=#a9cdeb
+color5=#75507b
+color6=#c9caec
+color7=#f2f2f2
+
+color8=#141414
+color9=#f99286
+color10=#c3f786
+color11=#fcfbcc
+color12=#b6defb
+color13=#ad7fa8
+color14=#d7d9fc
+color15=#e2e2e2

--- a/termux/Sublette.properties
+++ b/termux/Sublette.properties
@@ -1,0 +1,22 @@
+# Sublette
+foreground=#ccced0
+background=#202535
+cursor=#ccced0
+
+color0=#253045
+color1=#ee5577
+color2=#55ee77
+color3=#ffdd88
+color4=#5588ff
+color5=#ff77cc
+color6=#44eeee
+color7=#f5f5da
+
+color8=#405570
+color9=#ee6655
+color10=#99ee77
+color11=#ffff77
+color12=#77bbff
+color13=#aa88ff
+color14=#55ffbb
+color15=#ffffee

--- a/termux/Subliminal.properties
+++ b/termux/Subliminal.properties
@@ -1,0 +1,22 @@
+# Subliminal
+foreground=#d4d4d4
+background=#282c35
+cursor=#c7c7c7
+
+color0=#7f7f7f
+color1=#e15a60
+color2=#a9cfa4
+color3=#ffe2a9
+color4=#6699cc
+color5=#f1a5ab
+color6=#5fb3b3
+color7=#d4d4d4
+
+color8=#7f7f7f
+color9=#e15a60
+color10=#a9cfa4
+color11=#ffe2a9
+color12=#6699cc
+color13=#f1a5ab
+color14=#5fb3b3
+color15=#d4d4d4

--- a/termux/Sundried.properties
+++ b/termux/Sundried.properties
@@ -1,0 +1,22 @@
+# Sundried
+foreground=#c9c9c9
+background=#1a1818
+cursor=#ffffff
+
+color0=#302b2a
+color1=#a7463d
+color2=#587744
+color3=#9d602a
+color4=#485b98
+color5=#864651
+color6=#9c814f
+color7=#c9c9c9
+
+color8=#4d4e48
+color9=#aa000c
+color10=#128c21
+color11=#fc6a21
+color12=#7999f7
+color13=#fd8aa1
+color14=#fad484
+color15=#ffffff

--- a/termux/Symfonic.properties
+++ b/termux/Symfonic.properties
@@ -1,0 +1,22 @@
+# Symfonic
+foreground=#ffffff
+background=#000000
+cursor=#dc322f
+
+color0=#000000
+color1=#dc322f
+color2=#56db3a
+color3=#ff8400
+color4=#0084d4
+color5=#b729d9
+color6=#ccccff
+color7=#ffffff
+
+color8=#1b1d21
+color9=#dc322f
+color10=#56db3a
+color11=#ff8400
+color12=#0084d4
+color13=#b729d9
+color14=#ccccff
+color15=#ffffff

--- a/termux/SynthwaveAlpha.properties
+++ b/termux/SynthwaveAlpha.properties
@@ -1,0 +1,22 @@
+# SynthwaveAlpha
+foreground=#f2f2e3
+background=#241b30
+cursor=#f2f2e3
+
+color0=#241b30
+color1=#e60a70
+color2=#00986c
+color3=#adad3e
+color4=#6e29ad
+color5=#b300ad
+color6=#00b0b1
+color7=#b9b1bc
+
+color8=#7f7094
+color9=#e60a70
+color10=#0ae4a4
+color11=#f9f972
+color12=#aa54f9
+color13=#ff00f6
+color14=#00fbfd
+color15=#f2f2e3

--- a/termux/Tango Adapted.properties
+++ b/termux/Tango Adapted.properties
@@ -1,0 +1,22 @@
+# Tango Adapted
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#ff0000
+color2=#59d600
+color3=#f0cb00
+color4=#00a2ff
+color5=#c17ecc
+color6=#00d0d6
+color7=#e6ebe1
+
+color8=#8f928b
+color9=#ff0013
+color10=#93ff00
+color11=#fff121
+color12=#88c9ff
+color13=#e9a7e1
+color14=#00feff
+color15=#f6f6f4

--- a/termux/Tango Half Adapted.properties
+++ b/termux/Tango Half Adapted.properties
@@ -1,0 +1,22 @@
+# Tango Half Adapted
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#ff0000
+color2=#4cc300
+color3=#e2c000
+color4=#008ef6
+color5=#a96cb3
+color6=#00bdc3
+color7=#e0e5db
+
+color8=#797d76
+color9=#ff0013
+color10=#8af600
+color11=#ffec00
+color12=#76bfff
+color13=#d898d1
+color14=#00f6fa
+color15=#f4f4f2

--- a/termux/Teerb.properties
+++ b/termux/Teerb.properties
@@ -1,0 +1,22 @@
+# Teerb
+foreground=#d0d0d0
+background=#262626
+cursor=#e4c9af
+
+color0=#1c1c1c
+color1=#d68686
+color2=#aed686
+color3=#d7af87
+color4=#86aed6
+color5=#d6aed6
+color6=#8adbb4
+color7=#d0d0d0
+
+color8=#1c1c1c
+color9=#d68686
+color10=#aed686
+color11=#e4c9af
+color12=#86aed6
+color13=#d6aed6
+color14=#b1e7dd
+color15=#efefef

--- a/termux/Terminal Basic.properties
+++ b/termux/Terminal Basic.properties
@@ -1,0 +1,22 @@
+# Terminal Basic
+foreground=#000000
+background=#ffffff
+cursor=#7f7f7f
+
+color0=#000000
+color1=#990000
+color2=#00a600
+color3=#999900
+color4=#0000b2
+color5=#b200b2
+color6=#00a6b2
+color7=#bfbfbf
+
+color8=#666666
+color9=#e50000
+color10=#00d900
+color11=#e5e500
+color12=#0000ff
+color13=#e500e5
+color14=#00e5e5
+color15=#e5e5e5

--- a/termux/Thayer Bright.properties
+++ b/termux/Thayer Bright.properties
@@ -1,0 +1,22 @@
+# Thayer Bright
+foreground=#f8f8f8
+background=#1b1d1e
+cursor=#fc971f
+
+color0=#1b1d1e
+color1=#f92672
+color2=#4df840
+color3=#f4fd22
+color4=#2757d6
+color5=#8c54fe
+color6=#38c8b5
+color7=#ccccc6
+
+color8=#505354
+color9=#ff5995
+color10=#b6e354
+color11=#feed6c
+color12=#3f78ff
+color13=#9e6ffe
+color14=#23cfd5
+color15=#f8f8f2

--- a/termux/The Hulk.properties
+++ b/termux/The Hulk.properties
@@ -1,0 +1,22 @@
+# The Hulk
+foreground=#b5b5b5
+background=#1b1d1e
+cursor=#16b61b
+
+color0=#1b1d1e
+color1=#269d1b
+color2=#13ce30
+color3=#63e457
+color4=#2525f5
+color5=#641f74
+color6=#378ca9
+color7=#d9d8d1
+
+color8=#505354
+color9=#8dff2a
+color10=#48ff77
+color11=#3afe16
+color12=#506b95
+color13=#72589d
+color14=#4085a6
+color15=#e5e6e1

--- a/termux/Tinacious Design (Dark).properties
+++ b/termux/Tinacious Design (Dark).properties
@@ -1,0 +1,22 @@
+# Tinacious Design (Dark)
+foreground=#cbcbf0
+background=#1d1d26
+cursor=#cbcbf0
+
+color0=#1d1d26
+color1=#ff3399
+color2=#00d364
+color3=#ffcc66
+color4=#00cbff
+color5=#cc66ff
+color6=#00ceca
+color7=#cbcbf0
+
+color8=#636667
+color9=#ff2f92
+color10=#00d364
+color11=#ffd479
+color12=#00cbff
+color13=#d783ff
+color14=#00d5d4
+color15=#d5d6f3

--- a/termux/Tinacious Design (Light).properties
+++ b/termux/Tinacious Design (Light).properties
@@ -1,0 +1,22 @@
+# Tinacious Design (Light)
+foreground=#1d1d26
+background=#f8f8ff
+cursor=#cbcbf0
+
+color0=#1d1d26
+color1=#ff3399
+color2=#00d364
+color3=#ffcc66
+color4=#00cbff
+color5=#cc66ff
+color6=#00ceca
+color7=#cbcbf0
+
+color8=#636667
+color9=#ff2f92
+color10=#00d364
+color11=#ffd479
+color12=#00cbff
+color13=#d783ff
+color14=#00d5d4
+color15=#d5d6f3

--- a/termux/Tomorrow Night Blue.properties
+++ b/termux/Tomorrow Night Blue.properties
@@ -1,0 +1,22 @@
+# Tomorrow Night Blue
+foreground=#ffffff
+background=#002451
+cursor=#ffffff
+
+color0=#000000
+color1=#ff9da4
+color2=#d1f1a9
+color3=#ffeead
+color4=#bbdaff
+color5=#ebbbff
+color6=#99ffff
+color7=#ffffff
+
+color8=#000000
+color9=#ff9da4
+color10=#d1f1a9
+color11=#ffeead
+color12=#bbdaff
+color13=#ebbbff
+color14=#99ffff
+color15=#ffffff

--- a/termux/Tomorrow Night Bright.properties
+++ b/termux/Tomorrow Night Bright.properties
@@ -1,0 +1,22 @@
+# Tomorrow Night Bright
+foreground=#eaeaea
+background=#000000
+cursor=#eaeaea
+
+color0=#000000
+color1=#d54e53
+color2=#b9ca4a
+color3=#e7c547
+color4=#7aa6da
+color5=#c397d8
+color6=#70c0b1
+color7=#ffffff
+
+color8=#000000
+color9=#d54e53
+color10=#b9ca4a
+color11=#e7c547
+color12=#7aa6da
+color13=#c397d8
+color14=#70c0b1
+color15=#ffffff

--- a/termux/Tomorrow Night Burns.properties
+++ b/termux/Tomorrow Night Burns.properties
@@ -1,0 +1,22 @@
+# Tomorrow Night Burns
+foreground=#a1b0b8
+background=#151515
+cursor=#ff443e
+
+color0=#252525
+color1=#832e31
+color2=#a63c40
+color3=#d3494e
+color4=#fc595f
+color5=#df9395
+color6=#ba8586
+color7=#f5f5f5
+
+color8=#5d6f71
+color9=#832e31
+color10=#a63c40
+color11=#d2494e
+color12=#fc595f
+color13=#df9395
+color14=#ba8586
+color15=#f5f5f5

--- a/termux/Tomorrow Night Eighties.properties
+++ b/termux/Tomorrow Night Eighties.properties
@@ -1,0 +1,22 @@
+# Tomorrow Night Eighties
+foreground=#cccccc
+background=#2d2d2d
+cursor=#cccccc
+
+color0=#000000
+color1=#f2777a
+color2=#99cc99
+color3=#ffcc66
+color4=#6699cc
+color5=#cc99cc
+color6=#66cccc
+color7=#ffffff
+
+color8=#000000
+color9=#f2777a
+color10=#99cc99
+color11=#ffcc66
+color12=#6699cc
+color13=#cc99cc
+color14=#66cccc
+color15=#ffffff

--- a/termux/Tomorrow Night.properties
+++ b/termux/Tomorrow Night.properties
@@ -1,0 +1,22 @@
+# Tomorrow Night
+foreground=#c5c8c6
+background=#1d1f21
+cursor=#c5c8c6
+
+color0=#000000
+color1=#cc6666
+color2=#b5bd68
+color3=#f0c674
+color4=#81a2be
+color5=#b294bb
+color6=#8abeb7
+color7=#ffffff
+
+color8=#000000
+color9=#cc6666
+color10=#b5bd68
+color11=#f0c674
+color12=#81a2be
+color13=#b294bb
+color14=#8abeb7
+color15=#ffffff

--- a/termux/Tomorrow.properties
+++ b/termux/Tomorrow.properties
@@ -1,0 +1,22 @@
+# Tomorrow
+foreground=#4d4d4c
+background=#ffffff
+cursor=#4d4d4c
+
+color0=#000000
+color1=#c82829
+color2=#718c00
+color3=#eab700
+color4=#4271ae
+color5=#8959a8
+color6=#3e999f
+color7=#ffffff
+
+color8=#000000
+color9=#c82829
+color10=#718c00
+color11=#eab700
+color12=#4271ae
+color13=#8959a8
+color14=#3e999f
+color15=#ffffff

--- a/termux/ToyChest.properties
+++ b/termux/ToyChest.properties
@@ -1,0 +1,22 @@
+# ToyChest
+foreground=#31d07b
+background=#24364b
+cursor=#d5d5d5
+
+color0=#2c3f58
+color1=#be2d26
+color2=#1a9172
+color3=#db8e27
+color4=#325d96
+color5=#8a5edc
+color6=#35a08f
+color7=#23d183
+
+color8=#336889
+color9=#dd5944
+color10=#31d07b
+color11=#e7d84b
+color12=#34a6da
+color13=#ae6bdc
+color14=#42c3ae
+color15=#d5d5d5

--- a/termux/Treehouse.properties
+++ b/termux/Treehouse.properties
@@ -1,0 +1,22 @@
+# Treehouse
+foreground=#786b53
+background=#191919
+cursor=#fac814
+
+color0=#321300
+color1=#b2270e
+color2=#44a900
+color3=#aa820c
+color4=#58859a
+color5=#97363d
+color6=#b25a1e
+color7=#786b53
+
+color8=#433626
+color9=#ed5d20
+color10=#55f238
+color11=#f2b732
+color12=#85cfed
+color13=#e14c5a
+color14=#f07d14
+color15=#ffc800

--- a/termux/Twilight.properties
+++ b/termux/Twilight.properties
@@ -1,0 +1,22 @@
+# Twilight
+foreground=#ffffd4
+background=#141414
+cursor=#ffffff
+
+color0=#141414
+color1=#c06d44
+color2=#afb97a
+color3=#c2a86c
+color4=#44474a
+color5=#b4be7c
+color6=#778385
+color7=#ffffd4
+
+color8=#262626
+color9=#de7c4c
+color10=#ccd88c
+color11=#e2c47e
+color12=#5a5e62
+color13=#d0dc8e
+color14=#8a989b
+color15=#ffffd4

--- a/termux/Ubuntu.properties
+++ b/termux/Ubuntu.properties
@@ -1,0 +1,22 @@
+# Ubuntu
+foreground=#eeeeec
+background=#300a24
+cursor=#bbbbbb
+
+color0=#2e3436
+color1=#cc0000
+color2=#4e9a06
+color3=#c4a000
+color4=#3465a4
+color5=#75507b
+color6=#06989a
+color7=#d3d7cf
+
+color8=#555753
+color9=#ef2929
+color10=#8ae234
+color11=#fce94f
+color12=#729fcf
+color13=#ad7fa8
+color14=#34e2e2
+color15=#eeeeec

--- a/termux/UltraDark.properties
+++ b/termux/UltraDark.properties
@@ -1,0 +1,22 @@
+# UltraDark
+foreground=#ffffff
+background=#000000
+cursor=#fefefe
+
+color0=#000000
+color1=#f07178
+color2=#c3e88d
+color3=#ffcb6b
+color4=#82aaff
+color5=#c792ea
+color6=#89ddff
+color7=#cccccc
+
+color8=#333333
+color9=#f6a9ae
+color10=#dbf1ba
+color11=#ffdfa6
+color12=#b4ccff
+color13=#ddbdf2
+color14=#b8eaff
+color15=#ffffff

--- a/termux/UltraViolent.properties
+++ b/termux/UltraViolent.properties
@@ -1,0 +1,22 @@
+# UltraViolent
+foreground=#c1c1c1
+background=#242728
+cursor=#c1c1c1
+
+color0=#242728
+color1=#ff0090
+color2=#b6ff00
+color3=#fff727
+color4=#47e0fb
+color5=#d731ff
+color6=#0effbb
+color7=#e1e1e1
+
+color8=#636667
+color9=#fb58b4
+color10=#deff8c
+color11=#ebe087
+color12=#7fecff
+color13=#e681ff
+color14=#69fcd3
+color15=#f9f9f5

--- a/termux/UnderTheSea.properties
+++ b/termux/UnderTheSea.properties
@@ -1,0 +1,22 @@
+# UnderTheSea
+foreground=#ffffff
+background=#011116
+cursor=#4afcd6
+
+color0=#022026
+color1=#b2302d
+color2=#00a941
+color3=#59819c
+color4=#459a86
+color5=#00599d
+color6=#5d7e19
+color7=#405555
+
+color8=#384451
+color9=#ff4242
+color10=#2aea5e
+color11=#8ed4fd
+color12=#61d5ba
+color13=#1298ff
+color14=#98d028
+color15=#58fbd6

--- a/termux/Unikitty.properties
+++ b/termux/Unikitty.properties
@@ -1,0 +1,22 @@
+# Unikitty
+foreground=#0b0b0b
+background=#ff8cd9
+cursor=#bafc8b
+
+color0=#0c0c0c
+color1=#a80f20
+color2=#bafc8b
+color3=#eedf4b
+color4=#145fcd
+color5=#ff36a2
+color6=#6bd1bc
+color7=#e2d7e1
+
+color8=#434343
+color9=#d91329
+color10=#d3ffaf
+color11=#ffef50
+color12=#0075ea
+color13=#fdd5e5
+color14=#79ecd5
+color15=#fff3fe

--- a/termux/Urple.properties
+++ b/termux/Urple.properties
@@ -1,0 +1,22 @@
+# Urple
+foreground=#877a9b
+background=#1b1b23
+cursor=#a063eb
+
+color0=#000000
+color1=#b0425b
+color2=#37a415
+color3=#ad5c42
+color4=#564d9b
+color5=#6c3ca1
+color6=#808080
+color7=#87799c
+
+color8=#5d3225
+color9=#ff6388
+color10=#29e620
+color11=#f08161
+color12=#867aed
+color13=#a05eee
+color14=#eaeaea
+color15=#bfa3ff

--- a/termux/Vaughn.properties
+++ b/termux/Vaughn.properties
@@ -1,0 +1,22 @@
+# Vaughn
+foreground=#dcdccc
+background=#25234f
+cursor=#ff5555
+
+color0=#25234f
+color1=#705050
+color2=#60b48a
+color3=#dfaf8f
+color4=#5555ff
+color5=#f08cc3
+color6=#8cd0d3
+color7=#709080
+
+color8=#709080
+color9=#dca3a3
+color10=#60b48a
+color11=#f0dfaf
+color12=#5555ff
+color13=#ec93d3
+color14=#93e0e3
+color15=#ffffff

--- a/termux/VibrantInk.properties
+++ b/termux/VibrantInk.properties
@@ -1,0 +1,22 @@
+# VibrantInk
+foreground=#ffffff
+background=#000000
+cursor=#ffffff
+
+color0=#878787
+color1=#ff6600
+color2=#ccff04
+color3=#ffcc00
+color4=#44b4cc
+color5=#9933cc
+color6=#44b4cc
+color7=#f5f5f5
+
+color8=#555555
+color9=#ff0000
+color10=#00ff00
+color11=#ffff00
+color12=#0000ff
+color13=#ff00ff
+color14=#00ffff
+color15=#e5e5e5

--- a/termux/Violet Dark.properties
+++ b/termux/Violet Dark.properties
@@ -1,0 +1,22 @@
+# Violet Dark
+foreground=#708284
+background=#1c1d1f
+cursor=#708284
+
+color0=#56595c
+color1=#c94c22
+color2=#85981c
+color3=#b4881d
+color4=#2e8bce
+color5=#d13a82
+color6=#32a198
+color7=#c9c6bd
+
+color8=#45484b
+color9=#bd3613
+color10=#738a04
+color11=#a57705
+color12=#2176c7
+color13=#c61c6f
+color14=#259286
+color15=#c9c6bd

--- a/termux/Violet Light.properties
+++ b/termux/Violet Light.properties
@@ -1,0 +1,22 @@
+# Violet Light
+foreground=#536870
+background=#fcf4dc
+cursor=#536870
+
+color0=#56595c
+color1=#c94c22
+color2=#85981c
+color3=#b4881d
+color4=#2e8bce
+color5=#d13a82
+color6=#32a198
+color7=#d3d0c9
+
+color8=#45484b
+color9=#bd3613
+color10=#738a04
+color11=#a57705
+color12=#2176c7
+color13=#c61c6f
+color14=#259286
+color15=#c9c6bd

--- a/termux/WarmNeon.properties
+++ b/termux/WarmNeon.properties
@@ -1,0 +1,22 @@
+# WarmNeon
+foreground=#afdab6
+background=#404040
+cursor=#30ff24
+
+color0=#000000
+color1=#e24346
+color2=#39b13a
+color3=#dae145
+color4=#4261c5
+color5=#f920fb
+color6=#2abbd4
+color7=#d0b8a3
+
+color8=#fefcfc
+color9=#e97071
+color10=#9cc090
+color11=#ddda7a
+color12=#7b91d6
+color13=#f674ba
+color14=#5ed1e5
+color15=#d8c8bb

--- a/termux/Wez.properties
+++ b/termux/Wez.properties
@@ -1,0 +1,22 @@
+# Wez
+foreground=#b3b3b3
+background=#000000
+cursor=#53ae71
+
+color0=#000000
+color1=#cc5555
+color2=#55cc55
+color3=#cdcd55
+color4=#5555cc
+color5=#cc55cc
+color6=#7acaca
+color7=#cccccc
+
+color8=#555555
+color9=#ff5555
+color10=#55ff55
+color11=#ffff55
+color12=#5555ff
+color13=#ff55ff
+color14=#55ffff
+color15=#ffffff

--- a/termux/Whimsy.properties
+++ b/termux/Whimsy.properties
@@ -1,0 +1,22 @@
+# Whimsy
+foreground=#b3b0d6
+background=#29283b
+cursor=#b3b0d6
+
+color0=#535178
+color1=#ef6487
+color2=#5eca89
+color3=#fdd877
+color4=#65aef7
+color5=#aa7ff0
+color6=#43c1be
+color7=#ffffff
+
+color8=#535178
+color9=#ef6487
+color10=#5eca89
+color11=#fdd877
+color12=#65aef7
+color13=#aa7ff0
+color14=#43c1be
+color15=#ffffff

--- a/termux/WildCherry.properties
+++ b/termux/WildCherry.properties
@@ -1,0 +1,22 @@
+# WildCherry
+foreground=#dafaff
+background=#1f1726
+cursor=#dd00ff
+
+color0=#000507
+color1=#d94085
+color2=#2ab250
+color3=#ffd16f
+color4=#883cdc
+color5=#ececec
+color6=#c1b8b7
+color7=#fff8de
+
+color8=#009cc9
+color9=#da6bac
+color10=#f4dca5
+color11=#eac066
+color12=#308cba
+color13=#ae636b
+color14=#ff919d
+color15=#e4838d

--- a/termux/Wombat.properties
+++ b/termux/Wombat.properties
@@ -1,0 +1,22 @@
+# Wombat
+foreground=#dedacf
+background=#171717
+cursor=#bbbbbb
+
+color0=#000000
+color1=#ff615a
+color2=#b1e969
+color3=#ebd99c
+color4=#5da9f6
+color5=#e86aff
+color6=#82fff7
+color7=#dedacf
+
+color8=#313131
+color9=#f58c80
+color10=#ddf88f
+color11=#eee5b2
+color12=#a5c7ff
+color13=#ddaaff
+color14=#b7fff9
+color15=#ffffff

--- a/termux/Wryan.properties
+++ b/termux/Wryan.properties
@@ -1,0 +1,22 @@
+# Wryan
+foreground=#999993
+background=#101010
+cursor=#9e9ecb
+
+color0=#333333
+color1=#8c4665
+color2=#287373
+color3=#7c7c99
+color4=#395573
+color5=#5e468c
+color6=#31658c
+color7=#899ca1
+
+color8=#3d3d3d
+color9=#bf4d80
+color10=#53a6a6
+color11=#9e9ecb
+color12=#477ab3
+color13=#7e62b3
+color14=#6096bf
+color15=#c0c0c0

--- a/termux/Zenburn.properties
+++ b/termux/Zenburn.properties
@@ -1,0 +1,22 @@
+# Zenburn
+foreground=#dcdccc
+background=#3f3f3f
+cursor=#73635a
+
+color0=#4d4d4d
+color1=#705050
+color2=#60b48a
+color3=#f0dfaf
+color4=#506070
+color5=#dc8cc3
+color6=#8cd0d3
+color7=#dcdccc
+
+color8=#709080
+color9=#dca3a3
+color10=#c3bf9f
+color11=#e0cf9f
+color12=#94bff3
+color13=#ec93d3
+color14=#93e0e3
+color15=#ffffff

--- a/termux/arcoiris.properties
+++ b/termux/arcoiris.properties
@@ -1,0 +1,22 @@
+# arcoiris
+foreground=#eee4d9
+background=#201f1e
+cursor=#7a1c1c
+
+color0=#333333
+color1=#da2700
+color2=#12c258
+color3=#ffc656
+color4=#518bfc
+color5=#e37bd9
+color6=#63fad5
+color7=#bab2b2
+
+color8=#777777
+color9=#ffb9b9
+color10=#e3f6aa
+color11=#ffddaa
+color12=#b3e8f3
+color13=#cbbaf9
+color14=#bcffc7
+color15=#efefef

--- a/termux/ayu.properties
+++ b/termux/ayu.properties
@@ -1,0 +1,22 @@
+# ayu
+foreground=#e6e1cf
+background=#0f1419
+cursor=#f29718
+
+color0=#000000
+color1=#ff3333
+color2=#b8cc52
+color3=#e7c547
+color4=#36a3d9
+color5=#f07178
+color6=#95e6cb
+color7=#ffffff
+
+color8=#323232
+color9=#ff6565
+color10=#eafe84
+color11=#fff779
+color12=#68d5ff
+color13=#ffa3aa
+color14=#c7fffd
+color15=#ffffff

--- a/termux/ayu_light.properties
+++ b/termux/ayu_light.properties
@@ -1,0 +1,22 @@
+# ayu_light
+foreground=#5c6773
+background=#fafafa
+cursor=#ff6a00
+
+color0=#000000
+color1=#ff3333
+color2=#86b300
+color3=#f29718
+color4=#41a6d9
+color5=#f07178
+color6=#4dbf99
+color7=#ffffff
+
+color8=#323232
+color9=#ff6565
+color10=#b8e532
+color11=#ffc94a
+color12=#73d8ff
+color13=#ffa3aa
+color14=#7ff1cb
+color15=#ffffff

--- a/termux/catppuccin-frappe.properties
+++ b/termux/catppuccin-frappe.properties
@@ -1,0 +1,22 @@
+# catppuccin-frappe
+foreground=#c6d0f5
+background=#303446
+cursor=#f2d5cf
+
+color0=#51576d
+color1=#e78284
+color2=#a6d189
+color3=#e5c890
+color4=#8caaee
+color5=#f4b8e4
+color6=#81c8be
+color7=#b5bfe2
+
+color8=#626880
+color9=#e78284
+color10=#a6d189
+color11=#e5c890
+color12=#8caaee
+color13=#f4b8e4
+color14=#81c8be
+color15=#a5adce

--- a/termux/catppuccin-latte.properties
+++ b/termux/catppuccin-latte.properties
@@ -1,0 +1,22 @@
+# catppuccin-latte
+foreground=#4c4f69
+background=#eff1f5
+cursor=#dc8a78
+
+color0=#5c5f77
+color1=#d20f39
+color2=#40a02b
+color3=#df8e1d
+color4=#1e66f5
+color5=#ea76cb
+color6=#179299
+color7=#acb0be
+
+color8=#6c6f85
+color9=#d20f39
+color10=#40a02b
+color11=#df8e1d
+color12=#1e66f5
+color13=#ea76cb
+color14=#179299
+color15=#bcc0cc

--- a/termux/catppuccin-macchiato.properties
+++ b/termux/catppuccin-macchiato.properties
@@ -1,0 +1,22 @@
+# catppuccin-macchiato
+foreground=#cad3f5
+background=#24273a
+cursor=#f4dbd6
+
+color0=#494d64
+color1=#ed8796
+color2=#a6da95
+color3=#eed49f
+color4=#8aadf4
+color5=#f5bde6
+color6=#8bd5ca
+color7=#b8c0e0
+
+color8=#5b6078
+color9=#ed8796
+color10=#a6da95
+color11=#eed49f
+color12=#8aadf4
+color13=#f5bde6
+color14=#8bd5ca
+color15=#a5adcb

--- a/termux/catppuccin-mocha.properties
+++ b/termux/catppuccin-mocha.properties
@@ -1,0 +1,22 @@
+# catppuccin-mocha
+foreground=#cdd6f4
+background=#1e1e2e
+cursor=#f5e0dc
+
+color0=#45475a
+color1=#f38ba8
+color2=#a6e3a1
+color3=#f9e2af
+color4=#89b4fa
+color5=#f5c2e7
+color6=#94e2d5
+color7=#bac2de
+
+color8=#585b70
+color9=#f38ba8
+color10=#a6e3a1
+color11=#f9e2af
+color12=#89b4fa
+color13=#f5c2e7
+color14=#94e2d5
+color15=#a6adc8

--- a/termux/coffee_theme.properties
+++ b/termux/coffee_theme.properties
@@ -1,0 +1,22 @@
+# coffee_theme
+foreground=#000000
+background=#f5deb3
+cursor=#c7c7c7
+
+color0=#000000
+color1=#c91b00
+color2=#00c200
+color3=#c7c400
+color4=#0225c7
+color5=#ca30c7
+color6=#00c5c7
+color7=#c7c7c7
+
+color8=#686868
+color9=#ff6e67
+color10=#5ffa68
+color11=#fffc67
+color12=#6871ff
+color13=#ff77ff
+color14=#60fdff
+color15=#ffffff

--- a/termux/cyberpunk.properties
+++ b/termux/cyberpunk.properties
@@ -1,0 +1,22 @@
+# cyberpunk
+foreground=#e5e5e5
+background=#332a57
+cursor=#21f6bc
+
+color0=#000000
+color1=#ff7092
+color2=#00fbac
+color3=#fffa6a
+color4=#00bfff
+color5=#df95ff
+color6=#86cbfe
+color7=#ffffff
+
+color8=#000000
+color9=#ff8aa4
+color10=#21f6bc
+color11=#fff787
+color12=#1bccfd
+color13=#e6aefe
+color14=#99d6fc
+color15=#ffffff

--- a/termux/darkermatrix.properties
+++ b/termux/darkermatrix.properties
@@ -1,0 +1,22 @@
+# darkermatrix
+foreground=#28380d
+background=#070c0e
+cursor=#373a26
+
+color0=#091013
+color1=#002e18
+color2=#6fa64c
+color3=#595900
+color4=#00cb6b
+color5=#412a4d
+color6=#125459
+color7=#002e19
+
+color8=#333333
+color9=#00381d
+color10=#90d762
+color11=#e2e500
+color12=#00ff87
+color13=#412a4d
+color14=#176c73
+color15=#00381e

--- a/termux/darkmatrix.properties
+++ b/termux/darkmatrix.properties
@@ -1,0 +1,22 @@
+# darkmatrix
+foreground=#3e5715
+background=#070c0e
+cursor=#9fa86e
+
+color0=#091013
+color1=#006536
+color2=#6fa64c
+color3=#7e8000
+color4=#2c9a84
+color5=#452d53
+color6=#114d53
+color7=#006536
+
+color8=#333333
+color9=#00733d
+color10=#90d762
+color11=#e2e500
+color12=#46d8b8
+color13=#4a3059
+color14=#12545a
+color15=#006536

--- a/termux/deep.properties
+++ b/termux/deep.properties
@@ -1,0 +1,22 @@
+# deep
+foreground=#cdcdcd
+background=#090909
+cursor=#d0d0d0
+
+color0=#000000
+color1=#d70005
+color2=#1cd915
+color3=#d9bd26
+color4=#5665ff
+color5=#b052da
+color6=#50d2da
+color7=#e0e0e0
+
+color8=#535353
+color9=#fb0007
+color10=#22ff18
+color11=#fedc2b
+color12=#9fa9ff
+color13=#e09aff
+color14=#8df9ff
+color15=#ffffff

--- a/termux/duckbones.properties
+++ b/termux/duckbones.properties
@@ -1,0 +1,22 @@
+# duckbones
+foreground=#ebefc0
+background=#0e101a
+cursor=#edf2c2
+
+color0=#0e101a
+color1=#e03600
+color2=#5dcd97
+color3=#e39500
+color4=#00a3cb
+color5=#795ccc
+color6=#00a3cb
+color7=#ebefc0
+
+color8=#2b2f46
+color9=#ff4821
+color10=#58db9e
+color11=#f6a100
+color12=#00b4e0
+color13=#b3a1e6
+color14=#00b4e0
+color15=#b3b692

--- a/termux/iceberg-dark.properties
+++ b/termux/iceberg-dark.properties
@@ -1,0 +1,22 @@
+# iceberg-dark
+foreground=#c6c8d1
+background=#161821
+cursor=#c6c8d1
+
+color0=#1e2132
+color1=#e27878
+color2=#b4be82
+color3=#e2a478
+color4=#84a0c6
+color5=#a093c7
+color6=#89b8c2
+color7=#c6c8d1
+
+color8=#6b7089
+color9=#e98989
+color10=#c0ca8e
+color11=#e9b189
+color12=#91acd1
+color13=#ada0d3
+color14=#95c4ce
+color15=#d2d4de

--- a/termux/iceberg-light.properties
+++ b/termux/iceberg-light.properties
@@ -1,0 +1,22 @@
+# iceberg-light
+foreground=#33374c
+background=#e8e9ec
+cursor=#33374c
+
+color0=#dcdfe7
+color1=#cc517a
+color2=#668e3d
+color3=#c57339
+color4=#2d539e
+color5=#7759b4
+color6=#3f83a6
+color7=#33374c
+
+color8=#8389a3
+color9=#cc3768
+color10=#598030
+color11=#b6662d
+color12=#22478e
+color13=#6845ad
+color14=#327698
+color15=#262a3f

--- a/termux/idea.properties
+++ b/termux/idea.properties
@@ -1,0 +1,22 @@
+# idea
+foreground=#adadad
+background=#202020
+cursor=#bbbbbb
+
+color0=#adadad
+color1=#fc5256
+color2=#98b61c
+color3=#ccb444
+color4=#437ee7
+color5=#9d74b0
+color6=#248887
+color7=#181818
+
+color8=#ffffff
+color9=#fc7072
+color10=#98b61c
+color11=#ffff0b
+color12=#6c9ced
+color13=#fc7eff
+color14=#248887
+color15=#181818

--- a/termux/idleToes.properties
+++ b/termux/idleToes.properties
@@ -1,0 +1,22 @@
+# idleToes
+foreground=#ffffff
+background=#323232
+cursor=#d6d6d6
+
+color0=#323232
+color1=#d25252
+color2=#7fe173
+color3=#ffc66d
+color4=#4099ff
+color5=#f680ff
+color6=#bed6ff
+color7=#eeeeec
+
+color8=#535353
+color9=#f07070
+color10=#9dff91
+color11=#ffe48b
+color12=#5eb7f7
+color13=#ff9dff
+color14=#dcf4ff
+color15=#ffffff

--- a/termux/jubi.properties
+++ b/termux/jubi.properties
@@ -1,0 +1,22 @@
+# jubi
+foreground=#c3d3de
+background=#262b33
+cursor=#c3d3de
+
+color0=#3b3750
+color1=#cf7b98
+color2=#90a94b
+color3=#6ebfc0
+color4=#576ea6
+color5=#bc4f68
+color6=#75a7d2
+color7=#c3d3de
+
+color8=#a874ce
+color9=#de90ab
+color10=#bcdd61
+color11=#87e9ea
+color12=#8c9fcd
+color13=#e16c87
+color14=#b7c9ef
+color15=#d5e5f1

--- a/termux/kanagawabones.properties
+++ b/termux/kanagawabones.properties
@@ -1,0 +1,22 @@
+# kanagawabones
+foreground=#ddd8bb
+background=#1f1f28
+cursor=#e6e0c2
+
+color0=#1f1f28
+color1=#e46a78
+color2=#98bc6d
+color3=#e5c283
+color4=#7eb3c9
+color5=#957fb8
+color6=#7eb3c9
+color7=#ddd8bb
+
+color8=#3c3c51
+color9=#ec818c
+color10=#9ec967
+color11=#f1c982
+color12=#7bc2df
+color13=#a98fd2
+color14=#7bc2df
+color15=#a8a48d

--- a/termux/lovelace.properties
+++ b/termux/lovelace.properties
@@ -1,0 +1,22 @@
+# lovelace
+foreground=#fdfdfd
+background=#1d1f28
+cursor=#c574dd
+
+color0=#282a36
+color1=#f37f97
+color2=#5adecd
+color3=#f2a272
+color4=#8897f4
+color5=#c574dd
+color6=#79e6f3
+color7=#fdfdfd
+
+color8=#414458
+color9=#ff4971
+color10=#18e3c8
+color11=#ff8037
+color12=#556fff
+color13=#b043d1
+color14=#3fdcee
+color15=#bebec1

--- a/termux/matrix.properties
+++ b/termux/matrix.properties
@@ -1,0 +1,22 @@
+# matrix
+foreground=#426644
+background=#0f191c
+cursor=#384545
+
+color0=#0f191c
+color1=#23755a
+color2=#82d967
+color3=#ffd700
+color4=#3f5242
+color5=#409931
+color6=#50b45a
+color7=#507350
+
+color8=#688060
+color9=#2fc079
+color10=#90d762
+color11=#faff00
+color12=#4f7e7e
+color13=#11ff25
+color14=#c1ff8a
+color15=#678c61

--- a/termux/midnight-in-mojave.properties
+++ b/termux/midnight-in-mojave.properties
@@ -1,0 +1,22 @@
+# midnight-in-mojave
+foreground=#ffffff
+background=#1e1e1e
+cursor=#32d74b
+
+color0=#1e1e1e
+color1=#ff453a
+color2=#32d74b
+color3=#ffd60a
+color4=#0a84ff
+color5=#bf5af2
+color6=#5ac8fa
+color7=#ffffff
+
+color8=#1e1e1e
+color9=#ff453a
+color10=#32d74b
+color11=#ffd60a
+color12=#0a84ff
+color13=#bf5af2
+color14=#5ac8fa
+color15=#ffffff

--- a/termux/neobones_dark.properties
+++ b/termux/neobones_dark.properties
@@ -1,0 +1,22 @@
+# neobones_dark
+foreground=#c6d5cf
+background=#0f191f
+cursor=#ceddd7
+
+color0=#0f191f
+color1=#de6e7c
+color2=#90ff6b
+color3=#b77e64
+color4=#8190d4
+color5=#b279a7
+color6=#66a5ad
+color7=#c6d5cf
+
+color8=#263945
+color9=#e8838f
+color10=#a0ff85
+color11=#d68c67
+color12=#92a0e2
+color13=#cf86c1
+color14=#65b8c1
+color15=#98a39e

--- a/termux/neobones_light.properties
+++ b/termux/neobones_light.properties
@@ -1,0 +1,22 @@
+# neobones_light
+foreground=#202e18
+background=#e5ede6
+cursor=#202e18
+
+color0=#e5ede6
+color1=#a8334c
+color2=#567a30
+color3=#944927
+color4=#286486
+color5=#88507d
+color6=#3b8992
+color7=#202e18
+
+color8=#b3c6b6
+color9=#94253e
+color10=#3f5a22
+color11=#803d1c
+color12=#1d5573
+color13=#7b3b70
+color14=#2b747c
+color15=#415934

--- a/termux/niji.properties
+++ b/termux/niji.properties
@@ -1,0 +1,22 @@
+# niji
+foreground=#ffffff
+background=#141515
+cursor=#ffc663
+
+color0=#333333
+color1=#d23e08
+color2=#54ca74
+color3=#fff700
+color4=#2ab9ff
+color5=#ff50da
+color6=#1ef9f5
+color7=#ddd0c4
+
+color8=#515151
+color9=#ffb7b7
+color10=#c1ffae
+color11=#fcffb8
+color12=#8efff3
+color13=#ffa2ed
+color14=#bcffc7
+color15=#ffffff

--- a/termux/nord-light.properties
+++ b/termux/nord-light.properties
@@ -1,0 +1,22 @@
+# nord-light
+foreground=#414858
+background=#e5e9f0
+cursor=#88c0d0
+
+color0=#3b4252
+color1=#bf616a
+color2=#a3be8c
+color3=#ebcb8b
+color4=#81a1c1
+color5=#b48ead
+color6=#88c0d0
+color7=#d8dee9
+
+color8=#4c566a
+color9=#bf616a
+color10=#a3be8c
+color11=#ebcb8b
+color12=#81a1c1
+color13=#b48ead
+color14=#8fbcbb
+color15=#eceff4

--- a/termux/nord.properties
+++ b/termux/nord.properties
@@ -1,0 +1,22 @@
+# nord
+foreground=#d8dee9
+background=#2e3440
+cursor=#eceff4
+
+color0=#3b4252
+color1=#bf616a
+color2=#a3be8c
+color3=#ebcb8b
+color4=#81a1c1
+color5=#b48ead
+color6=#88c0d0
+color7=#e5e9f0
+
+color8=#4c566a
+color9=#bf616a
+color10=#a3be8c
+color11=#ebcb8b
+color12=#81a1c1
+color13=#b48ead
+color14=#8fbcbb
+color15=#eceff4

--- a/termux/primary.properties
+++ b/termux/primary.properties
@@ -1,0 +1,22 @@
+# primary
+foreground=#000000
+background=#ffffff
+cursor=#000000
+
+color0=#000000
+color1=#db4437
+color2=#0f9d58
+color3=#f4b400
+color4=#4285f4
+color5=#db4437
+color6=#4285f4
+color7=#ffffff
+
+color8=#000000
+color9=#db4437
+color10=#0f9d58
+color11=#f4b400
+color12=#4285f4
+color13=#4285f4
+color14=#0f9d58
+color15=#ffffff

--- a/termux/purplepeter.properties
+++ b/termux/purplepeter.properties
@@ -1,0 +1,22 @@
+# purplepeter
+foreground=#ece7fa
+background=#2a1a4a
+cursor=#c7c7c7
+
+color0=#0a0520
+color1=#ff796d
+color2=#99b481
+color3=#efdfac
+color4=#66d9ef
+color5=#e78fcd
+color6=#ba8cff
+color7=#ffba81
+
+color8=#100b23
+color9=#f99f92
+color10=#b4be8f
+color11=#f2e9bf
+color12=#79daed
+color13=#ba91d4
+color14=#a0a0d6
+color15=#b9aed3

--- a/termux/rebecca.properties
+++ b/termux/rebecca.properties
@@ -1,0 +1,22 @@
+# rebecca
+foreground=#e8e6ed
+background=#292a44
+cursor=#b89bf9
+
+color0=#12131e
+color1=#dd7755
+color2=#04dbb5
+color3=#f2e7b7
+color4=#7aa5ff
+color5=#bf9cf9
+color6=#56d3c2
+color7=#e4e3e9
+
+color8=#666699
+color9=#ff92cd
+color10=#01eac0
+color11=#fffca8
+color12=#69c0fa
+color13=#c17ff8
+color14=#8bfde1
+color15=#f4f2f9

--- a/termux/rose-pine-dawn.properties
+++ b/termux/rose-pine-dawn.properties
@@ -1,0 +1,22 @@
+# rose-pine-dawn
+foreground=#575279
+background=#faf4ed
+cursor=#575279
+
+color0=#f2e9e1
+color1=#b4637a
+color2=#56949f
+color3=#ea9d34
+color4=#286983
+color5=#907aa9
+color6=#d7827e
+color7=#575279
+
+color8=#9893a5
+color9=#b4637a
+color10=#56949f
+color11=#ea9d34
+color12=#286983
+color13=#907aa9
+color14=#d7827e
+color15=#575279

--- a/termux/rose-pine-moon.properties
+++ b/termux/rose-pine-moon.properties
@@ -1,0 +1,22 @@
+# rose-pine-moon
+foreground=#e0def4
+background=#232136
+cursor=#e0def4
+
+color0=#393552
+color1=#eb6f92
+color2=#9ccfd8
+color3=#f6c177
+color4=#3e8fb0
+color5=#c4a7e7
+color6=#ea9a97
+color7=#e0def4
+
+color8=#6e6a86
+color9=#eb6f92
+color10=#9ccfd8
+color11=#f6c177
+color12=#3e8fb0
+color13=#c4a7e7
+color14=#ea9a97
+color15=#e0def4

--- a/termux/rose-pine.properties
+++ b/termux/rose-pine.properties
@@ -1,0 +1,22 @@
+# rose-pine
+foreground=#e0def4
+background=#191724
+cursor=#e0def4
+
+color0=#26233a
+color1=#eb6f92
+color2=#9ccfd8
+color3=#f6c177
+color4=#31748f
+color5=#c4a7e7
+color6=#ebbcba
+color7=#e0def4
+
+color8=#6e6a86
+color9=#eb6f92
+color10=#9ccfd8
+color11=#f6c177
+color12=#31748f
+color13=#c4a7e7
+color14=#ebbcba
+color15=#e0def4

--- a/termux/seoulbones_dark.properties
+++ b/termux/seoulbones_dark.properties
@@ -1,0 +1,22 @@
+# seoulbones_dark
+foreground=#dddddd
+background=#4b4b4b
+cursor=#e2e2e2
+
+color0=#4b4b4b
+color1=#e388a3
+color2=#98bd99
+color3=#ffdf9b
+color4=#97bdde
+color5=#a5a6c5
+color6=#6fbdbe
+color7=#dddddd
+
+color8=#6c6465
+color9=#eb99b1
+color10=#8fcd92
+color11=#ffe5b3
+color12=#a2c8e9
+color13=#b2b3da
+color14=#6bcacb
+color15=#a8a8a8

--- a/termux/seoulbones_light.properties
+++ b/termux/seoulbones_light.properties
@@ -1,0 +1,22 @@
+# seoulbones_light
+foreground=#555555
+background=#e2e2e2
+cursor=#555555
+
+color0=#e2e2e2
+color1=#dc5284
+color2=#628562
+color3=#c48562
+color4=#0084a3
+color5=#896788
+color6=#008586
+color7=#555555
+
+color8=#bfbabb
+color9=#be3c6d
+color10=#487249
+color11=#a76b48
+color12=#006f89
+color13=#7f4c7e
+color14=#006f70
+color15=#777777

--- a/termux/shades-of-purple.properties
+++ b/termux/shades-of-purple.properties
@@ -1,0 +1,22 @@
+# shades-of-purple
+foreground=#ffffff
+background=#1e1d40
+cursor=#fad000
+
+color0=#000000
+color1=#d90429
+color2=#3ad900
+color3=#ffe700
+color4=#6943ff
+color5=#ff2c70
+color6=#00c5c7
+color7=#c7c7c7
+
+color8=#686868
+color9=#f92a1c
+color10=#43d426
+color11=#f1d000
+color12=#6871ff
+color13=#ff77ff
+color14=#79e8fb
+color15=#ffffff

--- a/termux/synthwave-everything.properties
+++ b/termux/synthwave-everything.properties
@@ -1,0 +1,22 @@
+# synthwave-everything
+foreground=#f0eff1
+background=#2a2139
+cursor=#72f1b8
+
+color0=#fefefe
+color1=#f97e72
+color2=#72f1b8
+color3=#fede5d
+color4=#6d77b3
+color5=#c792ea
+color6=#f772e0
+color7=#fefefe
+
+color8=#fefefe
+color9=#f88414
+color10=#72f1b8
+color11=#fff951
+color12=#36f9f6
+color13=#e1acff
+color14=#f92aad
+color15=#fefefe

--- a/termux/synthwave.properties
+++ b/termux/synthwave.properties
@@ -1,0 +1,22 @@
+# synthwave
+foreground=#dad9c7
+background=#000000
+cursor=#19cde6
+
+color0=#000000
+color1=#f6188f
+color2=#1ebb2b
+color3=#fdf834
+color4=#2186ec
+color5=#f85a21
+color6=#12c3e2
+color7=#ffffff
+
+color8=#000000
+color9=#f841a0
+color10=#25c141
+color11=#fdf454
+color12=#2f9ded
+color13=#f97137
+color14=#19cde6
+color15=#ffffff

--- a/termux/tokyonight-day.properties
+++ b/termux/tokyonight-day.properties
@@ -1,0 +1,22 @@
+# tokyonight-day
+foreground=#3760bf
+background=#e1e2e7
+cursor=#3760bf
+
+color0=#e9e9ed
+color1=#f52a65
+color2=#587539
+color3=#8c6c3e
+color4=#2e7de9
+color5=#9854f1
+color6=#007197
+color7=#6172b0
+
+color8=#a1a6c5
+color9=#f52a65
+color10=#587539
+color11=#8c6c3e
+color12=#2e7de9
+color13=#9854f1
+color14=#007197
+color15=#3760bf

--- a/termux/tokyonight-storm.properties
+++ b/termux/tokyonight-storm.properties
@@ -1,0 +1,22 @@
+# tokyonight-storm
+foreground=#c0caf5
+background=#24283b
+cursor=#c0caf5
+
+color0=#1d202f
+color1=#f7768e
+color2=#9ece6a
+color3=#e0af68
+color4=#7aa2f7
+color5=#bb9af7
+color6=#7dcfff
+color7=#a9b1d6
+
+color8=#414868
+color9=#f7768e
+color10=#9ece6a
+color11=#e0af68
+color12=#7aa2f7
+color13=#bb9af7
+color14=#7dcfff
+color15=#c0caf5

--- a/termux/tokyonight.properties
+++ b/termux/tokyonight.properties
@@ -1,0 +1,22 @@
+# tokyonight
+foreground=#c0caf5
+background=#1a1b26
+cursor=#c0caf5
+
+color0=#15161e
+color1=#f7768e
+color2=#9ece6a
+color3=#e0af68
+color4=#7aa2f7
+color5=#bb9af7
+color6=#7dcfff
+color7=#a9b1d6
+
+color8=#414868
+color9=#f7768e
+color10=#9ece6a
+color11=#e0af68
+color12=#7aa2f7
+color13=#bb9af7
+color14=#7dcfff
+color15=#c0caf5

--- a/termux/vimbones.properties
+++ b/termux/vimbones.properties
@@ -1,0 +1,22 @@
+# vimbones
+foreground=#353535
+background=#f0f0ca
+cursor=#353535
+
+color0=#f0f0ca
+color1=#a8334c
+color2=#4f6c31
+color3=#944927
+color4=#286486
+color5=#88507d
+color6=#3b8992
+color7=#353535
+
+color8=#c6c6a3
+color9=#94253e
+color10=#3f5a22
+color11=#803d1c
+color12=#1d5573
+color13=#7b3b70
+color14=#2b747c
+color15=#5c5c5c

--- a/termux/wilmersdorf.properties
+++ b/termux/wilmersdorf.properties
@@ -1,0 +1,22 @@
+# wilmersdorf
+foreground=#c6c6c6
+background=#282b33
+cursor=#7ebebd
+
+color0=#34373e
+color1=#e06383
+color2=#7ebebd
+color3=#cccccc
+color4=#a6c1e0
+color5=#e1c1ee
+color6=#5b94ab
+color7=#ababab
+
+color8=#434750
+color9=#fa7193
+color10=#8fd7d6
+color11=#d1dfff
+color12=#b2cff0
+color13=#efccfd
+color14=#69abc5
+color15=#d3d3d3

--- a/termux/zenbones.properties
+++ b/termux/zenbones.properties
@@ -1,0 +1,22 @@
+# zenbones
+foreground=#2c363c
+background=#f0edec
+cursor=#2c363c
+
+color0=#f0edec
+color1=#a8334c
+color2=#4f6c31
+color3=#944927
+color4=#286486
+color5=#88507d
+color6=#3b8992
+color7=#2c363c
+
+color8=#cfc1ba
+color9=#94253e
+color10=#3f5a22
+color11=#803d1c
+color12=#1d5573
+color13=#7b3b70
+color14=#2b747c
+color15=#4f5e68

--- a/termux/zenbones_dark.properties
+++ b/termux/zenbones_dark.properties
@@ -1,0 +1,22 @@
+# zenbones_dark
+foreground=#b4bdc3
+background=#1c1917
+cursor=#c4cacf
+
+color0=#1c1917
+color1=#de6e7c
+color2=#819b69
+color3=#b77e64
+color4=#6099c0
+color5=#b279a7
+color6=#66a5ad
+color7=#b4bdc3
+
+color8=#403833
+color9=#e8838f
+color10=#8bae68
+color11=#d68c67
+color12=#61abda
+color13=#cf86c1
+color14=#65b8c1
+color15=#888f94

--- a/termux/zenbones_light.properties
+++ b/termux/zenbones_light.properties
@@ -1,0 +1,22 @@
+# zenbones_light
+foreground=#2c363c
+background=#f0edec
+cursor=#2c363c
+
+color0=#f0edec
+color1=#a8334c
+color2=#4f6c31
+color3=#944927
+color4=#286486
+color5=#88507d
+color6=#3b8992
+color7=#2c363c
+
+color8=#cfc1ba
+color9=#94253e
+color10=#3f5a22
+color11=#803d1c
+color12=#1d5573
+color13=#7b3b70
+color14=#2b747c
+color15=#4f5e68

--- a/termux/zenburned.properties
+++ b/termux/zenburned.properties
@@ -1,0 +1,22 @@
+# zenburned
+foreground=#f0e4cf
+background=#404040
+cursor=#f3eadb
+
+color0=#404040
+color1=#e3716e
+color2=#819b69
+color3=#b77e64
+color4=#6099c0
+color5=#b279a7
+color6=#66a5ad
+color7=#f0e4cf
+
+color8=#625a5b
+color9=#ec8685
+color10=#8bae68
+color11=#d68c67
+color12=#61abda
+color13=#cf86c1
+color14=#65b8c1
+color15=#c0ab86

--- a/termux/zenwritten_dark.properties
+++ b/termux/zenwritten_dark.properties
@@ -1,0 +1,22 @@
+# zenwritten_dark
+foreground=#bbbbbb
+background=#191919
+cursor=#c9c9c9
+
+color0=#191919
+color1=#de6e7c
+color2=#819b69
+color3=#b77e64
+color4=#6099c0
+color5=#b279a7
+color6=#66a5ad
+color7=#bbbbbb
+
+color8=#3d3839
+color9=#e8838f
+color10=#8bae68
+color11=#d68c67
+color12=#61abda
+color13=#cf86c1
+color14=#65b8c1
+color15=#8e8e8e

--- a/termux/zenwritten_light.properties
+++ b/termux/zenwritten_light.properties
@@ -1,0 +1,22 @@
+# zenwritten_light
+foreground=#353535
+background=#eeeeee
+cursor=#353535
+
+color0=#eeeeee
+color1=#a8334c
+color2=#4f6c31
+color3=#944927
+color4=#286486
+color5=#88507d
+color6=#3b8992
+color7=#353535
+
+color8=#c6c3c3
+color9=#94253e
+color10=#3f5a22
+color11=#803d1c
+color12=#1d5573
+color13=#7b3b70
+color14=#2b747c
+color15=#5c5c5c

--- a/tools/templates/termux.properties
+++ b/tools/templates/termux.properties
@@ -1,0 +1,22 @@
+# {{ scheme_name }}
+foreground=#{{ Foreground_Color.hex }}
+background=#{{ Background_Color.hex }}
+cursor=#{{ Cursor_Color.hex }}
+
+color0=#{{ Ansi_0_Color.hex }}
+color1=#{{ Ansi_1_Color.hex }}
+color2=#{{ Ansi_2_Color.hex }}
+color3=#{{ Ansi_3_Color.hex }}
+color4=#{{ Ansi_4_Color.hex }}
+color5=#{{ Ansi_5_Color.hex }}
+color6=#{{ Ansi_6_Color.hex }}
+color7=#{{ Ansi_7_Color.hex }}
+
+color8=#{{ Ansi_8_Color.hex }}
+color9=#{{ Ansi_9_Color.hex }}
+color10=#{{ Ansi_10_Color.hex }}
+color11=#{{ Ansi_11_Color.hex }}
+color12=#{{ Ansi_12_Color.hex }}
+color13=#{{ Ansi_13_Color.hex }}
+color14=#{{ Ansi_14_Color.hex }}
+color15=#{{ Ansi_15_Color.hex }}


### PR DESCRIPTION
## Description
I added themes for the [Termux terminal emulator](https://termux.dev) and added README on how to apply it, so far, there's a lot of themes to test, but I got to test few themes and compared it with screenshots by running the `screenshotTable.sh` script. Let me know if there are other things that needed to be fixed.

![image](https://github.com/mbadolato/iTerm2-Color-Schemes/assets/119603393/634cbac6-b78e-4923-93d0-8f8028aea1f8)
![image](https://github.com/mbadolato/iTerm2-Color-Schemes/assets/119603393/fed0863a-fa45-426c-9cfe-cadd2bb2787c)

