### PR TITLE
ghostty: prefix colors with `#`

### DIFF
--- a/ghostty/3024 Day
+++ b/ghostty/3024 Day
@@ -14,8 +14,8 @@ palette = 12=#807d7c
 palette = 13=#d6d5d4
 palette = 14=#cdab53
 palette = 15=#f7f7f7
-background = f7f7f7
-foreground = 4a4543
-cursor-color = 4a4543
-selection-background = a5a2a2
-selection-foreground = 4a4543
+background = #f7f7f7
+foreground = #4a4543
+cursor-color = #4a4543
+selection-background = #a5a2a2
+selection-foreground = #4a4543

--- a/ghostty/3024 Night
+++ b/ghostty/3024 Night
@@ -14,8 +14,8 @@ palette = 12=#807d7c
 palette = 13=#d6d5d4
 palette = 14=#cdab53
 palette = 15=#f7f7f7
-background = 090300
-foreground = a5a2a2
-cursor-color = a5a2a2
-selection-background = 4a4543
-selection-foreground = a5a2a2
+background = #090300
+foreground = #a5a2a2
+cursor-color = #a5a2a2
+selection-background = #4a4543
+selection-foreground = #a5a2a2

--- a/ghostty/Aardvark Blue
+++ b/ghostty/Aardvark Blue
@@ -14,8 +14,8 @@ palette = 12=#60a4ec
 palette = 13=#e26be2
 palette = 14=#60b6cb
 palette = 15=#f7f7f7
-background = 102040
-foreground = dddddd
-cursor-color = 007acc
-selection-background = bfdbfe
-selection-foreground = 000000
+background = #102040
+foreground = #dddddd
+cursor-color = #007acc
+selection-background = #bfdbfe
+selection-foreground = #000000

--- a/ghostty/Abernathy
+++ b/ghostty/Abernathy
@@ -14,8 +14,8 @@ palette = 12=#11b5f6
 palette = 13=#ff00ff
 palette = 14=#00ffff
 palette = 15=#ffffff
-background = 111416
-foreground = eeeeec
-cursor-color = bbbbbb
-selection-background = eeeeec
-selection-foreground = 333333
+background = #111416
+foreground = #eeeeec
+cursor-color = #bbbbbb
+selection-background = #eeeeec
+selection-foreground = #333333

--- a/ghostty/Adventure
+++ b/ghostty/Adventure
@@ -14,8 +14,8 @@ palette = 12=#97d7ef
 palette = 13=#aa7900
 palette = 14=#bdcfe5
 palette = 15=#e4d5c7
-background = 040404
-foreground = feffff
-cursor-color = feffff
-selection-background = 606060
-selection-foreground = ffffff
+background = #040404
+foreground = #feffff
+cursor-color = #feffff
+selection-background = #606060
+selection-foreground = #ffffff

--- a/ghostty/AdventureTime
+++ b/ghostty/AdventureTime
@@ -14,8 +14,8 @@ palette = 12=#1997c6
 palette = 13=#9b5953
 palette = 14=#c8faf4
 palette = 15=#f6f5fb
-background = 1f1d45
-foreground = f8dcc0
-cursor-color = efbf38
-selection-background = 706b4e
-selection-foreground = f3d9c4
+background = #1f1d45
+foreground = #f8dcc0
+cursor-color = #efbf38
+selection-background = #706b4e
+selection-foreground = #f3d9c4

--- a/ghostty/Afterglow
+++ b/ghostty/Afterglow
@@ -14,8 +14,8 @@ palette = 12=#6c99bb
 palette = 13=#9f4e85
 palette = 14=#7dd6cf
 palette = 15=#f5f5f5
-background = 212121
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #212121
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0

--- a/ghostty/Alabaster
+++ b/ghostty/Alabaster
@@ -14,8 +14,8 @@ palette = 12=#007acc
 palette = 13=#e64ce6
 palette = 14=#00aacb
 palette = 15=#f7f7f7
-background = f7f7f7
-foreground = 000000
-cursor-color = 007acc
-selection-background = bfdbfe
-selection-foreground = 000000
+background = #f7f7f7
+foreground = #000000
+cursor-color = #007acc
+selection-background = #bfdbfe
+selection-foreground = #000000

--- a/ghostty/AlienBlood
+++ b/ghostty/AlienBlood
@@ -14,8 +14,8 @@ palette = 12=#00aae0
 palette = 13=#0058e0
 palette = 14=#00e0c4
 palette = 15=#73fa91
-background = 0f1610
-foreground = 637d75
-cursor-color = 73fa91
-selection-background = 1d4125
-selection-foreground = 73fa91
+background = #0f1610
+foreground = #637d75
+cursor-color = #73fa91
+selection-background = #1d4125
+selection-foreground = #73fa91

--- a/ghostty/Andromeda
+++ b/ghostty/Andromeda
@@ -14,8 +14,8 @@ palette = 12=#2472c8
 palette = 13=#bc3fbc
 palette = 14=#0fa8cd
 palette = 15=#e5e5e5
-background = 262a33
-foreground = e5e5e5
-cursor-color = f8f8f0
-selection-background = 5a5c62
-selection-foreground = ece7e7
+background = #262a33
+foreground = #e5e5e5
+cursor-color = #f8f8f0
+selection-background = #5a5c62
+selection-foreground = #ece7e7

--- a/ghostty/Apple Classic
+++ b/ghostty/Apple Classic
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 2c2b2b
-foreground = d5a200
-cursor-color = c7c7c7
-selection-background = 6b5b02
-selection-foreground = 67e000
+background = #2c2b2b
+foreground = #d5a200
+cursor-color = #c7c7c7
+selection-background = #6b5b02
+selection-foreground = #67e000

--- a/ghostty/Apple System Colors
+++ b/ghostty/Apple System Colors
@@ -14,8 +14,8 @@ palette = 12=#0a84ff
 palette = 13=#bf5af2
 palette = 14=#76d6ff
 palette = 15=#ffffff
-background = 1e1e1e
-foreground = ffffff
-cursor-color = 98989d
-selection-background = 3f638b
-selection-foreground = ffffff
+background = #1e1e1e
+foreground = #ffffff
+cursor-color = #98989d
+selection-background = #3f638b
+selection-foreground = #ffffff

--- a/ghostty/Argonaut
+++ b/ghostty/Argonaut
@@ -14,8 +14,8 @@ palette = 12=#0092ff
 palette = 13=#9a5feb
 palette = 14=#67fff0
 palette = 15=#ffffff
-background = 0e1019
-foreground = fffaf4
-cursor-color = ff0018
-selection-background = 002a3b
-selection-foreground = ffffff
+background = #0e1019
+foreground = #fffaf4
+cursor-color = #ff0018
+selection-background = #002a3b
+selection-foreground = #ffffff

--- a/ghostty/Arthur
+++ b/ghostty/Arthur
@@ -14,8 +14,8 @@ palette = 12=#87ceeb
 palette = 13=#996600
 palette = 14=#b0c4de
 palette = 15=#ddccbb
-background = 1c1c1c
-foreground = ddeedd
-cursor-color = e2bbef
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #1c1c1c
+foreground = #ddeedd
+cursor-color = #e2bbef
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/AtelierSulphurpool
+++ b/ghostty/AtelierSulphurpool
@@ -14,8 +14,8 @@ palette = 12=#898ea4
 palette = 13=#dfe2f1
 palette = 14=#9c637a
 palette = 15=#f5f7ff
-background = 202746
-foreground = 979db4
-cursor-color = 979db4
-selection-background = 5e6687
-selection-foreground = 979db4
+background = #202746
+foreground = #979db4
+cursor-color = #979db4
+selection-background = #5e6687
+selection-foreground = #979db4

--- a/ghostty/Atom
+++ b/ghostty/Atom
@@ -14,8 +14,8 @@ palette = 12=#96cbfe
 palette = 13=#b9b6fc
 palette = 14=#85befd
 palette = 15=#e0e0e0
-background = 161719
-foreground = c5c8c6
-cursor-color = d0d0d0
-selection-background = 444444
-selection-foreground = c5c8c6
+background = #161719
+foreground = #c5c8c6
+cursor-color = #d0d0d0
+selection-background = #444444
+selection-foreground = #c5c8c6

--- a/ghostty/AtomOneLight
+++ b/ghostty/AtomOneLight
@@ -14,8 +14,8 @@ palette = 12=#2f5af3
 palette = 13=#a00095
 palette = 14=#3f953a
 palette = 15=#ffffff
-background = f9f9f9
-foreground = 2a2c33
-cursor-color = bbbbbb
-selection-background = ededed
-selection-foreground = 2a2c33
+background = #f9f9f9
+foreground = #2a2c33
+cursor-color = #bbbbbb
+selection-background = #ededed
+selection-foreground = #2a2c33

--- a/ghostty/Aurora
+++ b/ghostty/Aurora
@@ -14,8 +14,8 @@ palette = 12=#03d6b8
 palette = 13=#ee5d43
 palette = 14=#03d6b8
 palette = 15=#c74ded
-background = 23262e
-foreground = ffca28
-cursor-color = ee5d43
-selection-background = 292e38
-selection-foreground = 00e8c6
+background = #23262e
+foreground = #ffca28
+cursor-color = #ee5d43
+selection-background = #292e38
+selection-foreground = #00e8c6

--- a/ghostty/Ayu Mirage
+++ b/ghostty/Ayu Mirage
@@ -14,8 +14,8 @@ palette = 12=#73d0ff
 palette = 13=#d4bfff
 palette = 14=#95e6cb
 palette = 15=#ffffff
-background = 1f2430
-foreground = cbccc6
-cursor-color = ffcc66
-selection-background = 33415e
-selection-foreground = cbccc6
+background = #1f2430
+foreground = #cbccc6
+cursor-color = #ffcc66
+selection-background = #33415e
+selection-foreground = #cbccc6

--- a/ghostty/Banana Blueberry
+++ b/ghostty/Banana Blueberry
@@ -14,8 +14,8 @@ palette = 12=#91fff4
 palette = 13=#da70d6
 palette = 14=#bcf3ff
 palette = 15=#ffffff
-background = 191323
-foreground = cccccc
-cursor-color = e07d13
-selection-background = 220525
-selection-foreground = f4f4f4
+background = #191323
+foreground = #cccccc
+cursor-color = #e07d13
+selection-background = #220525
+selection-foreground = #f4f4f4

--- a/ghostty/Batman
+++ b/ghostty/Batman
@@ -14,8 +14,8 @@ palette = 12=#919495
 palette = 13=#9a9a9d
 palette = 14=#a3a3a6
 palette = 15=#dadbd6
-background = 1b1d1e
-foreground = 6f6f6f
-cursor-color = fcef0c
-selection-background = 4d504c
-selection-foreground = f0e04a
+background = #1b1d1e
+foreground = #6f6f6f
+cursor-color = #fcef0c
+selection-background = #4d504c
+selection-foreground = #f0e04a

--- a/ghostty/Belafonte Day
+++ b/ghostty/Belafonte Day
@@ -14,8 +14,8 @@ palette = 12=#426a79
 palette = 13=#97522c
 palette = 14=#989a9c
 palette = 15=#d5ccba
-background = d5ccba
-foreground = 45373c
-cursor-color = 45373c
-selection-background = 968c83
-selection-foreground = 45373c
+background = #d5ccba
+foreground = #45373c
+cursor-color = #45373c
+selection-background = #968c83
+selection-foreground = #45373c

--- a/ghostty/Belafonte Night
+++ b/ghostty/Belafonte Night
@@ -14,8 +14,8 @@ palette = 12=#426a79
 palette = 13=#97522c
 palette = 14=#989a9c
 palette = 15=#d5ccba
-background = 20111b
-foreground = 968c83
-cursor-color = 968c83
-selection-background = 45373c
-selection-foreground = 968c83
+background = #20111b
+foreground = #968c83
+cursor-color = #968c83
+selection-background = #45373c
+selection-foreground = #968c83

--- a/ghostty/BirdsOfParadise
+++ b/ghostty/BirdsOfParadise
@@ -14,8 +14,8 @@ palette = 12=#b8d3ed
 palette = 13=#d19ecb
 palette = 14=#93cfd7
 palette = 15=#fff9d5
-background = 2a1f1d
-foreground = e0dbb7
-cursor-color = 573d26
-selection-background = 563c27
-selection-foreground = e0dbbb
+background = #2a1f1d
+foreground = #e0dbb7
+cursor-color = #573d26
+selection-background = #563c27
+selection-foreground = #e0dbbb

--- a/ghostty/Blazer
+++ b/ghostty/Blazer
@@ -14,8 +14,8 @@ palette = 12=#bdbddb
 palette = 13=#dbbddb
 palette = 14=#bddbdb
 palette = 15=#ffffff
-background = 0d1926
-foreground = d9e6f2
-cursor-color = d9e6f2
-selection-background = c1ddff
-selection-foreground = 000000
+background = #0d1926
+foreground = #d9e6f2
+cursor-color = #d9e6f2
+selection-background = #c1ddff
+selection-foreground = #000000

--- a/ghostty/Blue Matrix
+++ b/ghostty/Blue Matrix
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#d682ec
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 101116
-foreground = 00a2ff
-cursor-color = 76ff9f
-selection-background = c1deff
-selection-foreground = 000000
+background = #101116
+foreground = #00a2ff
+cursor-color = #76ff9f
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/BlueBerryPie
+++ b/ghostty/BlueBerryPie
@@ -14,8 +14,8 @@ palette = 12=#39173d
 palette = 13=#bc94b7
 palette = 14=#5e6071
 palette = 15=#0a6c7e
-background = 1c0c28
-foreground = babab9
-cursor-color = fcfad6
-selection-background = 606060
-selection-foreground = ffffff
+background = #1c0c28
+foreground = #babab9
+cursor-color = #fcfad6
+selection-background = #606060
+selection-foreground = #ffffff

--- a/ghostty/BlueDolphin
+++ b/ghostty/BlueDolphin
@@ -14,8 +14,8 @@ palette = 12=#9cc4ff
 palette = 13=#ddb0f6
 palette = 14=#a3f7ff
 palette = 15=#ffffff
-background = 006984
-foreground = c5f2ff
-cursor-color = ffcc00
-selection-background = 2baeca
-selection-foreground = eceff1
+background = #006984
+foreground = #c5f2ff
+cursor-color = #ffcc00
+selection-background = #2baeca
+selection-foreground = #eceff1

--- a/ghostty/BlulocoDark
+++ b/ghostty/BlulocoDark
@@ -14,8 +14,8 @@ palette = 12=#10b1fe
 palette = 13=#ff78f8
 palette = 14=#5fb9bc
 palette = 15=#ffffff
-background = 282c34
-foreground = b9c0cb
-cursor-color = ffcc00
-selection-background = b9c0ca
-selection-foreground = 272b33
+background = #282c34
+foreground = #b9c0cb
+cursor-color = #ffcc00
+selection-background = #b9c0ca
+selection-foreground = #272b33

--- a/ghostty/BlulocoLight
+++ b/ghostty/BlulocoLight
@@ -14,8 +14,8 @@ palette = 12=#0099e1
 palette = 13=#ce33c0
 palette = 14=#6d93bb
 palette = 15=#d3d3d3
-background = f9f9f9
-foreground = 373a41
-cursor-color = f32759
-selection-background = daf0ff
-selection-foreground = 373a41
+background = #f9f9f9
+foreground = #373a41
+cursor-color = #f32759
+selection-background = #daf0ff
+selection-foreground = #373a41

--- a/ghostty/Borland
+++ b/ghostty/Borland
@@ -14,8 +14,8 @@ palette = 12=#b5dcff
 palette = 13=#ff9cfe
 palette = 14=#dfdffe
 palette = 15=#ffffff
-background = 0000a4
-foreground = ffff4e
-cursor-color = ffa560
-selection-background = a4a4a4
-selection-foreground = 0000a4
+background = #0000a4
+foreground = #ffff4e
+cursor-color = #ffa560
+selection-background = #a4a4a4
+selection-foreground = #0000a4

--- a/ghostty/Breeze
+++ b/ghostty/Breeze
@@ -14,8 +14,8 @@ palette = 12=#3daee9
 palette = 13=#8e44ad
 palette = 14=#16a085
 palette = 15=#fcfcfc
-background = 31363b
-foreground = eff0f1
-cursor-color = eff0f1
-selection-background = eff0f1
-selection-foreground = 31363b
+background = #31363b
+foreground = #eff0f1
+cursor-color = #eff0f1
+selection-background = #eff0f1
+selection-foreground = #31363b

--- a/ghostty/Bright Lights
+++ b/ghostty/Bright Lights
@@ -14,8 +14,8 @@ palette = 12=#76d5ff
 palette = 13=#ba76e7
 palette = 14=#6cbfb5
 palette = 15=#c2c8d7
-background = 191919
-foreground = b3c9d7
-cursor-color = f34b00
-selection-background = b3c9d7
-selection-foreground = 191919
+background = #191919
+foreground = #b3c9d7
+cursor-color = #f34b00
+selection-background = #b3c9d7
+selection-foreground = #191919

--- a/ghostty/Broadcast
+++ b/ghostty/Broadcast
@@ -14,8 +14,8 @@ palette = 12=#9fcef0
 palette = 13=#ffffff
 palette = 14=#a0cef0
 palette = 15=#ffffff
-background = 2b2b2b
-foreground = e6e1dc
-cursor-color = ffffff
-selection-background = 5a647e
-selection-foreground = e6e1dc
+background = #2b2b2b
+foreground = #e6e1dc
+cursor-color = #ffffff
+selection-background = #5a647e
+selection-foreground = #e6e1dc

--- a/ghostty/Brogrammer
+++ b/ghostty/Brogrammer
@@ -14,8 +14,8 @@ palette = 12=#1081d6
 palette = 13=#5350b9
 palette = 14=#0f7ddb
 palette = 15=#ffffff
-background = 131313
-foreground = d6dbe5
-cursor-color = b9b9b9
-selection-background = 1f1f1f
-selection-foreground = d6dbe5
+background = #131313
+foreground = #d6dbe5
+cursor-color = #b9b9b9
+selection-background = #1f1f1f
+selection-foreground = #d6dbe5

--- a/ghostty/Builtin Dark
+++ b/ghostty/Builtin Dark
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Builtin Light
+++ b/ghostty/Builtin Light
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Builtin Pastel Dark
+++ b/ghostty/Builtin Pastel Dark
@@ -14,8 +14,8 @@ palette = 12=#b5dcff
 palette = 13=#ff9cfe
 palette = 14=#dfdffe
 palette = 15=#ffffff
-background = 000000
-foreground = bbbbbb
-cursor-color = ffa560
-selection-background = 363983
-selection-foreground = f2f2f2
+background = #000000
+foreground = #bbbbbb
+cursor-color = #ffa560
+selection-background = #363983
+selection-foreground = #f2f2f2

--- a/ghostty/Builtin Solarized Dark
+++ b/ghostty/Builtin Solarized Dark
@@ -14,8 +14,8 @@ palette = 12=#839496
 palette = 13=#6c71c4
 palette = 14=#93a1a1
 palette = 15=#fdf6e3
-background = 002b36
-foreground = 839496
-cursor-color = 839496
-selection-background = 073642
-selection-foreground = 93a1a1
+background = #002b36
+foreground = #839496
+cursor-color = #839496
+selection-background = #073642
+selection-foreground = #93a1a1

--- a/ghostty/Builtin Solarized Light
+++ b/ghostty/Builtin Solarized Light
@@ -14,8 +14,8 @@ palette = 12=#839496
 palette = 13=#6c71c4
 palette = 14=#93a1a1
 palette = 15=#fdf6e3
-background = fdf6e3
-foreground = 657b83
-cursor-color = 657b83
-selection-background = eee8d5
-selection-foreground = 586e75
+background = #fdf6e3
+foreground = #657b83
+cursor-color = #657b83
+selection-background = #eee8d5
+selection-foreground = #586e75

--- a/ghostty/Builtin Tango Dark
+++ b/ghostty/Builtin Tango Dark
@@ -14,8 +14,8 @@ palette = 12=#729fcf
 palette = 13=#ad7fa8
 palette = 14=#34e2e2
 palette = 15=#eeeeec
-background = 000000
-foreground = ffffff
-cursor-color = ffffff
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Builtin Tango Light
+++ b/ghostty/Builtin Tango Light
@@ -14,8 +14,8 @@ palette = 12=#729fcf
 palette = 13=#ad7fa8
 palette = 14=#34e2e2
 palette = 15=#eeeeec
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/C64
+++ b/ghostty/C64
@@ -14,8 +14,8 @@ palette = 12=#40318d
 palette = 13=#8b3f96
 palette = 14=#67b6bd
 palette = 15=#f7f7f7
-background = 40318d
-foreground = 7869c4
-cursor-color = 7869c4
-selection-background = 7869c4
-selection-foreground = 40318d
+background = #40318d
+foreground = #7869c4
+cursor-color = #7869c4
+selection-background = #7869c4
+selection-foreground = #40318d

--- a/ghostty/CGA
+++ b/ghostty/CGA
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = aaaaaa
-cursor-color = b8b8b8
-selection-background = c1deff
-selection-foreground = 000000
+background = #000000
+foreground = #aaaaaa
+cursor-color = #b8b8b8
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/CLRS
+++ b/ghostty/CLRS
@@ -14,8 +14,8 @@ palette = 12=#1670ff
 palette = 13=#e900b0
 palette = 14=#3ad5ce
 palette = 15=#eeeeec
-background = ffffff
-foreground = 262626
-cursor-color = 6fd3fc
-selection-background = 6fd3fc
-selection-foreground = 041730
+background = #ffffff
+foreground = #262626
+cursor-color = #6fd3fc
+selection-background = #6fd3fc
+selection-foreground = #041730

--- a/ghostty/Calamity
+++ b/ghostty/Calamity
@@ -14,8 +14,8 @@ palette = 12=#3b79c7
 palette = 13=#f92672
 palette = 14=#74d3de
 palette = 15=#ffffff
-background = 2f2833
-foreground = d5ced9
-cursor-color = d5ced9
-selection-background = 7e6c88
-selection-foreground = d5ced9
+background = #2f2833
+foreground = #d5ced9
+cursor-color = #d5ced9
+selection-background = #7e6c88
+selection-foreground = #d5ced9

--- a/ghostty/Chalk
+++ b/ghostty/Chalk
@@ -14,8 +14,8 @@ palette = 12=#4196ff
 palette = 13=#fc5275
 palette = 14=#53cdbd
 palette = 15=#d2d8d9
-background = 2b2d2e
-foreground = d2d8d9
-cursor-color = 708284
-selection-background = e4e8ed
-selection-foreground = 3f4041
+background = #2b2d2e
+foreground = #d2d8d9
+cursor-color = #708284
+selection-background = #e4e8ed
+selection-foreground = #3f4041

--- a/ghostty/Chalkboard
+++ b/ghostty/Chalkboard
@@ -14,8 +14,8 @@ palette = 12=#aaaadb
 palette = 13=#dbaada
 palette = 14=#aadadb
 palette = 15=#ffffff
-background = 29262f
-foreground = d9e6f2
-cursor-color = d9e6f2
-selection-background = 073642
-selection-foreground = ffffff
+background = #29262f
+foreground = #d9e6f2
+cursor-color = #d9e6f2
+selection-background = #073642
+selection-foreground = #ffffff

--- a/ghostty/ChallengerDeep
+++ b/ghostty/ChallengerDeep
@@ -14,8 +14,8 @@ palette = 12=#91ddff
 palette = 13=#c991e1
 palette = 14=#aaffe4
 palette = 15=#cbe3e7
-background = 1e1c31
-foreground = cbe1e7
-cursor-color = fbfcfc
-selection-background = cbe1e7
-selection-foreground = 1e1c31
+background = #1e1c31
+foreground = #cbe1e7
+cursor-color = #fbfcfc
+selection-background = #cbe1e7
+selection-foreground = #1e1c31

--- a/ghostty/Chester
+++ b/ghostty/Chester
@@ -14,8 +14,8 @@ palette = 12=#278ad6
 palette = 13=#d34590
 palette = 14=#27dede
 palette = 15=#ffffff
-background = 2c3643
-foreground = ffffff
-cursor-color = b4b1b1
-selection-background = 67747c
-selection-foreground = ffffff
+background = #2c3643
+foreground = #ffffff
+cursor-color = #b4b1b1
+selection-background = #67747c
+selection-foreground = #ffffff

--- a/ghostty/Ciapre
+++ b/ghostty/Ciapre
@@ -14,8 +14,8 @@ palette = 12=#3097c6
 palette = 13=#d33061
 palette = 14=#f3dbb2
 palette = 15=#f4f4f4
-background = 191c27
-foreground = aea47a
-cursor-color = 92805b
-selection-background = 172539
-selection-foreground = aea47f
+background = #191c27
+foreground = #aea47a
+cursor-color = #92805b
+selection-background = #172539
+selection-foreground = #aea47f

--- a/ghostty/Cobalt Neon
+++ b/ghostty/Cobalt Neon
@@ -14,8 +14,8 @@ palette = 12=#3c7dd2
 palette = 13=#8230a7
 palette = 14=#6cbc67
 palette = 15=#8ff586
-background = 142838
-foreground = 8ff586
-cursor-color = c4206f
-selection-background = 094fb1
-selection-foreground = 8ff586
+background = #142838
+foreground = #8ff586
+cursor-color = #c4206f
+selection-background = #094fb1
+selection-foreground = #8ff586

--- a/ghostty/Cobalt2
+++ b/ghostty/Cobalt2
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#6ae3fa
 palette = 15=#ffffff
-background = 132738
-foreground = ffffff
-cursor-color = f0cc09
-selection-background = 18354f
-selection-foreground = b5b5b5
+background = #132738
+foreground = #ffffff
+cursor-color = #f0cc09
+selection-background = #18354f
+selection-foreground = #b5b5b5

--- a/ghostty/CrayonPonyFish
+++ b/ghostty/CrayonPonyFish
@@ -14,8 +14,8 @@ palette = 12=#cfc9ff
 palette = 13=#fc6cba
 palette = 14=#ffceaf
 palette = 15=#b0949d
-background = 150707
-foreground = 68525a
-cursor-color = 68525a
-selection-background = 2b1b1d
-selection-foreground = 69525a
+background = #150707
+foreground = #68525a
+cursor-color = #68525a
+selection-background = #2b1b1d
+selection-foreground = #69525a

--- a/ghostty/CutiePro
+++ b/ghostty/CutiePro
@@ -14,8 +14,8 @@ palette = 12=#80c5de
 palette = 13=#b294bb
 palette = 14=#9dccbb
 palette = 15=#ffffff
-background = 181818
-foreground = d5d0c9
-cursor-color = efc4cd
-selection-background = 363636
-selection-foreground = d5d0c9
+background = #181818
+foreground = #d5d0c9
+cursor-color = #efc4cd
+selection-background = #363636
+selection-foreground = #d5d0c9

--- a/ghostty/Cyberdyne
+++ b/ghostty/Cyberdyne
@@ -14,8 +14,8 @@ palette = 12=#c2e3ff
 palette = 13=#ffb2fe
 palette = 14=#e6e7fe
 palette = 15=#ffffff
-background = 151144
-foreground = 00ff92
-cursor-color = 00ff9c
-selection-background = 454d96
-selection-foreground = f4f4f4
+background = #151144
+foreground = #00ff92
+cursor-color = #00ff9c
+selection-background = #454d96
+selection-foreground = #f4f4f4

--- a/ghostty/CyberpunkScarletProtocol
+++ b/ghostty/CyberpunkScarletProtocol
@@ -14,8 +14,8 @@ palette = 12=#6a71f6
 palette = 13=#ae40e4
 palette = 14=#8efafd
 palette = 15=#ffffff
-background = 101116
-foreground = d13554
-cursor-color = 9bfca8
-selection-background = c7ddfc
-selection-foreground = 000000
+background = #101116
+foreground = #d13554
+cursor-color = #9bfca8
+selection-background = #c7ddfc
+selection-foreground = #000000

--- a/ghostty/Dark Modern
+++ b/ghostty/Dark Modern
@@ -14,8 +14,8 @@ palette = 12=#3b8eea
 palette = 13=#d670d6
 palette = 14=#29b8db
 palette = 15=#e5e5e5
-background = 1f1f1f
-foreground = cccccc
-cursor-color = ffffff
-selection-background = 3a3d41
-selection-foreground = e0e0e0
+background = #1f1f1f
+foreground = #cccccc
+cursor-color = #ffffff
+selection-background = #3a3d41
+selection-foreground = #e0e0e0

--- a/ghostty/Dark Pastel
+++ b/ghostty/Dark Pastel
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = ffffff
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #ffffff
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Dark+
+++ b/ghostty/Dark+
@@ -14,8 +14,8 @@ palette = 12=#3b8eea
 palette = 13=#d670d6
 palette = 14=#29b8db
 palette = 15=#e5e5e5
-background = 1e1e1e
-foreground = cccccc
-cursor-color = ffffff
-selection-background = 3a3d41
-selection-foreground = e0e0e0
+background = #1e1e1e
+foreground = #cccccc
+cursor-color = #ffffff
+selection-background = #3a3d41
+selection-foreground = #e0e0e0

--- a/ghostty/Darkside
+++ b/ghostty/Darkside
@@ -14,8 +14,8 @@ palette = 12=#387cd3
 palette = 13=#957bbe
 palette = 14=#3d97e2
 palette = 15=#bababa
-background = 222324
-foreground = bababa
-cursor-color = bbbbbb
-selection-background = 303333
-selection-foreground = bababa
+background = #222324
+foreground = #bababa
+cursor-color = #bbbbbb
+selection-background = #303333
+selection-foreground = #bababa

--- a/ghostty/Desert
+++ b/ghostty/Desert
@@ -14,8 +14,8 @@ palette = 12=#87ceff
 palette = 13=#ff55ff
 palette = 14=#ffd700
 palette = 15=#ffffff
-background = 333333
-foreground = ffffff
-cursor-color = 00ff00
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #333333
+foreground = #ffffff
+cursor-color = #00ff00
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Dimidium
+++ b/ghostty/Dimidium
@@ -14,8 +14,8 @@ palette = 12=#688dfd
 palette = 13=#ed6fe9
 palette = 14=#32e0fb
 palette = 15=#d3d8d9
-background = 141414
-foreground = bab7b6
-cursor-color = 37e57b
-selection-background = 8db8e5
-selection-foreground = 141414
+background = #141414
+foreground = #bab7b6
+cursor-color = #37e57b
+selection-background = #8db8e5
+selection-foreground = #141414

--- a/ghostty/DimmedMonokai
+++ b/ghostty/DimmedMonokai
@@ -14,8 +14,8 @@ palette = 12=#186de3
 palette = 13=#fb0067
 palette = 14=#2e706d
 palette = 15=#fdffb9
-background = 1f1f1f
-foreground = b9bcba
-cursor-color = f83e19
-selection-background = 2a2d32
-selection-foreground = b9bcba
+background = #1f1f1f
+foreground = #b9bcba
+cursor-color = #f83e19
+selection-background = #2a2d32
+selection-foreground = #b9bcba

--- a/ghostty/Django
+++ b/ghostty/Django
@@ -14,8 +14,8 @@ palette = 12=#568264
 palette = 13=#ffffff
 palette = 14=#cfffd1
 palette = 15=#ffffff
-background = 0b2f20
-foreground = f8f8f8
-cursor-color = 336442
-selection-background = 245032
-selection-foreground = f8f8f8
+background = #0b2f20
+foreground = #f8f8f8
+cursor-color = #336442
+selection-background = #245032
+selection-foreground = #f8f8f8

--- a/ghostty/DjangoRebornAgain
+++ b/ghostty/DjangoRebornAgain
@@ -14,8 +14,8 @@ palette = 12=#568264
 palette = 13=#ffffff
 palette = 14=#cfffd1
 palette = 15=#ffffff
-background = 051f14
-foreground = dadedc
-cursor-color = ffcc00
-selection-background = 203727
-selection-foreground = dadedc
+background = #051f14
+foreground = #dadedc
+cursor-color = #ffcc00
+selection-background = #203727
+selection-foreground = #dadedc

--- a/ghostty/DjangoSmooth
+++ b/ghostty/DjangoSmooth
@@ -14,8 +14,8 @@ palette = 12=#cacaca
 palette = 13=#ffffff
 palette = 14=#cfffd1
 palette = 15=#ffffff
-background = 245032
-foreground = f8f8f8
-cursor-color = 336442
-selection-background = 336442
-selection-foreground = f8f8f8
+background = #245032
+foreground = #f8f8f8
+cursor-color = #336442
+selection-background = #336442
+selection-foreground = #f8f8f8

--- a/ghostty/Doom Peacock
+++ b/ghostty/Doom Peacock
@@ -14,8 +14,8 @@ palette = 12=#51afef
 palette = 13=#c678dd
 palette = 14=#46d9ff
 palette = 15=#dfdfdf
-background = 2b2a27
-foreground = ede0ce
-cursor-color = 9c9c9d
-selection-background = a60033
-selection-foreground = ffffff
+background = #2b2a27
+foreground = #ede0ce
+cursor-color = #9c9c9d
+selection-background = #a60033
+selection-foreground = #ffffff

--- a/ghostty/DoomOne
+++ b/ghostty/DoomOne
@@ -14,8 +14,8 @@ palette = 12=#a9a1e1
 palette = 13=#c678dd
 palette = 14=#51afef
 palette = 15=#bfbfbf
-background = 282c34
-foreground = bbc2cf
-cursor-color = 51afef
-selection-background = 42444b
-selection-foreground = bbc2cf
+background = #282c34
+foreground = #bbc2cf
+cursor-color = #51afef
+selection-background = #42444b
+selection-foreground = #bbc2cf

--- a/ghostty/DotGov
+++ b/ghostty/DotGov
@@ -14,8 +14,8 @@ palette = 12=#17b2e0
 palette = 13=#7830b0
 palette = 14=#8bd2ed
 palette = 15=#ffffff
-background = 262c35
-foreground = ebebeb
-cursor-color = d9002f
-selection-background = 1a4080
-selection-foreground = ffffff
+background = #262c35
+foreground = #ebebeb
+cursor-color = #d9002f
+selection-background = #1a4080
+selection-foreground = #ffffff

--- a/ghostty/Dracula
+++ b/ghostty/Dracula
@@ -14,8 +14,8 @@ palette = 12=#bd93f9
 palette = 13=#ff79c6
 palette = 14=#8be9fd
 palette = 15=#ffffff
-background = 1e1f29
-foreground = f8f8f2
-cursor-color = bbbbbb
-selection-background = 44475a
-selection-foreground = ffffff
+background = #1e1f29
+foreground = #f8f8f2
+cursor-color = #bbbbbb
+selection-background = #44475a
+selection-foreground = #ffffff

--- a/ghostty/Dracula+
+++ b/ghostty/Dracula+
@@ -14,8 +14,8 @@ palette = 12=#d6acff
 palette = 13=#ff92df
 palette = 14=#a4ffff
 palette = 15=#f8f8f2
-background = 212121
-foreground = f8f8f2
-cursor-color = eceff4
-selection-background = f8f8f2
-selection-foreground = 545454
+background = #212121
+foreground = #f8f8f2
+cursor-color = #eceff4
+selection-background = #f8f8f2
+selection-foreground = #545454

--- a/ghostty/Duotone Dark
+++ b/ghostty/Duotone Dark
@@ -14,8 +14,8 @@ palette = 12=#ffc284
 palette = 13=#de8d40
 palette = 14=#2488ff
 palette = 15=#eae5ff
-background = 1f1d27
-foreground = b7a1ff
-cursor-color = ff9839
-selection-background = 353147
-selection-foreground = b7a2ff
+background = #1f1d27
+foreground = #b7a1ff
+cursor-color = #ff9839
+selection-background = #353147
+selection-foreground = #b7a2ff

--- a/ghostty/ENCOM
+++ b/ghostty/ENCOM
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#ff00ff
 palette = 14=#00cdcd
 palette = 15=#ffffff
-background = 000000
-foreground = 00a595
-cursor-color = bbbbbb
-selection-background = 00a48c
-selection-foreground = 3de1c9
+background = #000000
+foreground = #00a595
+cursor-color = #bbbbbb
+selection-background = #00a48c
+selection-foreground = #3de1c9

--- a/ghostty/Earthsong
+++ b/ghostty/Earthsong
@@ -14,8 +14,8 @@ palette = 12=#5fdaff
 palette = 13=#ff9269
 palette = 14=#84f088
 palette = 15=#f6f7ec
-background = 292520
-foreground = e5c7a9
-cursor-color = f6f7ec
-selection-background = 121418
-selection-foreground = e5c7a9
+background = #292520
+foreground = #e5c7a9
+cursor-color = #f6f7ec
+selection-background = #121418
+selection-foreground = #e5c7a9

--- a/ghostty/Elemental
+++ b/ghostty/Elemental
@@ -14,8 +14,8 @@ palette = 12=#79d9d9
 palette = 13=#cd7c54
 palette = 14=#59d599
 palette = 15=#fff1e9
-background = 22211d
-foreground = 807a74
-cursor-color = facb80
-selection-background = 413829
-selection-foreground = facd77
+background = #22211d
+foreground = #807a74
+cursor-color = #facb80
+selection-background = #413829
+selection-foreground = #facd77

--- a/ghostty/Elementary
+++ b/ghostty/Elementary
@@ -14,8 +14,8 @@ palette = 12=#0955ff
 palette = 13=#fb0050
 palette = 14=#3ea8fc
 palette = 15=#8c00ec
-background = 181818
-foreground = efefef
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #181818
+foreground = #efefef
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Espresso
+++ b/ghostty/Espresso
@@ -14,8 +14,8 @@ palette = 12=#8ab7d9
 palette = 13=#efb5f7
 palette = 14=#dcf4ff
 palette = 15=#ffffff
-background = 323232
-foreground = ffffff
-cursor-color = d6d6d6
-selection-background = 5b5b5b
-selection-foreground = ffffff
+background = #323232
+foreground = #ffffff
+cursor-color = #d6d6d6
+selection-background = #5b5b5b
+selection-foreground = #ffffff

--- a/ghostty/Espresso Libre
+++ b/ghostty/Espresso Libre
@@ -14,8 +14,8 @@ palette = 12=#43a8ed
 palette = 13=#ff818a
 palette = 14=#34e2e2
 palette = 15=#eeeeec
-background = 2a211c
-foreground = b8a898
-cursor-color = ffffff
-selection-background = c3dcff
-selection-foreground = b8a898
+background = #2a211c
+foreground = #b8a898
+cursor-color = #ffffff
+selection-background = #c3dcff
+selection-foreground = #b8a898

--- a/ghostty/Everblush
+++ b/ghostty/Everblush
@@ -14,8 +14,8 @@ palette = 12=#71baf2
 palette = 13=#ce89df
 palette = 14=#67cbe7
 palette = 15=#bdc3c2
-background = 141b1e
-foreground = dadada
-cursor-color = dadada
-selection-background = 141b1e
-selection-foreground = dadada
+background = #141b1e
+foreground = #dadada
+cursor-color = #dadada
+selection-background = #141b1e
+selection-foreground = #dadada

--- a/ghostty/Everforest Dark - Hard
+++ b/ghostty/Everforest Dark - Hard
@@ -14,8 +14,8 @@ palette = 12=#3a94c5
 palette = 13=#df69ba
 palette = 14=#35a77c
 palette = 15=#fffbef
-background = 1e2326
-foreground = d3c6aa
-cursor-color = e69875
-selection-background = 4c3743
-selection-foreground = d3c6aa
+background = #1e2326
+foreground = #d3c6aa
+cursor-color = #e69875
+selection-background = #4c3743
+selection-foreground = #d3c6aa

--- a/ghostty/Fahrenheit
+++ b/ghostty/Fahrenheit
@@ -14,8 +14,8 @@ palette = 12=#cb4a05
 palette = 13=#4e739f
 palette = 14=#fed04d
 palette = 15=#ffffff
-background = 000000
-foreground = ffffce
-cursor-color = bbbbbb
-selection-background = 4e739f
-selection-foreground = ffffce
+background = #000000
+foreground = #ffffce
+cursor-color = #bbbbbb
+selection-background = #4e739f
+selection-foreground = #ffffce

--- a/ghostty/Fairyfloss
+++ b/ghostty/Fairyfloss
@@ -14,8 +14,8 @@ palette = 12=#c2ffdf
 palette = 13=#ffb8d1
 palette = 14=#c5a3ff
 palette = 15=#f8f8f0
-background = 5a5475
-foreground = f8f8f2
-cursor-color = f8f8f0
-selection-background = 8077a8
-selection-foreground = f6e1ce
+background = #5a5475
+foreground = #f8f8f2
+cursor-color = #f8f8f0
+selection-background = #8077a8
+selection-foreground = #f6e1ce

--- a/ghostty/Fideloper
+++ b/ghostty/Fideloper
@@ -14,8 +14,8 @@ palette = 12=#7c85c4
 palette = 13=#5c5db2
 palette = 14=#819090
 palette = 15=#fcf4df
-background = 292f33
-foreground = dbdae0
-cursor-color = d4605a
-selection-background = efb8ac
-selection-foreground = ffffff
+background = #292f33
+foreground = #dbdae0
+cursor-color = #d4605a
+selection-background = #efb8ac
+selection-foreground = #ffffff

--- a/ghostty/Firefly Traditional
+++ b/ghostty/Firefly Traditional
@@ -14,8 +14,8 @@ palette = 12=#838dff
 palette = 13=#ff5cfe
 palette = 14=#29f0f0
 palette = 15=#ebebeb
-background = 000000
-foreground = f5f5f5
-cursor-color = 00f900
-selection-background = cfeac6
-selection-foreground = 000000
+background = #000000
+foreground = #f5f5f5
+cursor-color = #00f900
+selection-background = #cfeac6
+selection-foreground = #000000

--- a/ghostty/FirefoxDev
+++ b/ghostty/FirefoxDev
@@ -14,8 +14,8 @@ palette = 12=#006fc0
 palette = 13=#a200da
 palette = 14=#005794
 palette = 15=#e2e2e2
-background = 0e1011
-foreground = 7c8fa4
-cursor-color = 708284
-selection-background = 163c61
-selection-foreground = f2f5f9
+background = #0e1011
+foreground = #7c8fa4
+cursor-color = #708284
+selection-background = #163c61
+selection-foreground = #f2f5f9

--- a/ghostty/Firewatch
+++ b/ghostty/Firewatch
@@ -14,8 +14,8 @@ palette = 12=#4c89c5
 palette = 13=#d55119
 palette = 14=#44a8b6
 palette = 15=#e6e5ff
-background = 1e2027
-foreground = 9ba2b2
-cursor-color = f6f7ec
-selection-background = 2f363e
-selection-foreground = 7d8fa4
+background = #1e2027
+foreground = #9ba2b2
+cursor-color = #f6f7ec
+selection-background = #2f363e
+selection-foreground = #7d8fa4

--- a/ghostty/FishTank
+++ b/ghostty/FishTank
@@ -14,8 +14,8 @@ palette = 12=#b2befa
 palette = 13=#fda5cd
 palette = 14=#a5bd86
 palette = 15=#f6ffec
-background = 232537
-foreground = ecf0fe
-cursor-color = fecd5e
-selection-background = fcf7e9
-selection-foreground = 232537
+background = #232537
+foreground = #ecf0fe
+cursor-color = #fecd5e
+selection-background = #fcf7e9
+selection-foreground = #232537

--- a/ghostty/Flat
+++ b/ghostty/Flat
@@ -14,8 +14,8 @@ palette = 12=#3c7dd2
 palette = 13=#8230a7
 palette = 14=#35b387
 palette = 15=#e7eced
-background = 002240
-foreground = 2cc55d
-cursor-color = e5be0c
-selection-background = 792b9c
-selection-foreground = ffffff
+background = #002240
+foreground = #2cc55d
+cursor-color = #e5be0c
+selection-background = #792b9c
+selection-foreground = #ffffff

--- a/ghostty/Flatland
+++ b/ghostty/Flatland
@@ -14,8 +14,8 @@ palette = 12=#61b9d0
 palette = 13=#695abc
 palette = 14=#d63865
 palette = 15=#ffffff
-background = 1d1f21
-foreground = b8dbef
-cursor-color = 708284
-selection-background = 2b2a24
-selection-foreground = ffffff
+background = #1d1f21
+foreground = #b8dbef
+cursor-color = #708284
+selection-background = #2b2a24
+selection-foreground = #ffffff

--- a/ghostty/Floraverse
+++ b/ghostty/Floraverse
@@ -14,8 +14,8 @@ palette = 12=#40a4cf
 palette = 13=#f12aae
 palette = 14=#62caa8
 palette = 15=#fff5db
-background = 0e0d15
-foreground = dbd1b9
-cursor-color = bbbbbb
-selection-background = f3e0b8
-selection-foreground = 08002e
+background = #0e0d15
+foreground = #dbd1b9
+cursor-color = #bbbbbb
+selection-background = #f3e0b8
+selection-foreground = #08002e

--- a/ghostty/ForestBlue
+++ b/ghostty/ForestBlue
@@ -14,8 +14,8 @@ palette = 12=#39a7a2
 palette = 13=#7e62b3
 palette = 14=#6096bf
 palette = 15=#e2d8cd
-background = 051519
-foreground = e2d8cd
-cursor-color = 9e9ecb
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #051519
+foreground = #e2d8cd
+cursor-color = #9e9ecb
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Framer
+++ b/ghostty/Framer
@@ -14,8 +14,8 @@ palette = 12=#33bbff
 palette = 13=#cebbff
 palette = 14=#bbecff
 palette = 15=#ffffff
-background = 111111
-foreground = 777777
-cursor-color = fcdc08
-selection-background = 666666
-selection-foreground = ffffff
+background = #111111
+foreground = #777777
+cursor-color = #fcdc08
+selection-background = #666666
+selection-foreground = #ffffff

--- a/ghostty/FrontEndDelight
+++ b/ghostty/FrontEndDelight
@@ -14,8 +14,8 @@ palette = 12=#3393ca
 palette = 13=#e75e4f
 palette = 14=#4fbce6
 palette = 15=#8c735b
-background = 1b1c1d
-foreground = adadad
-cursor-color = cdcdcd
-selection-background = ea6154
-selection-foreground = 1b1c1d
+background = #1b1c1d
+foreground = #adadad
+cursor-color = #cdcdcd
+selection-background = #ea6154
+selection-foreground = #1b1c1d

--- a/ghostty/FunForrest
+++ b/ghostty/FunForrest
@@ -14,8 +14,8 @@ palette = 12=#7cc9cf
 palette = 13=#d26349
 palette = 14=#e6a96b
 palette = 15=#ffeaa3
-background = 251200
-foreground = dec165
-cursor-color = e5591c
-selection-background = e5591c
-selection-foreground = 000000
+background = #251200
+foreground = #dec165
+cursor-color = #e5591c
+selection-background = #e5591c
+selection-foreground = #000000

--- a/ghostty/Galaxy
+++ b/ghostty/Galaxy
@@ -14,8 +14,8 @@ palette = 12=#589df6
 palette = 13=#e75699
 palette = 14=#3979bc
 palette = 15=#ffffff
-background = 1d2837
-foreground = ffffff
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #1d2837
+foreground = #ffffff
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Galizur
+++ b/ghostty/Galizur
@@ -14,8 +14,8 @@ palette = 12=#3377ff
 palette = 13=#aa77ff
 palette = 14=#33ddff
 palette = 15=#bbccdd
-background = 071317
-foreground = ddeeff
-cursor-color = ddeeff
-selection-background = 071317
-selection-foreground = ddeeff
+background = #071317
+foreground = #ddeeff
+cursor-color = #ddeeff
+selection-background = #071317
+selection-foreground = #ddeeff

--- a/ghostty/GitHub Dark
+++ b/ghostty/GitHub Dark
@@ -14,8 +14,8 @@ palette = 12=#6ca4f8
 palette = 13=#db61a2
 palette = 14=#2b7489
 palette = 15=#ffffff
-background = 101216
-foreground = 8b949e
-cursor-color = c9d1d9
-selection-background = 3b5070
-selection-foreground = ffffff
+background = #101216
+foreground = #8b949e
+cursor-color = #c9d1d9
+selection-background = #3b5070
+selection-foreground = #ffffff

--- a/ghostty/Github
+++ b/ghostty/Github
@@ -14,8 +14,8 @@ palette = 12=#2e6cba
 palette = 13=#ffa29f
 palette = 14=#1cfafe
 palette = 15=#ffffff
-background = f4f4f4
-foreground = 3e3e3e
-cursor-color = 3f3f3f
-selection-background = a9c1e2
-selection-foreground = 535353
+background = #f4f4f4
+foreground = #3e3e3e
+cursor-color = #3f3f3f
+selection-background = #a9c1e2
+selection-foreground = #535353

--- a/ghostty/Glacier
+++ b/ghostty/Glacier
@@ -14,8 +14,8 @@ palette = 12=#2a8bc1
 palette = 13=#ea4727
 palette = 14=#a0b6d3
 palette = 15=#ffffff
-background = 0c1115
-foreground = ffffff
-cursor-color = 6c6c6c
-selection-background = bd2523
-selection-foreground = ffffff
+background = #0c1115
+foreground = #ffffff
+cursor-color = #6c6c6c
+selection-background = #bd2523
+selection-foreground = #ffffff

--- a/ghostty/Grape
+++ b/ghostty/Grape
@@ -14,8 +14,8 @@ palette = 12=#a9bcec
 palette = 13=#ad81c2
 palette = 14=#9de3eb
 palette = 15=#a288f7
-background = 171423
-foreground = 9f9fa1
-cursor-color = a288f7
-selection-background = 493d70
-selection-foreground = 171422
+background = #171423
+foreground = #9f9fa1
+cursor-color = #a288f7
+selection-background = #493d70
+selection-foreground = #171422

--- a/ghostty/Grass
+++ b/ghostty/Grass
@@ -14,8 +14,8 @@ palette = 12=#0000bb
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 13773d
-foreground = fff0a5
-cursor-color = 8c2800
-selection-background = b64926
-selection-foreground = ffffff
+background = #13773d
+foreground = #fff0a5
+cursor-color = #8c2800
+selection-background = #b64926
+selection-foreground = #ffffff

--- a/ghostty/Grey-green
+++ b/ghostty/Grey-green
@@ -14,8 +14,8 @@ palette = 12=#00afff
 palette = 13=#ff008a
 palette = 14=#00ffd3
 palette = 15=#f5ecec
-background = 002a1a
-foreground = ffffff
-cursor-color = fff400
-selection-background = 517e50
-selection-foreground = e2e2e2
+background = #002a1a
+foreground = #ffffff
+cursor-color = #fff400
+selection-background = #517e50
+selection-foreground = #e2e2e2

--- a/ghostty/GruvboxDark
+++ b/ghostty/GruvboxDark
@@ -14,8 +14,8 @@ palette = 12=#83a598
 palette = 13=#d3869b
 palette = 14=#8ec07c
 palette = 15=#ebdbb2
-background = 282828
-foreground = ebdbb2
-cursor-color = ebdbb2
-selection-background = 665c54
-selection-foreground = ebdbb2
+background = #282828
+foreground = #ebdbb2
+cursor-color = #ebdbb2
+selection-background = #665c54
+selection-foreground = #ebdbb2

--- a/ghostty/GruvboxDarkHard
+++ b/ghostty/GruvboxDarkHard
@@ -14,8 +14,8 @@ palette = 12=#83a598
 palette = 13=#d3869b
 palette = 14=#8ec07c
 palette = 15=#ebdbb2
-background = 1b1b1b
-foreground = ebdbb2
-cursor-color = ebdbb2
-selection-background = 665c54
-selection-foreground = ebdbb2
+background = #1b1b1b
+foreground = #ebdbb2
+cursor-color = #ebdbb2
+selection-background = #665c54
+selection-foreground = #ebdbb2

--- a/ghostty/GruvboxLight
+++ b/ghostty/GruvboxLight
@@ -14,8 +14,8 @@ palette = 12=#458588
 palette = 13=#b16186
 palette = 14=#689d69
 palette = 15=#7c6f64
-background = fbf1c7
-foreground = 282828
-cursor-color = 282828
-selection-background = d5c4a1
-selection-foreground = 665c54
+background = #fbf1c7
+foreground = #282828
+cursor-color = #282828
+selection-background = #d5c4a1
+selection-foreground = #665c54

--- a/ghostty/Guezwhoz
+++ b/ghostty/Guezwhoz
@@ -14,8 +14,8 @@ palette = 12=#87afd7
 palette = 13=#afafd7
 palette = 14=#87d7d7
 palette = 15=#dadada
-background = 1c1c1c
-foreground = d0d0d0
-cursor-color = eeeeee
-selection-background = 005f5f
-selection-foreground = eeeeee
+background = #1c1c1c
+foreground = #d0d0d0
+cursor-color = #eeeeee
+selection-background = #005f5f
+selection-foreground = #eeeeee

--- a/ghostty/HaX0R_BLUE
+++ b/ghostty/HaX0R_BLUE
@@ -14,8 +14,8 @@ palette = 12=#00b3f7
 palette = 13=#00b3f7
 palette = 14=#00b3f7
 palette = 15=#fefefe
-background = 010515
-foreground = 11b7ff
-cursor-color = 10b6ff
-selection-background = c1e4ff
-selection-foreground = f6f6f6
+background = #010515
+foreground = #11b7ff
+cursor-color = #10b6ff
+selection-background = #c1e4ff
+selection-foreground = #f6f6f6

--- a/ghostty/HaX0R_GR33N
+++ b/ghostty/HaX0R_GR33N
@@ -14,8 +14,8 @@ palette = 12=#19e20e
 palette = 13=#19e20e
 palette = 14=#19e20e
 palette = 15=#fefefe
-background = 020f01
-foreground = 16b10e
-cursor-color = 15d00d
-selection-background = d4ffc1
-selection-foreground = fdfdfd
+background = #020f01
+foreground = #16b10e
+cursor-color = #15d00d
+selection-background = #d4ffc1
+selection-foreground = #fdfdfd

--- a/ghostty/HaX0R_R3D
+++ b/ghostty/HaX0R_R3D
@@ -14,8 +14,8 @@ palette = 12=#ff1010
 palette = 13=#ff1010
 palette = 14=#ff1010
 palette = 15=#fefefe
-background = 200101
-foreground = b10e0e
-cursor-color = b00d0d
-selection-background = ebc1ff
-selection-foreground = fdfdfd
+background = #200101
+foreground = #b10e0e
+cursor-color = #b00d0d
+selection-background = #ebc1ff
+selection-foreground = #fdfdfd

--- a/ghostty/Hacktober
+++ b/ghostty/Hacktober
@@ -14,8 +14,8 @@ palette = 12=#5389c5
 palette = 13=#e795a5
 palette = 14=#ebc587
 palette = 15=#ffffff
-background = 141414
-foreground = c9c9c9
-cursor-color = c9c9c9
-selection-background = 141414
-selection-foreground = c9c9c9
+background = #141414
+foreground = #c9c9c9
+cursor-color = #c9c9c9
+selection-background = #141414
+selection-foreground = #c9c9c9

--- a/ghostty/Hardcore
+++ b/ghostty/Hardcore
@@ -14,8 +14,8 @@ palette = 12=#66d9ef
 palette = 13=#9e6ffe
 palette = 14=#a3babf
 palette = 15=#f8f8f2
-background = 121212
-foreground = a0a0a0
-cursor-color = bbbbbb
-selection-background = 453b39
-selection-foreground = b6bbc0
+background = #121212
+foreground = #a0a0a0
+cursor-color = #bbbbbb
+selection-background = #453b39
+selection-foreground = #b6bbc0

--- a/ghostty/Harper
+++ b/ghostty/Harper
@@ -14,8 +14,8 @@ palette = 12=#489e48
 palette = 13=#b296c6
 palette = 14=#f5bfd7
 palette = 15=#fefbea
-background = 010101
-foreground = a8a49d
-cursor-color = a8a49d
-selection-background = 5a5753
-selection-foreground = a8a49d
+background = #010101
+foreground = #a8a49d
+cursor-color = #a8a49d
+selection-background = #5a5753
+selection-foreground = #a8a49d

--- a/ghostty/Highway
+++ b/ghostty/Highway
@@ -14,8 +14,8 @@ palette = 12=#4fc2fd
 palette = 13=#de0071
 palette = 14=#5d504a
 palette = 15=#ffffff
-background = 222225
-foreground = ededed
-cursor-color = e0d9b9
-selection-background = 384564
-selection-foreground = ededed
+background = #222225
+foreground = #ededed
+cursor-color = #e0d9b9
+selection-background = #384564
+selection-foreground = #ededed

--- a/ghostty/Hipster Green
+++ b/ghostty/Hipster Green
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = 100b05
-foreground = 84c138
-cursor-color = 23ff18
-selection-background = 083905
-selection-foreground = ffffff
+background = #100b05
+foreground = #84c138
+cursor-color = #23ff18
+selection-background = #083905
+selection-foreground = #ffffff

--- a/ghostty/Hivacruz
+++ b/ghostty/Hivacruz
@@ -14,8 +14,8 @@ palette = 12=#898ea4
 palette = 13=#dfe2f1
 palette = 14=#9c637a
 palette = 15=#f5f7ff
-background = 132638
-foreground = ede4e4
-cursor-color = 979db4
-selection-background = 5e6687
-selection-foreground = 979db4
+background = #132638
+foreground = #ede4e4
+cursor-color = #979db4
+selection-background = #5e6687
+selection-foreground = #979db4

--- a/ghostty/Homebrew
+++ b/ghostty/Homebrew
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = 000000
-foreground = 00ff00
-cursor-color = 23ff18
-selection-background = 083905
-selection-foreground = ffffff
+background = #000000
+foreground = #00ff00
+cursor-color = #23ff18
+selection-background = #083905
+selection-foreground = #ffffff

--- a/ghostty/Hopscotch
+++ b/ghostty/Hopscotch
@@ -14,8 +14,8 @@ palette = 12=#989498
 palette = 13=#d5d3d5
 palette = 14=#b33508
 palette = 15=#ffffff
-background = 322931
-foreground = b9b5b8
-cursor-color = b9b5b8
-selection-background = 5c545b
-selection-foreground = b9b5b8
+background = #322931
+foreground = #b9b5b8
+cursor-color = #b9b5b8
+selection-background = #5c545b
+selection-foreground = #b9b5b8

--- a/ghostty/Hopscotch.256
+++ b/ghostty/Hopscotch.256
@@ -14,8 +14,8 @@ palette = 12=#1290bf
 palette = 13=#c85e7c
 palette = 14=#149b93
 palette = 15=#ffffff
-background = 322931
-foreground = b9b5b8
-cursor-color = b9b5b8
-selection-background = 5c545b
-selection-foreground = b9b5b8
+background = #322931
+foreground = #b9b5b8
+cursor-color = #b9b5b8
+selection-background = #5c545b
+selection-foreground = #b9b5b8

--- a/ghostty/Horizon
+++ b/ghostty/Horizon
@@ -14,8 +14,8 @@ palette = 12=#56c2ea
 palette = 13=#c38ce1
 palette = 14=#3ce8e6
 palette = 15=#ffffff
-background = 1c1e26
-foreground = bbbaba
-cursor-color = c7c7c7
-selection-background = 292b36
-selection-foreground = dfd3d5
+background = #1c1e26
+foreground = #bbbaba
+cursor-color = #c7c7c7
+selection-background = #292b36
+selection-foreground = #dfd3d5

--- a/ghostty/Hurtado
+++ b/ghostty/Hurtado
@@ -14,8 +14,8 @@ palette = 12=#89beff
 palette = 13=#c001c1
 palette = 14=#86eafe
 palette = 15=#dbdbdb
-background = 000000
-foreground = dbdbdb
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #dbdbdb
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Hybrid
+++ b/ghostty/Hybrid
@@ -14,8 +14,8 @@ palette = 12=#4b6b88
 palette = 13=#6e5079
 palette = 14=#4d7b74
 palette = 15=#5a626a
-background = 161719
-foreground = b7bcba
-cursor-color = b7bcba
-selection-background = 1e1f22
-selection-foreground = b7bcba
+background = #161719
+foreground = #b7bcba
+cursor-color = #b7bcba
+selection-background = #1e1f22
+selection-foreground = #b7bcba

--- a/ghostty/IC_Green_PPL
+++ b/ghostty/IC_Green_PPL
@@ -14,8 +14,8 @@ palette = 12=#2efaeb
 palette = 13=#50fafa
 palette = 14=#3cfac8
 palette = 15=#e0f1dc
-background = 2c2c2c
-foreground = e0f1dc
-cursor-color = 47fa6b
-selection-background = 116b41
-selection-foreground = e0f1dc
+background = #2c2c2c
+foreground = #e0f1dc
+cursor-color = #47fa6b
+selection-background = #116b41
+selection-foreground = #e0f1dc

--- a/ghostty/IC_Orange_PPL
+++ b/ghostty/IC_Orange_PPL
@@ -14,8 +14,8 @@ palette = 12=#ffbe55
 palette = 13=#fc874f
 palette = 14=#c69752
 palette = 15=#fafaff
-background = 262626
-foreground = ffcb83
-cursor-color = fc531d
-selection-background = c14020
-selection-foreground = ffc88a
+background = #262626
+foreground = #ffcb83
+cursor-color = #fc531d
+selection-background = #c14020
+selection-foreground = #ffc88a

--- a/ghostty/IR_Black
+++ b/ghostty/IR_Black
@@ -14,8 +14,8 @@ palette = 12=#b5dcff
 palette = 13=#fb9cfe
 palette = 14=#e0e0fe
 palette = 15=#ffffff
-background = 000000
-foreground = f1f1f1
-cursor-color = 808080
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #f1f1f1
+cursor-color = #808080
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Jackie Brown
+++ b/ghostty/Jackie Brown
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = 2c1d16
-foreground = ffcc2f
-cursor-color = 23ff18
-selection-background = af8d21
-selection-foreground = ffffff
+background = #2c1d16
+foreground = #ffcc2f
+cursor-color = #23ff18
+selection-background = #af8d21
+selection-foreground = #ffffff

--- a/ghostty/Japanesque
+++ b/ghostty/Japanesque
@@ -14,8 +14,8 @@ palette = 12=#135979
 palette = 13=#604291
 palette = 14=#76bbca
 palette = 15=#b2b5ae
-background = 1e1e1e
-foreground = f7f6ec
-cursor-color = edcf4f
-selection-background = 175877
-selection-foreground = f7f6ec
+background = #1e1e1e
+foreground = #f7f6ec
+cursor-color = #edcf4f
+selection-background = #175877
+selection-foreground = #f7f6ec

--- a/ghostty/Jellybeans
+++ b/ghostty/Jellybeans
@@ -14,8 +14,8 @@ palette = 12=#b1d8f6
 palette = 13=#fbdaff
 palette = 14=#1ab2a8
 palette = 15=#ffffff
-background = 121212
-foreground = dedede
-cursor-color = ffa560
-selection-background = 474e91
-selection-foreground = f4f4f4
+background = #121212
+foreground = #dedede
+cursor-color = #ffa560
+selection-background = #474e91
+selection-foreground = #f4f4f4

--- a/ghostty/JetBrains Darcula
+++ b/ghostty/JetBrains Darcula
@@ -14,8 +14,8 @@ palette = 12=#6d9df1
 palette = 13=#fb82ff
 palette = 14=#60d3d1
 palette = 15=#eeeeee
-background = 202020
-foreground = adadad
-cursor-color = ffffff
-selection-background = 1a3272
-selection-foreground = adadad
+background = #202020
+foreground = #adadad
+cursor-color = #ffffff
+selection-background = #1a3272
+selection-foreground = #adadad

--- a/ghostty/Kanagawa Dragon
+++ b/ghostty/Kanagawa Dragon
@@ -14,8 +14,8 @@ palette = 12=#7fb4ca
 palette = 13=#938aa9
 palette = 14=#7aa89f
 palette = 15=#c5c9c5
-background = 181616
-foreground = c8c093
-cursor-color = c5c9c5
-selection-background = 223249
-selection-foreground = c5c9c5
+background = #181616
+foreground = #c8c093
+cursor-color = #c5c9c5
+selection-background = #223249
+selection-foreground = #c5c9c5

--- a/ghostty/Kanagawa Wave
+++ b/ghostty/Kanagawa Wave
@@ -14,8 +14,8 @@ palette = 12=#7fb4ca
 palette = 13=#938aa9
 palette = 14=#7aa89f
 palette = 15=#dcd7ba
-background = 1f1f28
-foreground = dcd7ba
-cursor-color = c8c093
-selection-background = 2d4f67
-selection-foreground = c8c093
+background = #1f1f28
+foreground = #dcd7ba
+cursor-color = #c8c093
+selection-background = #2d4f67
+selection-foreground = #c8c093

--- a/ghostty/Kibble
+++ b/ghostty/Kibble
@@ -14,8 +14,8 @@ palette = 12=#97a4f7
 palette = 13=#c495f0
 palette = 14=#68f2e0
 palette = 15=#ffffff
-background = 0e100a
-foreground = f7f7f7
-cursor-color = 9fda9c
-selection-background = 9ba787
-selection-foreground = 000000
+background = #0e100a
+foreground = #f7f7f7
+cursor-color = #9fda9c
+selection-background = #9ba787
+selection-foreground = #000000

--- a/ghostty/Kolorit
+++ b/ghostty/Kolorit
@@ -14,8 +14,8 @@ palette = 12=#5db4ee
 palette = 13=#da6cda
 palette = 14=#57e9eb
 palette = 15=#ededed
-background = 1d1a1e
-foreground = efecec
-cursor-color = c7c7c7
-selection-background = e1925c
-selection-foreground = 1d1a1e
+background = #1d1a1e
+foreground = #efecec
+cursor-color = #c7c7c7
+selection-background = #e1925c
+selection-foreground = #1d1a1e

--- a/ghostty/Konsolas
+++ b/ghostty/Konsolas
@@ -14,8 +14,8 @@ palette = 12=#4b4bff
 palette = 13=#ff54ff
 palette = 14=#69ffff
 palette = 15=#ffffff
-background = 060606
-foreground = c8c1c1
-cursor-color = c8c1c1
-selection-background = 060606
-selection-foreground = c8c1c1
+background = #060606
+foreground = #c8c1c1
+cursor-color = #c8c1c1
+selection-background = #060606
+selection-foreground = #c8c1c1

--- a/ghostty/Lab Fox
+++ b/ghostty/Lab Fox
@@ -14,8 +14,8 @@ palette = 12=#db501f
 palette = 13=#441090
 palette = 14=#7d53e7
 palette = 15=#ffffff
-background = 2e2e2e
-foreground = ffffff
-cursor-color = 7f7f7f
-selection-background = cb392e
-selection-foreground = ffffff
+background = #2e2e2e
+foreground = #ffffff
+cursor-color = #7f7f7f
+selection-background = #cb392e
+selection-foreground = #ffffff

--- a/ghostty/Laser
+++ b/ghostty/Laser
@@ -14,8 +14,8 @@ palette = 12=#f92883
 palette = 13=#ffb2fe
 palette = 14=#e6e7fe
 palette = 15=#ffffff
-background = 030d18
-foreground = f106e3
-cursor-color = 00ff9c
-selection-background = 2e206a
-selection-foreground = f4f4f4
+background = #030d18
+foreground = #f106e3
+cursor-color = #00ff9c
+selection-background = #2e206a
+selection-foreground = #f4f4f4

--- a/ghostty/Later This Evening
+++ b/ghostty/Later This Evening
@@ -14,8 +14,8 @@ palette = 12=#6699d6
 palette = 13=#ab53d6
 palette = 14=#5fc0ae
 palette = 15=#c1c2c2
-background = 222222
-foreground = 959595
-cursor-color = 424242
-selection-background = 424242
-selection-foreground = 959595
+background = #222222
+foreground = #959595
+cursor-color = #424242
+selection-background = #424242
+selection-foreground = #959595

--- a/ghostty/Lavandula
+++ b/ghostty/Lavandula
@@ -14,8 +14,8 @@ palette = 12=#8e87e0
 palette = 13=#a776e0
 palette = 14=#9ad4e0
 palette = 15=#8c91fa
-background = 050014
-foreground = 736e7d
-cursor-color = 8c91fa
-selection-background = 37323c
-selection-foreground = 8c91fa
+background = #050014
+foreground = #736e7d
+cursor-color = #8c91fa
+selection-background = #37323c
+selection-foreground = #8c91fa

--- a/ghostty/LiquidCarbon
+++ b/ghostty/LiquidCarbon
@@ -14,8 +14,8 @@ palette = 12=#0099cc
 palette = 13=#cc69c8
 palette = 14=#7ac4cc
 palette = 15=#bccccc
-background = 303030
-foreground = afc2c2
-cursor-color = ffffff
-selection-background = 7dbeff
-selection-foreground = 000000
+background = #303030
+foreground = #afc2c2
+cursor-color = #ffffff
+selection-background = #7dbeff
+selection-foreground = #000000

--- a/ghostty/LiquidCarbonTransparent
+++ b/ghostty/LiquidCarbonTransparent
@@ -14,8 +14,8 @@ palette = 12=#0099cc
 palette = 13=#cc69c8
 palette = 14=#7ac4cc
 palette = 15=#bccccc
-background = 000000
-foreground = afc2c2
-cursor-color = ffffff
-selection-background = 7dbeff
-selection-foreground = 000000
+background = #000000
+foreground = #afc2c2
+cursor-color = #ffffff
+selection-background = #7dbeff
+selection-foreground = #000000

--- a/ghostty/LiquidCarbonTransparentInverse
+++ b/ghostty/LiquidCarbonTransparentInverse
@@ -14,8 +14,8 @@ palette = 12=#0099cc
 palette = 13=#cc69c8
 palette = 14=#7ac4cc
 palette = 15=#000000
-background = 000000
-foreground = afc2c2
-cursor-color = ffffff
-selection-background = 7dbeff
-selection-foreground = 000000
+background = #000000
+foreground = #afc2c2
+cursor-color = #ffffff
+selection-background = #7dbeff
+selection-foreground = #000000

--- a/ghostty/Man Page
+++ b/ghostty/Man Page
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = fef49c
-foreground = 000000
-cursor-color = 7f7f7f
-selection-background = a4c9cd
-selection-foreground = 000000
+background = #fef49c
+foreground = #000000
+cursor-color = #7f7f7f
+selection-background = #a4c9cd
+selection-foreground = #000000

--- a/ghostty/Mariana
+++ b/ghostty/Mariana
@@ -14,8 +14,8 @@ palette = 12=#85add6
 palette = 13=#d8b6d8
 palette = 14=#82c4c4
 palette = 15=#ffffff
-background = 343d46
-foreground = d8dee9
-cursor-color = fcbb6a
-selection-background = 4e5a65
-selection-foreground = d8dee9
+background = #343d46
+foreground = #d8dee9
+cursor-color = #fcbb6a
+selection-background = #4e5a65
+selection-foreground = #d8dee9

--- a/ghostty/Material
+++ b/ghostty/Material
@@ -14,8 +14,8 @@ palette = 12=#54a4f3
 palette = 13=#aa4dbc
 palette = 14=#26bbd1
 palette = 15=#d9d9d9
-background = eaeaea
-foreground = 232322
-cursor-color = 16afca
-selection-background = c2c2c2
-selection-foreground = 4e4e4e
+background = #eaeaea
+foreground = #232322
+cursor-color = #16afca
+selection-background = #c2c2c2
+selection-foreground = #4e4e4e

--- a/ghostty/MaterialDark
+++ b/ghostty/MaterialDark
@@ -14,8 +14,8 @@ palette = 12=#54a4f3
 palette = 13=#aa4dbc
 palette = 14=#26bbd1
 palette = 15=#d9d9d9
-background = 232322
-foreground = e5e5e5
-cursor-color = 16afca
-selection-background = dfdfdf
-selection-foreground = 3d3d3d
+background = #232322
+foreground = #e5e5e5
+cursor-color = #16afca
+selection-background = #dfdfdf
+selection-foreground = #3d3d3d

--- a/ghostty/MaterialDarker
+++ b/ghostty/MaterialDarker
@@ -14,8 +14,8 @@ palette = 12=#82aaff
 palette = 13=#c792ea
 palette = 14=#89ddff
 palette = 15=#ffffff
-background = 212121
-foreground = eeffff
-cursor-color = ffffff
-selection-background = eeffff
-selection-foreground = 545454
+background = #212121
+foreground = #eeffff
+cursor-color = #ffffff
+selection-background = #eeffff
+selection-foreground = #545454

--- a/ghostty/MaterialDesignColors
+++ b/ghostty/MaterialDesignColors
@@ -14,8 +14,8 @@ palette = 12=#70cfff
 palette = 13=#fc669b
 palette = 14=#9affe6
 palette = 15=#ffffff
-background = 1d262a
-foreground = e7ebed
-cursor-color = eaeaea
-selection-background = 4e6a78
-selection-foreground = e7ebed
+background = #1d262a
+foreground = #e7ebed
+cursor-color = #eaeaea
+selection-background = #4e6a78
+selection-foreground = #e7ebed

--- a/ghostty/MaterialOcean
+++ b/ghostty/MaterialOcean
@@ -14,8 +14,8 @@ palette = 12=#82aaff
 palette = 13=#c792ea
 palette = 14=#89ddff
 palette = 15=#ffffff
-background = 0f111a
-foreground = 8f93a2
-cursor-color = ffcc00
-selection-background = 1f2233
-selection-foreground = 8f93a2
+background = #0f111a
+foreground = #8f93a2
+cursor-color = #ffcc00
+selection-background = #1f2233
+selection-foreground = #8f93a2

--- a/ghostty/Mathias
+++ b/ghostty/Mathias
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = 555555
-selection-foreground = f2f2f2
+background = #000000
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #555555
+selection-foreground = #f2f2f2

--- a/ghostty/Medallion
+++ b/ghostty/Medallion
@@ -14,8 +14,8 @@ palette = 12=#acb8ff
 palette = 13=#ffa0ff
 palette = 14=#ffbc51
 palette = 15=#fed698
-background = 1d1908
-foreground = cac296
-cursor-color = d3ba30
-selection-background = 626dac
-selection-foreground = cac29a
+background = #1d1908
+foreground = #cac296
+cursor-color = #d3ba30
+selection-background = #626dac
+selection-foreground = #cac29a

--- a/ghostty/Mellifluous
+++ b/ghostty/Mellifluous
@@ -14,8 +14,8 @@ palette = 12=#5a6599
 palette = 13=#9c6995
 palette = 14=#74a39e
 palette = 15=#ffffff
-background = 1a1a1a
-foreground = dadada
-cursor-color = bfad9e
-selection-background = 2d2d2d
-selection-foreground = c0af8c
+background = #1a1a1a
+foreground = #dadada
+cursor-color = #bfad9e
+selection-background = #2d2d2d
+selection-foreground = #c0af8c

--- a/ghostty/Mirage
+++ b/ghostty/Mirage
@@ -14,8 +14,8 @@ palette = 12=#7fb5ff
 palette = 13=#ddb3ff
 palette = 14=#85cc95
 palette = 15=#ffffff
-background = 1b2738
-foreground = a6b2c0
-cursor-color = ddb3ff
-selection-background = 273951
-selection-foreground = d3dbe5
+background = #1b2738
+foreground = #a6b2c0
+cursor-color = #ddb3ff
+selection-background = #273951
+selection-foreground = #d3dbe5

--- a/ghostty/Misterioso
+++ b/ghostty/Misterioso
@@ -14,8 +14,8 @@ palette = 12=#23d7d7
 palette = 13=#ff37ff
 palette = 14=#00ede1
 palette = 15=#ffffff
-background = 2d3743
-foreground = e1e1e0
-cursor-color = 000000
-selection-background = 2d37ff
-selection-foreground = 000000
+background = #2d3743
+foreground = #e1e1e0
+cursor-color = #000000
+selection-background = #2d37ff
+selection-foreground = #000000

--- a/ghostty/Molokai
+++ b/ghostty/Molokai
@@ -14,8 +14,8 @@ palette = 12=#00afff
 palette = 13=#af87ff
 palette = 14=#51ceff
 palette = 15=#ffffff
-background = 121212
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #121212
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/MonaLisa
+++ b/ghostty/MonaLisa
@@ -14,8 +14,8 @@ palette = 12=#9eb2b4
 palette = 13=#ff5b6a
 palette = 14=#8acd8f
 palette = 15=#ffe598
-background = 120b0d
-foreground = f7d66a
-cursor-color = c46c32
-selection-background = f7d66a
-selection-foreground = 120b0d
+background = #120b0d
+foreground = #f7d66a
+cursor-color = #c46c32
+selection-background = #f7d66a
+selection-foreground = #120b0d

--- a/ghostty/Monokai Remastered
+++ b/ghostty/Monokai Remastered
@@ -14,8 +14,8 @@ palette = 12=#9d65ff
 palette = 13=#f4005f
 palette = 14=#58d1eb
 palette = 15=#f6f6ef
-background = 0c0c0c
-foreground = d9d9d9
-cursor-color = fc971f
-selection-background = 343434
-selection-foreground = ffffff
+background = #0c0c0c
+foreground = #d9d9d9
+cursor-color = #fc971f
+selection-background = #343434
+selection-foreground = #ffffff

--- a/ghostty/Monokai Soda
+++ b/ghostty/Monokai Soda
@@ -14,8 +14,8 @@ palette = 12=#9d65ff
 palette = 13=#f4005f
 palette = 14=#58d1eb
 palette = 15=#f6f6ef
-background = 1a1a1a
-foreground = c4c5b5
-cursor-color = f6f7ec
-selection-background = 343434
-selection-foreground = c4c5b5
+background = #1a1a1a
+foreground = #c4c5b5
+cursor-color = #f6f7ec
+selection-background = #343434
+selection-foreground = #c4c5b5

--- a/ghostty/Monokai Vivid
+++ b/ghostty/Monokai Vivid
@@ -14,8 +14,8 @@ palette = 12=#0443ff
 palette = 13=#f200f6
 palette = 14=#51ceff
 palette = 15=#ffffff
-background = 121212
-foreground = f9f9f9
-cursor-color = fb0007
-selection-background = ffffff
-selection-foreground = 000000
+background = #121212
+foreground = #f9f9f9
+cursor-color = #fb0007
+selection-background = #ffffff
+selection-foreground = #000000

--- a/ghostty/N0tch2k
+++ b/ghostty/N0tch2k
@@ -14,8 +14,8 @@ palette = 12=#98bd5e
 palette = 13=#a3a3a3
 palette = 14=#dcdcdc
 palette = 15=#d8c8bb
-background = 222222
-foreground = a0a0a0
-cursor-color = aa9175
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #222222
+foreground = #a0a0a0
+cursor-color = #aa9175
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Neon
+++ b/ghostty/Neon
@@ -14,8 +14,8 @@ palette = 12=#3c40cb
 palette = 13=#f15be5
 palette = 14=#88fffe
 palette = 15=#ffffff
-background = 14161a
-foreground = 00fffc
-cursor-color = c7c7c7
-selection-background = 0013ff
-selection-foreground = 08d2cf
+background = #14161a
+foreground = #00fffc
+cursor-color = #c7c7c7
+selection-background = #0013ff
+selection-foreground = #08d2cf

--- a/ghostty/Neopolitan
+++ b/ghostty/Neopolitan
@@ -14,8 +14,8 @@ palette = 12=#253b76
 palette = 13=#ff0080
 palette = 14=#8da6ce
 palette = 15=#f8f8f8
-background = 271f19
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 253b76
-selection-foreground = ffffff
+background = #271f19
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #253b76
+selection-foreground = #ffffff

--- a/ghostty/Neutron
+++ b/ghostty/Neutron
@@ -14,8 +14,8 @@ palette = 12=#6a7c93
 palette = 13=#a4799d
 palette = 14=#3f94a8
 palette = 15=#ebedf2
-background = 1c1e22
-foreground = e6e8ef
-cursor-color = f6f7ec
-selection-background = 2f363e
-selection-foreground = 7d8fa4
+background = #1c1e22
+foreground = #e6e8ef
+cursor-color = #f6f7ec
+selection-background = #2f363e
+selection-foreground = #7d8fa4

--- a/ghostty/Night Owlish Light
+++ b/ghostty/Night Owlish Light
@@ -14,8 +14,8 @@ palette = 12=#5ca7e4
 palette = 13=#697098
 palette = 14=#00c990
 palette = 15=#989fb1
-background = ffffff
-foreground = 403f53
-cursor-color = 403f53
-selection-background = f2f2f2
-selection-foreground = 403f53
+background = #ffffff
+foreground = #403f53
+cursor-color = #403f53
+selection-background = #f2f2f2
+selection-foreground = #403f53

--- a/ghostty/NightLion v1
+++ b/ghostty/NightLion v1
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/NightLion v2
+++ b/ghostty/NightLion v2
@@ -14,8 +14,8 @@ palette = 12=#62cbe8
 palette = 13=#ff9bf5
 palette = 14=#00ccd8
 palette = 15=#ffffff
-background = 171717
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #171717
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Nocturnal Winter
+++ b/ghostty/Nocturnal Winter
@@ -14,8 +14,8 @@ palette = 12=#6096ff
 palette = 13=#ff78a2
 palette = 14=#0ae78d
 palette = 15=#ffffff
-background = 0d0d17
-foreground = e6e5e5
-cursor-color = e6e5e5
-selection-background = adbdd0
-selection-foreground = 000000
+background = #0d0d17
+foreground = #e6e5e5
+cursor-color = #e6e5e5
+selection-background = #adbdd0
+selection-foreground = #000000

--- a/ghostty/Novel
+++ b/ghostty/Novel
@@ -14,8 +14,8 @@ palette = 12=#0000cc
 palette = 13=#cc00cc
 palette = 14=#0087cc
 palette = 15=#ffffff
-background = dfdbc3
-foreground = 3b2322
-cursor-color = 73635a
-selection-background = a4a390
-selection-foreground = 000000
+background = #dfdbc3
+foreground = #3b2322
+cursor-color = #73635a
+selection-background = #a4a390
+selection-foreground = #000000

--- a/ghostty/NvimDark
+++ b/ghostty/NvimDark
@@ -14,8 +14,8 @@ palette = 12=#a6dbff
 palette = 13=#ffcaff
 palette = 14=#8cf8f7
 palette = 15=#eef1f8
-background = 14161b
-foreground = e0e2ea
-cursor-color = 9b9ea4
-selection-background = 4f5258
-selection-foreground = e0e2ea
+background = #14161b
+foreground = #e0e2ea
+cursor-color = #9b9ea4
+selection-background = #4f5258
+selection-foreground = #e0e2ea

--- a/ghostty/NvimLight
+++ b/ghostty/NvimLight
@@ -14,8 +14,8 @@ palette = 12=#004c73
 palette = 13=#470045
 palette = 14=#007373
 palette = 15=#eef1f8
-background = e0e2ea
-foreground = 14161b
-cursor-color = 9b9ea4
-selection-background = 9b9ea4
-selection-foreground = 14161b
+background = #e0e2ea
+foreground = #14161b
+cursor-color = #9b9ea4
+selection-background = #9b9ea4
+selection-foreground = #14161b

--- a/ghostty/Obsidian
+++ b/ghostty/Obsidian
@@ -14,8 +14,8 @@ palette = 12=#a1d7ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 283033
-foreground = cdcdcd
-cursor-color = c0cad0
-selection-background = 3e4c4f
-selection-foreground = dfe1e2
+background = #283033
+foreground = #cdcdcd
+cursor-color = #c0cad0
+selection-background = #3e4c4f
+selection-foreground = #dfe1e2

--- a/ghostty/Ocean
+++ b/ghostty/Ocean
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = 224fbc
-foreground = ffffff
-cursor-color = 7f7f7f
-selection-background = 216dff
-selection-foreground = ffffff
+background = #224fbc
+foreground = #ffffff
+cursor-color = #7f7f7f
+selection-background = #216dff
+selection-foreground = #ffffff

--- a/ghostty/Oceanic-Next
+++ b/ghostty/Oceanic-Next
@@ -14,8 +14,8 @@ palette = 12=#7198c8
 palette = 13=#bd96c2
 palette = 14=#74b1b2
 palette = 15=#ffffff
-background = 1b2b34
-foreground = c1c5cd
-cursor-color = c1c5cd
-selection-background = 515b65
-selection-foreground = c1c5cd
+background = #1b2b34
+foreground = #c1c5cd
+cursor-color = #c1c5cd
+selection-background = #515b65
+selection-foreground = #c1c5cd

--- a/ghostty/OceanicMaterial
+++ b/ghostty/OceanicMaterial
@@ -14,8 +14,8 @@ palette = 12=#54a4f3
 palette = 13=#aa4dbc
 palette = 14=#42c7da
 palette = 15=#ffffff
-background = 1c262b
-foreground = c2c8d7
-cursor-color = b3b8c3
-selection-background = 6dc2b8
-selection-foreground = c2c8d7
+background = #1c262b
+foreground = #c2c8d7
+cursor-color = #b3b8c3
+selection-background = #6dc2b8
+selection-foreground = #c2c8d7

--- a/ghostty/Ollie
+++ b/ghostty/Ollie
@@ -14,8 +14,8 @@ palette = 12=#4488ff
 palette = 13=#ffc21d
 palette = 14=#1ffaff
 palette = 15=#5b6ea7
-background = 222125
-foreground = 8a8dae
-cursor-color = 5b6ea7
-selection-background = 1e3a66
-selection-foreground = 8a8eac
+background = #222125
+foreground = #8a8dae
+cursor-color = #5b6ea7
+selection-background = #1e3a66
+selection-foreground = #8a8eac

--- a/ghostty/OneHalfDark
+++ b/ghostty/OneHalfDark
@@ -14,8 +14,8 @@ palette = 12=#61afef
 palette = 13=#c678dd
 palette = 14=#56b6c2
 palette = 15=#dcdfe4
-background = 282c34
-foreground = dcdfe4
-cursor-color = a3b3cc
-selection-background = 474e5d
-selection-foreground = dcdfe4
+background = #282c34
+foreground = #dcdfe4
+cursor-color = #a3b3cc
+selection-background = #474e5d
+selection-foreground = #dcdfe4

--- a/ghostty/OneHalfLight
+++ b/ghostty/OneHalfLight
@@ -14,8 +14,8 @@ palette = 12=#61afef
 palette = 13=#c678dd
 palette = 14=#56b6c2
 palette = 15=#ffffff
-background = fafafa
-foreground = 383a42
-cursor-color = bfceff
-selection-background = bfceff
-selection-foreground = 383a42
+background = #fafafa
+foreground = #383a42
+cursor-color = #bfceff
+selection-background = #bfceff
+selection-foreground = #383a42

--- a/ghostty/Operator Mono Dark
+++ b/ghostty/Operator Mono Dark
@@ -14,8 +14,8 @@ palette = 12=#89d3f6
 palette = 13=#ff2c7a
 palette = 14=#82eada
 palette = 15=#fdfdf6
-background = 191919
-foreground = c3cac2
-cursor-color = fcdc08
-selection-background = 19273b
-selection-foreground = dde5dc
+background = #191919
+foreground = #c3cac2
+cursor-color = #fcdc08
+selection-background = #19273b
+selection-foreground = #dde5dc

--- a/ghostty/Overnight Slumber
+++ b/ghostty/Overnight Slumber
@@ -14,8 +14,8 @@ palette = 12=#8dabe1
 palette = 13=#c792eb
 palette = 14=#ffa7c4
 palette = 15=#ffffff
-background = 0e1729
-foreground = ced2d6
-cursor-color = ffa7c4
-selection-background = 1f2b41
-selection-foreground = ced2d6
+background = #0e1729
+foreground = #ced2d6
+cursor-color = #ffa7c4
+selection-background = #1f2b41
+selection-foreground = #ced2d6

--- a/ghostty/Oxocarbon
+++ b/ghostty/Oxocarbon
@@ -14,8 +14,8 @@ palette = 12=#42be65
 palette = 13=#be95ff
 palette = 14=#ff7eb6
 palette = 15=#f2f4f8
-background = 161616
-foreground = f2f4f8
-cursor-color = ffffff
-selection-background = 393939
-selection-foreground = 161616
+background = #161616
+foreground = #f2f4f8
+cursor-color = #ffffff
+selection-background = #393939
+selection-foreground = #161616

--- a/ghostty/PaleNightHC
+++ b/ghostty/PaleNightHC
@@ -14,8 +14,8 @@ palette = 12=#b4ccff
 palette = 13=#ddbdf2
 palette = 14=#b8eaff
 palette = 15=#999999
-background = 3e4251
-foreground = cccccc
-cursor-color = ffcb6b
-selection-background = 717cb4
-selection-foreground = 80cbc4
+background = #3e4251
+foreground = #cccccc
+cursor-color = #ffcb6b
+selection-background = #717cb4
+selection-foreground = #80cbc4

--- a/ghostty/Pandora
+++ b/ghostty/Pandora
@@ -14,8 +14,8 @@ palette = 12=#23d7d7
 palette = 13=#ff37ff
 palette = 14=#00ede1
 palette = 15=#ffffff
-background = 141e43
-foreground = e1e1e1
-cursor-color = 43d58e
-selection-background = 2d37ff
-selection-foreground = 82e0ff
+background = #141e43
+foreground = #e1e1e1
+cursor-color = #43d58e
+selection-background = #2d37ff
+selection-foreground = #82e0ff

--- a/ghostty/Paraiso Dark
+++ b/ghostty/Paraiso Dark
@@ -14,8 +14,8 @@ palette = 12=#06b6ef
 palette = 13=#815ba4
 palette = 14=#5bc4bf
 palette = 15=#e7e9db
-background = 2f1e2e
-foreground = a39e9b
-cursor-color = a39e9b
-selection-background = 4f424c
-selection-foreground = a39e9b
+background = #2f1e2e
+foreground = #a39e9b
+cursor-color = #a39e9b
+selection-background = #4f424c
+selection-foreground = #a39e9b

--- a/ghostty/PaulMillr
+++ b/ghostty/PaulMillr
@@ -14,8 +14,8 @@ palette = 12=#709aed
 palette = 13=#db67e6
 palette = 14=#7adff2
 palette = 15=#ffffff
-background = 000000
-foreground = f2f2f2
-cursor-color = 4d4d4d
-selection-background = 414141
-selection-foreground = ffffff
+background = #000000
+foreground = #f2f2f2
+cursor-color = #4d4d4d
+selection-background = #414141
+selection-foreground = #ffffff

--- a/ghostty/PencilDark
+++ b/ghostty/PencilDark
@@ -14,8 +14,8 @@ palette = 12=#20bbfc
 palette = 13=#6855de
 palette = 14=#4fb8cc
 palette = 15=#f1f1f1
-background = 212121
-foreground = f1f1f1
-cursor-color = 20bbfc
-selection-background = b6d6fd
-selection-foreground = f1f1f1
+background = #212121
+foreground = #f1f1f1
+cursor-color = #20bbfc
+selection-background = #b6d6fd
+selection-foreground = #f1f1f1

--- a/ghostty/PencilLight
+++ b/ghostty/PencilLight
@@ -14,8 +14,8 @@ palette = 12=#20bbfc
 palette = 13=#6855de
 palette = 14=#4fb8cc
 palette = 15=#f1f1f1
-background = f1f1f1
-foreground = 424242
-cursor-color = 20bbfc
-selection-background = b6d6fd
-selection-foreground = 424242
+background = #f1f1f1
+foreground = #424242
+cursor-color = #20bbfc
+selection-background = #b6d6fd
+selection-foreground = #424242

--- a/ghostty/Peppermint
+++ b/ghostty/Peppermint
@@ -14,8 +14,8 @@ palette = 12=#6fbce2
 palette = 13=#e586e7
 palette = 14=#96dcdb
 palette = 15=#dfdfdf
-background = 000000
-foreground = c8c8c8
-cursor-color = bbbbbb
-selection-background = e6e6e6
-selection-foreground = 000000
+background = #000000
+foreground = #c8c8c8
+cursor-color = #bbbbbb
+selection-background = #e6e6e6
+selection-foreground = #000000

--- a/ghostty/Piatto Light
+++ b/ghostty/Piatto Light
@@ -14,8 +14,8 @@ palette = 12=#3c5ea8
 palette = 13=#a454b2
 palette = 14=#829429
 palette = 15=#f2f2f2
-background = ffffff
-foreground = 414141
-cursor-color = 5e77c8
-selection-background = 706b4e
-selection-foreground = acbcdc
+background = #ffffff
+foreground = #414141
+cursor-color = #5e77c8
+selection-background = #706b4e
+selection-foreground = #acbcdc

--- a/ghostty/Pnevma
+++ b/ghostty/Pnevma
@@ -14,8 +14,8 @@ palette = 12=#a1bdce
 palette = 13=#d7beda
 palette = 14=#b1e7dd
 palette = 15=#efefef
-background = 1c1c1c
-foreground = d0d0d0
-cursor-color = e4c9af
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #1c1c1c
+foreground = #d0d0d0
+cursor-color = #e4c9af
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Popping and Locking
+++ b/ghostty/Popping and Locking
@@ -14,8 +14,8 @@ palette = 12=#99c6ca
 palette = 13=#d3869b
 palette = 14=#7ec16e
 palette = 15=#ebdbb2
-background = 181921
-foreground = ebdbb2
-cursor-color = c7c7c7
-selection-background = ebdbb2
-selection-foreground = 928374
+background = #181921
+foreground = #ebdbb2
+cursor-color = #c7c7c7
+selection-background = #ebdbb2
+selection-foreground = #928374

--- a/ghostty/Pro
+++ b/ghostty/Pro
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = 000000
-foreground = f2f2f2
-cursor-color = 4d4d4d
-selection-background = 414141
-selection-foreground = 000000
+background = #000000
+foreground = #f2f2f2
+cursor-color = #4d4d4d
+selection-background = #414141
+selection-foreground = #000000

--- a/ghostty/Pro Light
+++ b/ghostty/Pro Light
@@ -14,8 +14,8 @@ palette = 12=#0082ff
 palette = 13=#ff7eff
 palette = 14=#61f7f8
 palette = 15=#f2f2f2
-background = ffffff
-foreground = 191919
-cursor-color = 4d4d4d
-selection-background = c1ddff
-selection-foreground = 191919
+background = #ffffff
+foreground = #191919
+cursor-color = #4d4d4d
+selection-background = #c1ddff
+selection-foreground = #191919

--- a/ghostty/Purple Rain
+++ b/ghostty/Purple Rain
@@ -14,8 +14,8 @@ palette = 12=#00a6ff
 palette = 13=#ac7bf0
 palette = 14=#74fdf3
 palette = 15=#ffffff
-background = 21084a
-foreground = fffbf6
-cursor-color = ff271d
-selection-background = 287691
-selection-foreground = ffffff
+background = #21084a
+foreground = #fffbf6
+cursor-color = #ff271d
+selection-background = #287691
+selection-foreground = #ffffff

--- a/ghostty/Rapture
+++ b/ghostty/Rapture
@@ -14,8 +14,8 @@ palette = 12=#6c9bf5
 palette = 13=#ff4fa1
 palette = 14=#64e0ff
 palette = 15=#ffffff
-background = 111e2a
-foreground = c0c9e5
-cursor-color = ffffff
-selection-background = 304b66
-selection-foreground = ffffff
+background = #111e2a
+foreground = #c0c9e5
+cursor-color = #ffffff
+selection-background = #304b66
+selection-foreground = #ffffff

--- a/ghostty/Raycast_Dark
+++ b/ghostty/Raycast_Dark
@@ -14,8 +14,8 @@ palette = 12=#56c2ff
 palette = 13=#cf2f98
 palette = 14=#52eee5
 palette = 15=#ffffff
-background = 1a1a1a
-foreground = ffffff
-cursor-color = cccccc
-selection-background = 333333
-selection-foreground = 000000
+background = #1a1a1a
+foreground = #ffffff
+cursor-color = #cccccc
+selection-background = #333333
+selection-foreground = #000000

--- a/ghostty/Raycast_Light
+++ b/ghostty/Raycast_Light
@@ -14,8 +14,8 @@ palette = 12=#138af2
 palette = 13=#9a1b6e
 palette = 14=#3eb8bf
 palette = 15=#ffffff
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = e5e5e5
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #e5e5e5
+selection-foreground = #000000

--- a/ghostty/Red Alert
+++ b/ghostty/Red Alert
@@ -14,8 +14,8 @@ palette = 12=#65aaf1
 palette = 13=#ddb7df
 palette = 14=#b7dfdd
 palette = 15=#ffffff
-background = 762423
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 073642
-selection-foreground = ffffff
+background = #762423
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #073642
+selection-foreground = #ffffff

--- a/ghostty/Red Planet
+++ b/ghostty/Red Planet
@@ -14,8 +14,8 @@ palette = 12=#60827e
 palette = 13=#de4974
 palette = 14=#38add8
 palette = 15=#d6bfb8
-background = 222222
-foreground = c2b790
-cursor-color = c2b790
-selection-background = 1b324a
-selection-foreground = bcb291
+background = #222222
+foreground = #c2b790
+cursor-color = #c2b790
+selection-background = #1b324a
+selection-foreground = #bcb291

--- a/ghostty/Red Sands
+++ b/ghostty/Red Sands
@@ -14,8 +14,8 @@ palette = 12=#0072ae
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 7a251e
-foreground = d7c9a7
-cursor-color = ffffff
-selection-background = a4a390
-selection-foreground = 000000
+background = #7a251e
+foreground = #d7c9a7
+cursor-color = #ffffff
+selection-background = #a4a390
+selection-foreground = #000000

--- a/ghostty/Relaxed
+++ b/ghostty/Relaxed
@@ -14,8 +14,8 @@ palette = 12=#7eaac7
 palette = 13=#b06698
 palette = 14=#acbbd0
 palette = 15=#f7f7f7
-background = 353a44
-foreground = d9d9d9
-cursor-color = d9d9d9
-selection-background = 6a7985
-selection-foreground = d9d9d9
+background = #353a44
+foreground = #d9d9d9
+cursor-color = #d9d9d9
+selection-background = #6a7985
+selection-foreground = #d9d9d9

--- a/ghostty/Retro
+++ b/ghostty/Retro
@@ -14,8 +14,8 @@ palette = 12=#16ba10
 palette = 13=#16ba10
 palette = 14=#16ba10
 palette = 15=#16ba10
-background = 000000
-foreground = 13a10e
-cursor-color = 13a10e
-selection-background = ffffff
-selection-foreground = 000000
+background = #000000
+foreground = #13a10e
+cursor-color = #13a10e
+selection-background = #ffffff
+selection-foreground = #000000

--- a/ghostty/RetroLegends
+++ b/ghostty/RetroLegends
@@ -14,8 +14,8 @@ palette = 12=#4c80ff
 palette = 13=#e666ff
 palette = 14=#59e6ff
 palette = 15=#f2fff2
-background = 0d0d0d
-foreground = 45eb45
-cursor-color = 45eb45
-selection-background = 336633
-selection-foreground = f2fff2
+background = #0d0d0d
+foreground = #45eb45
+cursor-color = #45eb45
+selection-background = #336633
+selection-foreground = #f2fff2

--- a/ghostty/Rippedcasts
+++ b/ghostty/Rippedcasts
@@ -14,8 +14,8 @@ palette = 12=#86bdc9
 palette = 13=#e500e5
 palette = 14=#8c9bc4
 palette = 15=#e5e5e5
-background = 2b2b2b
-foreground = ffffff
-cursor-color = 7f7f7f
-selection-background = 5a647e
-selection-foreground = f2f2f2
+background = #2b2b2b
+foreground = #ffffff
+cursor-color = #7f7f7f
+selection-background = #5a647e
+selection-foreground = #f2f2f2

--- a/ghostty/Rouge 2
+++ b/ghostty/Rouge 2
@@ -14,8 +14,8 @@ palette = 12=#98b3cd
 palette = 13=#8283a1
 palette = 14=#abcbd3
 palette = 15=#e8e8ea
-background = 17182b
-foreground = a2a3aa
-cursor-color = 969e92
-selection-background = 5d5d6b
-selection-foreground = dfe5ee
+background = #17182b
+foreground = #a2a3aa
+cursor-color = #969e92
+selection-background = #5d5d6b
+selection-foreground = #dfe5ee

--- a/ghostty/Royal
+++ b/ghostty/Royal
@@ -14,8 +14,8 @@ palette = 12=#90baf9
 palette = 13=#a479e3
 palette = 14=#acd4eb
 palette = 15=#9e8cbd
-background = 100815
-foreground = 514968
-cursor-color = 524966
-selection-background = 1f1d2b
-selection-foreground = a593cd
+background = #100815
+foreground = #514968
+cursor-color = #524966
+selection-background = #1f1d2b
+selection-foreground = #a593cd

--- a/ghostty/Ryuuko
+++ b/ghostty/Ryuuko
@@ -14,8 +14,8 @@ palette = 12=#6a8e95
 palette = 13=#b18a73
 palette = 14=#88b2ac
 palette = 15=#ececec
-background = 2c3941
-foreground = ececec
-cursor-color = ececec
-selection-background = 002831
-selection-foreground = 819090
+background = #2c3941
+foreground = #ececec
+cursor-color = #ececec
+selection-background = #002831
+selection-foreground = #819090

--- a/ghostty/Sakura
+++ b/ghostty/Sakura
@@ -14,8 +14,8 @@ palette = 12=#9892f1
 palette = 13=#e90cdd
 palette = 14=#eeeeee
 palette = 15=#cbb6ff
-background = 18131e
-foreground = dd7bdc
-cursor-color = ff65fd
-selection-background = c05cbf
-selection-foreground = 24242e
+background = #18131e
+foreground = #dd7bdc
+cursor-color = #ff65fd
+selection-background = #c05cbf
+selection-foreground = #24242e

--- a/ghostty/Scarlet Protocol
+++ b/ghostty/Scarlet Protocol
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#bd35ec
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 1c153d
-foreground = e41951
-cursor-color = 76ff9f
-selection-background = c1deff
-selection-foreground = 000000
+background = #1c153d
+foreground = #e41951
+cursor-color = #76ff9f
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/SeaShells
+++ b/ghostty/SeaShells
@@ -14,8 +14,8 @@ palette = 12=#1bbcdd
 palette = 13=#bbe3ee
 palette = 14=#87acb4
 palette = 15=#fee4ce
-background = 09141b
-foreground = deb88d
-cursor-color = fca02f
-selection-background = 1e4962
-selection-foreground = fee4ce
+background = #09141b
+foreground = #deb88d
+cursor-color = #fca02f
+selection-background = #1e4962
+selection-foreground = #fee4ce

--- a/ghostty/Seafoam Pastel
+++ b/ghostty/Seafoam Pastel
@@ -14,8 +14,8 @@ palette = 12=#7ac3cf
 palette = 13=#d6b2a1
 palette = 14=#ade0e0
 palette = 15=#e0e0e0
-background = 243435
-foreground = d4e7d4
-cursor-color = 57647a
-selection-background = ffffff
-selection-foreground = 9e8b13
+background = #243435
+foreground = #d4e7d4
+cursor-color = #57647a
+selection-background = #ffffff
+selection-foreground = #9e8b13

--- a/ghostty/Seti
+++ b/ghostty/Seti
@@ -14,8 +14,8 @@ palette = 12=#43a5d5
 palette = 13=#8b57b5
 palette = 14=#8ec43d
 palette = 15=#ffffff
-background = 111213
-foreground = cacecd
-cursor-color = e3bf21
-selection-background = 303233
-selection-foreground = cacecd
+background = #111213
+foreground = #cacecd
+cursor-color = #e3bf21
+selection-background = #303233
+selection-foreground = #cacecd

--- a/ghostty/Shaman
+++ b/ghostty/Shaman
@@ -14,8 +14,8 @@ palette = 12=#61d5ba
 palette = 13=#1298ff
 palette = 14=#98d028
 palette = 15=#58fbd6
-background = 001015
-foreground = 405555
-cursor-color = 4afcd6
-selection-background = 415555
-selection-foreground = 5afad6
+background = #001015
+foreground = #405555
+cursor-color = #4afcd6
+selection-background = #415555
+selection-foreground = #5afad6

--- a/ghostty/Slate
+++ b/ghostty/Slate
@@ -14,8 +14,8 @@ palette = 12=#7ab0d2
 palette = 13=#c5a7d9
 palette = 14=#8cdfe0
 palette = 15=#e0e0e0
-background = 222222
-foreground = 35b1d2
-cursor-color = 87d3c4
-selection-background = 0f3754
-selection-foreground = 2dffc0
+background = #222222
+foreground = #35b1d2
+cursor-color = #87d3c4
+selection-background = #0f3754
+selection-foreground = #2dffc0

--- a/ghostty/SleepyHollow
+++ b/ghostty/SleepyHollow
@@ -14,8 +14,8 @@ palette = 12=#8086ef
 palette = 13=#e2c2bb
 palette = 14=#a4dce7
 palette = 15=#d2c7a9
-background = 121214
-foreground = af9a91
-cursor-color = af9a91
-selection-background = 575256
-selection-foreground = d2c7a9
+background = #121214
+foreground = #af9a91
+cursor-color = #af9a91
+selection-background = #575256
+selection-foreground = #d2c7a9

--- a/ghostty/Smyck
+++ b/ghostty/Smyck
@@ -14,8 +14,8 @@ palette = 12=#8dcff0
 palette = 13=#f79aff
 palette = 14=#6ad9cf
 palette = 15=#f7f7f7
-background = 1b1b1b
-foreground = f7f7f7
-cursor-color = bbbbbb
-selection-background = 207483
-selection-foreground = f7f7f7
+background = #1b1b1b
+foreground = #f7f7f7
+cursor-color = #bbbbbb
+selection-background = #207483
+selection-foreground = #f7f7f7

--- a/ghostty/Snazzy
+++ b/ghostty/Snazzy
@@ -14,8 +14,8 @@ palette = 12=#49baff
 palette = 13=#fc4cb4
 palette = 14=#8be9fe
 palette = 15=#ededec
-background = 1e1f29
-foreground = ebece6
-cursor-color = e4e4e4
-selection-background = 81aec6
-selection-foreground = 000000
+background = #1e1f29
+foreground = #ebece6
+cursor-color = #e4e4e4
+selection-background = #81aec6
+selection-foreground = #000000

--- a/ghostty/SoftServer
+++ b/ghostty/SoftServer
@@ -14,8 +14,8 @@ palette = 12=#62b1df
 palette = 13=#606edf
 palette = 14=#64e39c
 palette = 15=#d2e0de
-background = 242626
-foreground = 99a3a2
-cursor-color = d2e0de
-selection-background = 7f8786
-selection-foreground = effffe
+background = #242626
+foreground = #99a3a2
+cursor-color = #d2e0de
+selection-background = #7f8786
+selection-foreground = #effffe

--- a/ghostty/Solarized Darcula
+++ b/ghostty/Solarized Darcula
@@ -14,8 +14,8 @@ palette = 12=#2075c7
 palette = 13=#797fd4
 palette = 14=#15968d
 palette = 15=#d2d8d9
-background = 3d3f41
-foreground = d2d8d9
-cursor-color = 708284
-selection-background = 214283
-selection-foreground = d2d8d9
+background = #3d3f41
+foreground = #d2d8d9
+cursor-color = #708284
+selection-background = #214283
+selection-foreground = #d2d8d9

--- a/ghostty/Solarized Dark - Patched
+++ b/ghostty/Solarized Dark - Patched
@@ -14,8 +14,8 @@ palette = 12=#708284
 palette = 13=#5956ba
 palette = 14=#819090
 palette = 15=#fcf4dc
-background = 001e27
-foreground = 708284
-cursor-color = 708284
-selection-background = 002831
-selection-foreground = 819090
+background = #001e27
+foreground = #708284
+cursor-color = #708284
+selection-background = #002831
+selection-foreground = #819090

--- a/ghostty/Solarized Dark Higher Contrast
+++ b/ghostty/Solarized Dark Higher Contrast
@@ -14,8 +14,8 @@ palette = 12=#178ec8
 palette = 13=#e24d8e
 palette = 14=#00b39e
 palette = 15=#fcf4dc
-background = 001e27
-foreground = 9cc2c3
-cursor-color = f34b00
-selection-background = 003748
-selection-foreground = 7a8f8e
+background = #001e27
+foreground = #9cc2c3
+cursor-color = #f34b00
+selection-background = #003748
+selection-foreground = #7a8f8e

--- a/ghostty/SpaceGray
+++ b/ghostty/SpaceGray
@@ -14,8 +14,8 @@ palette = 12=#7d8fa4
 palette = 13=#a47996
 palette = 14=#85a7a5
 palette = 15=#ffffff
-background = 20242d
-foreground = b3b8c3
-cursor-color = b3b8c3
-selection-background = 16181e
-selection-foreground = b3b8c3
+background = #20242d
+foreground = #b3b8c3
+cursor-color = #b3b8c3
+selection-background = #16181e
+selection-foreground = #b3b8c3

--- a/ghostty/SpaceGray Bright
+++ b/ghostty/SpaceGray Bright
@@ -14,8 +14,8 @@ palette = 12=#7baec1
 palette = 13=#b98aae
 palette = 14=#85c9b8
 palette = 15=#f7f7f7
-background = 2a2e3a
-foreground = f3f3f3
-cursor-color = c6c6c6
-selection-background = cacaca
-selection-foreground = 000000
+background = #2a2e3a
+foreground = #f3f3f3
+cursor-color = #c6c6c6
+selection-background = #cacaca
+selection-foreground = #000000

--- a/ghostty/SpaceGray Eighties
+++ b/ghostty/SpaceGray Eighties
@@ -14,8 +14,8 @@ palette = 12=#4d84d1
 palette = 13=#ff55ff
 palette = 14=#83e9e4
 palette = 15=#ffffff
-background = 222222
-foreground = bdbaae
-cursor-color = bbbbbb
-selection-background = 272e35
-selection-foreground = ffffff
+background = #222222
+foreground = #bdbaae
+cursor-color = #bbbbbb
+selection-background = #272e35
+selection-foreground = #ffffff

--- a/ghostty/SpaceGray Eighties Dull
+++ b/ghostty/SpaceGray Eighties Dull
@@ -14,8 +14,8 @@ palette = 12=#5486c0
 palette = 13=#bf83c1
 palette = 14=#58c2c1
 palette = 15=#ffffff
-background = 222222
-foreground = c9c6bc
-cursor-color = bbbbbb
-selection-background = 272e36
-selection-foreground = ffffff
+background = #222222
+foreground = #c9c6bc
+cursor-color = #bbbbbb
+selection-background = #272e36
+selection-foreground = #ffffff

--- a/ghostty/Spacedust
+++ b/ghostty/Spacedust
@@ -14,8 +14,8 @@ palette = 12=#67a0ce
 palette = 13=#ff8a3a
 palette = 14=#83a7b4
 palette = 15=#fefff1
-background = 0a1e24
-foreground = ecf0c1
-cursor-color = 708284
-selection-background = 0a385c
-selection-foreground = ffffff
+background = #0a1e24
+foreground = #ecf0c1
+cursor-color = #708284
+selection-background = #0a385c
+selection-foreground = #ffffff

--- a/ghostty/Spiderman
+++ b/ghostty/Spiderman
@@ -14,8 +14,8 @@ palette = 12=#1d50ff
 palette = 13=#747cff
 palette = 14=#6184ff
 palette = 15=#fffff9
-background = 1b1d1e
-foreground = e3e3e3
-cursor-color = 2c3fff
-selection-background = 070e50
-selection-foreground = f0272d
+background = #1b1d1e
+foreground = #e3e3e3
+cursor-color = #2c3fff
+selection-background = #070e50
+selection-foreground = #f0272d

--- a/ghostty/Spring
+++ b/ghostty/Spring
@@ -14,8 +14,8 @@ palette = 12=#15a9fd
 palette = 13=#8959a8
 palette = 14=#3e999f
 palette = 15=#ffffff
-background = ffffff
-foreground = 4d4d4c
-cursor-color = 4d4d4c
-selection-background = d6d6d6
-selection-foreground = 4d4d4c
+background = #ffffff
+foreground = #4d4d4c
+cursor-color = #4d4d4c
+selection-background = #d6d6d6
+selection-foreground = #4d4d4c

--- a/ghostty/Square
+++ b/ghostty/Square
@@ -14,8 +14,8 @@ palette = 12=#b6defb
 palette = 13=#ad7fa8
 palette = 14=#d7d9fc
 palette = 15=#e2e2e2
-background = 1a1a1a
-foreground = acacab
-cursor-color = fcfbcc
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #1a1a1a
+foreground = #acacab
+cursor-color = #fcfbcc
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Sublette
+++ b/ghostty/Sublette
@@ -14,8 +14,8 @@ palette = 12=#77bbff
 palette = 13=#aa88ff
 palette = 14=#55ffbb
 palette = 15=#ffffee
-background = 202535
-foreground = ccced0
-cursor-color = ccced0
-selection-background = ccced0
-selection-foreground = 202535
+background = #202535
+foreground = #ccced0
+cursor-color = #ccced0
+selection-background = #ccced0
+selection-foreground = #202535

--- a/ghostty/Subliminal
+++ b/ghostty/Subliminal
@@ -14,8 +14,8 @@ palette = 12=#6699cc
 palette = 13=#f1a5ab
 palette = 14=#5fb3b3
 palette = 15=#d4d4d4
-background = 282c35
-foreground = d4d4d4
-cursor-color = c7c7c7
-selection-background = 484e5b
-selection-foreground = ffffff
+background = #282c35
+foreground = #d4d4d4
+cursor-color = #c7c7c7
+selection-background = #484e5b
+selection-foreground = #ffffff

--- a/ghostty/Sugarplum
+++ b/ghostty/Sugarplum
@@ -14,8 +14,8 @@ palette = 12=#fa5dfd
 palette = 13=#c6a5fd
 palette = 14=#ffffff
 palette = 15=#b577fd
-background = 111147
-foreground = db7ddd
-cursor-color = 53b397
-selection-background = 5ca8dc
-selection-foreground = d0beee
+background = #111147
+foreground = #db7ddd
+cursor-color = #53b397
+selection-background = #5ca8dc
+selection-foreground = #d0beee

--- a/ghostty/Sundried
+++ b/ghostty/Sundried
@@ -14,8 +14,8 @@ palette = 12=#7999f7
 palette = 13=#fd8aa1
 palette = 14=#fad484
 palette = 15=#ffffff
-background = 1a1818
-foreground = c9c9c9
-cursor-color = ffffff
-selection-background = 302b2a
-selection-foreground = c9c9c9
+background = #1a1818
+foreground = #c9c9c9
+cursor-color = #ffffff
+selection-background = #302b2a
+selection-foreground = #c9c9c9

--- a/ghostty/Symfonic
+++ b/ghostty/Symfonic
@@ -14,8 +14,8 @@ palette = 12=#0084d4
 palette = 13=#b729d9
 palette = 14=#ccccff
 palette = 15=#ffffff
-background = 000000
-foreground = ffffff
-cursor-color = dc322f
-selection-background = 073642
-selection-foreground = ffffff
+background = #000000
+foreground = #ffffff
+cursor-color = #dc322f
+selection-background = #073642
+selection-foreground = #ffffff

--- a/ghostty/SynthwaveAlpha
+++ b/ghostty/SynthwaveAlpha
@@ -14,8 +14,8 @@ palette = 12=#aa54f9
 palette = 13=#ff00f6
 palette = 14=#00fbfd
 palette = 15=#f2f2e3
-background = 241b30
-foreground = f2f2e3
-cursor-color = f2f2e3
-selection-background = 6e29ad
-selection-foreground = f2f2e3
+background = #241b30
+foreground = #f2f2e3
+cursor-color = #f2f2e3
+selection-background = #6e29ad
+selection-foreground = #f2f2e3

--- a/ghostty/Tango Adapted
+++ b/ghostty/Tango Adapted
@@ -14,8 +14,8 @@ palette = 12=#88c9ff
 palette = 13=#e9a7e1
 palette = 14=#00feff
 palette = 15=#f6f6f4
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = c1deff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/Tango Half Adapted
+++ b/ghostty/Tango Half Adapted
@@ -14,8 +14,8 @@ palette = 12=#76bfff
 palette = 13=#d898d1
 palette = 14=#00f6fa
 palette = 15=#f4f4f2
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = c1deff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/Teerb
+++ b/ghostty/Teerb
@@ -14,8 +14,8 @@ palette = 12=#86aed6
 palette = 13=#d6aed6
 palette = 14=#b1e7dd
 palette = 15=#efefef
-background = 262626
-foreground = d0d0d0
-cursor-color = e4c9af
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #262626
+foreground = #d0d0d0
+cursor-color = #e4c9af
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Terminal Basic
+++ b/ghostty/Terminal Basic
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#e500e5
 palette = 14=#00e5e5
 palette = 15=#e5e5e5
-background = ffffff
-foreground = 000000
-cursor-color = 7f7f7f
-selection-background = a4c9ff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #7f7f7f
+selection-background = #a4c9ff
+selection-foreground = #000000

--- a/ghostty/Thayer Bright
+++ b/ghostty/Thayer Bright
@@ -14,8 +14,8 @@ palette = 12=#3f78ff
 palette = 13=#9e6ffe
 palette = 14=#23cfd5
 palette = 15=#f8f8f2
-background = 1b1d1e
-foreground = f8f8f8
-cursor-color = fc971f
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #1b1d1e
+foreground = #f8f8f8
+cursor-color = #fc971f
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/The Hulk
+++ b/ghostty/The Hulk
@@ -14,8 +14,8 @@ palette = 12=#506b95
 palette = 13=#72589d
 palette = 14=#4085a6
 palette = 15=#e5e6e1
-background = 1b1d1e
-foreground = b5b5b5
-cursor-color = 16b61b
-selection-background = 4d504c
-selection-foreground = 0b6309
+background = #1b1d1e
+foreground = #b5b5b5
+cursor-color = #16b61b
+selection-background = #4d504c
+selection-foreground = #0b6309

--- a/ghostty/Tinacious Design (Dark)
+++ b/ghostty/Tinacious Design (Dark)
@@ -14,8 +14,8 @@ palette = 12=#00cbff
 palette = 13=#d783ff
 palette = 14=#00d5d4
 palette = 15=#d5d6f3
-background = 1d1d26
-foreground = cbcbf0
-cursor-color = cbcbf0
-selection-background = ff3399
-selection-foreground = ffffff
+background = #1d1d26
+foreground = #cbcbf0
+cursor-color = #cbcbf0
+selection-background = #ff3399
+selection-foreground = #ffffff

--- a/ghostty/Tinacious Design (Light)
+++ b/ghostty/Tinacious Design (Light)
@@ -14,8 +14,8 @@ palette = 12=#00cbff
 palette = 13=#d783ff
 palette = 14=#00d5d4
 palette = 15=#d5d6f3
-background = f8f8ff
-foreground = 1d1d26
-cursor-color = cbcbf0
-selection-background = ff3399
-selection-foreground = ffffff
+background = #f8f8ff
+foreground = #1d1d26
+cursor-color = #cbcbf0
+selection-background = #ff3399
+selection-foreground = #ffffff

--- a/ghostty/Tomorrow
+++ b/ghostty/Tomorrow
@@ -14,8 +14,8 @@ palette = 12=#4271ae
 palette = 13=#8959a8
 palette = 14=#3e999f
 palette = 15=#ffffff
-background = ffffff
-foreground = 4d4d4c
-cursor-color = 4d4d4c
-selection-background = d6d6d6
-selection-foreground = 4d4d4c
+background = #ffffff
+foreground = #4d4d4c
+cursor-color = #4d4d4c
+selection-background = #d6d6d6
+selection-foreground = #4d4d4c

--- a/ghostty/Tomorrow Night
+++ b/ghostty/Tomorrow Night
@@ -14,8 +14,8 @@ palette = 12=#81a2be
 palette = 13=#b294bb
 palette = 14=#8abeb7
 palette = 15=#ffffff
-background = 1d1f21
-foreground = c5c8c6
-cursor-color = c5c8c6
-selection-background = 373b41
-selection-foreground = c5c8c6
+background = #1d1f21
+foreground = #c5c8c6
+cursor-color = #c5c8c6
+selection-background = #373b41
+selection-foreground = #c5c8c6

--- a/ghostty/Tomorrow Night Blue
+++ b/ghostty/Tomorrow Night Blue
@@ -14,8 +14,8 @@ palette = 12=#bbdaff
 palette = 13=#ebbbff
 palette = 14=#99ffff
 palette = 15=#ffffff
-background = 002451
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 003f8e
-selection-foreground = ffffff
+background = #002451
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #003f8e
+selection-foreground = #ffffff

--- a/ghostty/Tomorrow Night Bright
+++ b/ghostty/Tomorrow Night Bright
@@ -14,8 +14,8 @@ palette = 12=#7aa6da
 palette = 13=#c397d8
 palette = 14=#70c0b1
 palette = 15=#ffffff
-background = 000000
-foreground = eaeaea
-cursor-color = eaeaea
-selection-background = 424242
-selection-foreground = eaeaea
+background = #000000
+foreground = #eaeaea
+cursor-color = #eaeaea
+selection-background = #424242
+selection-foreground = #eaeaea

--- a/ghostty/Tomorrow Night Burns
+++ b/ghostty/Tomorrow Night Burns
@@ -14,8 +14,8 @@ palette = 12=#fc595f
 palette = 13=#df9395
 palette = 14=#ba8586
 palette = 15=#f5f5f5
-background = 151515
-foreground = a1b0b8
-cursor-color = ff443e
-selection-background = b0bec5
-selection-foreground = 2a2d32
+background = #151515
+foreground = #a1b0b8
+cursor-color = #ff443e
+selection-background = #b0bec5
+selection-foreground = #2a2d32

--- a/ghostty/Tomorrow Night Eighties
+++ b/ghostty/Tomorrow Night Eighties
@@ -14,8 +14,8 @@ palette = 12=#6699cc
 palette = 13=#cc99cc
 palette = 14=#66cccc
 palette = 15=#ffffff
-background = 2d2d2d
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 515151
-selection-foreground = cccccc
+background = #2d2d2d
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #515151
+selection-foreground = #cccccc

--- a/ghostty/ToyChest
+++ b/ghostty/ToyChest
@@ -14,8 +14,8 @@ palette = 12=#34a6da
 palette = 13=#ae6bdc
 palette = 14=#42c3ae
 palette = 15=#d5d5d5
-background = 24364b
-foreground = 31d07b
-cursor-color = d5d5d5
-selection-background = 5f217a
-selection-foreground = d5d5d5
+background = #24364b
+foreground = #31d07b
+cursor-color = #d5d5d5
+selection-background = #5f217a
+selection-foreground = #d5d5d5

--- a/ghostty/Treehouse
+++ b/ghostty/Treehouse
@@ -14,8 +14,8 @@ palette = 12=#85cfed
 palette = 13=#e14c5a
 palette = 14=#f07d14
 palette = 15=#ffc800
-background = 191919
-foreground = 786b53
-cursor-color = fac814
-selection-background = 786b53
-selection-foreground = fac800
+background = #191919
+foreground = #786b53
+cursor-color = #fac814
+selection-background = #786b53
+selection-foreground = #fac800

--- a/ghostty/Twilight
+++ b/ghostty/Twilight
@@ -14,8 +14,8 @@ palette = 12=#5a5e62
 palette = 13=#d0dc8e
 palette = 14=#8a989b
 palette = 15=#ffffd4
-background = 141414
-foreground = ffffd4
-cursor-color = ffffff
-selection-background = 313131
-selection-foreground = ffffd4
+background = #141414
+foreground = #ffffd4
+cursor-color = #ffffff
+selection-background = #313131
+selection-foreground = #ffffd4

--- a/ghostty/Ubuntu
+++ b/ghostty/Ubuntu
@@ -14,8 +14,8 @@ palette = 12=#729fcf
 palette = 13=#ad7fa8
 palette = 14=#34e2e2
 palette = 15=#eeeeec
-background = 300a24
-foreground = eeeeec
-cursor-color = bbbbbb
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #300a24
+foreground = #eeeeec
+cursor-color = #bbbbbb
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/UltraDark
+++ b/ghostty/UltraDark
@@ -14,8 +14,8 @@ palette = 12=#b4ccff
 palette = 13=#ddbdf2
 palette = 14=#b8eaff
 palette = 15=#ffffff
-background = 000000
-foreground = ffffff
-cursor-color = fefefe
-selection-background = 222222
-selection-foreground = cccccc
+background = #000000
+foreground = #ffffff
+cursor-color = #fefefe
+selection-background = #222222
+selection-foreground = #cccccc

--- a/ghostty/UltraViolent
+++ b/ghostty/UltraViolent
@@ -14,8 +14,8 @@ palette = 12=#7fecff
 palette = 13=#e681ff
 palette = 14=#69fcd3
 palette = 15=#f9f9f5
-background = 242728
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 574c49
-selection-foreground = c3c7cb
+background = #242728
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #574c49
+selection-foreground = #c3c7cb

--- a/ghostty/UnderTheSea
+++ b/ghostty/UnderTheSea
@@ -14,8 +14,8 @@ palette = 12=#61d5ba
 palette = 13=#1298ff
 palette = 14=#98d028
 palette = 15=#58fbd6
-background = 011116
-foreground = ffffff
-cursor-color = 4afcd6
-selection-background = 415555
-selection-foreground = 4dffda
+background = #011116
+foreground = #ffffff
+cursor-color = #4afcd6
+selection-background = #415555
+selection-foreground = #4dffda

--- a/ghostty/Unikitty
+++ b/ghostty/Unikitty
@@ -14,8 +14,8 @@ palette = 12=#0075ea
 palette = 13=#fdd5e5
 palette = 14=#79ecd5
 palette = 15=#fff3fe
-background = ff8cd9
-foreground = 0b0b0b
-cursor-color = bafc8b
-selection-background = 3ea9fe
-selection-foreground = ffffff
+background = #ff8cd9
+foreground = #0b0b0b
+cursor-color = #bafc8b
+selection-background = #3ea9fe
+selection-foreground = #ffffff

--- a/ghostty/Urple
+++ b/ghostty/Urple
@@ -14,8 +14,8 @@ palette = 12=#867aed
 palette = 13=#a05eee
 palette = 14=#eaeaea
 palette = 15=#bfa3ff
-background = 1b1b23
-foreground = 877a9b
-cursor-color = a063eb
-selection-background = a063eb
-selection-foreground = 1b1b22
+background = #1b1b23
+foreground = #877a9b
+cursor-color = #a063eb
+selection-background = #a063eb
+selection-foreground = #1b1b22

--- a/ghostty/Vaughn
+++ b/ghostty/Vaughn
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ec93d3
 palette = 14=#93e0e3
 palette = 15=#ffffff
-background = 25234f
-foreground = dcdccc
-cursor-color = ff5555
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #25234f
+foreground = #dcdccc
+cursor-color = #ff5555
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/VibrantInk
+++ b/ghostty/VibrantInk
@@ -14,8 +14,8 @@ palette = 12=#0000ff
 palette = 13=#ff00ff
 palette = 14=#00ffff
 palette = 15=#e5e5e5
-background = 000000
-foreground = ffffff
-cursor-color = ffffff
-selection-background = b5d5ff
-selection-foreground = 000000
+background = #000000
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #b5d5ff
+selection-foreground = #000000

--- a/ghostty/Violet Dark
+++ b/ghostty/Violet Dark
@@ -14,8 +14,8 @@ palette = 12=#2176c7
 palette = 13=#c61c6f
 palette = 14=#259286
 palette = 15=#c9c6bd
-background = 1c1d1f
-foreground = 708284
-cursor-color = 708284
-selection-background = 595ab7
-selection-foreground = 1c1d1f
+background = #1c1d1f
+foreground = #708284
+cursor-color = #708284
+selection-background = #595ab7
+selection-foreground = #1c1d1f

--- a/ghostty/Violet Light
+++ b/ghostty/Violet Light
@@ -14,8 +14,8 @@ palette = 12=#2176c7
 palette = 13=#c61c6f
 palette = 14=#259286
 palette = 15=#c9c6bd
-background = fcf4dc
-foreground = 536870
-cursor-color = 536870
-selection-background = 595ab7
-selection-foreground = fcf4dc
+background = #fcf4dc
+foreground = #536870
+cursor-color = #536870
+selection-background = #595ab7
+selection-foreground = #fcf4dc

--- a/ghostty/WarmNeon
+++ b/ghostty/WarmNeon
@@ -14,8 +14,8 @@ palette = 12=#7b91d6
 palette = 13=#f674ba
 palette = 14=#5ed1e5
 palette = 15=#d8c8bb
-background = 404040
-foreground = afdab6
-cursor-color = 30ff24
-selection-background = b0ad21
-selection-foreground = ffffff
+background = #404040
+foreground = #afdab6
+cursor-color = #30ff24
+selection-background = #b0ad21
+selection-foreground = #ffffff

--- a/ghostty/Wez
+++ b/ghostty/Wez
@@ -14,8 +14,8 @@ palette = 12=#5555ff
 palette = 13=#ff55ff
 palette = 14=#55ffff
 palette = 15=#ffffff
-background = 000000
-foreground = b3b3b3
-cursor-color = 53ae71
-selection-background = 4d52f8
-selection-foreground = 000000
+background = #000000
+foreground = #b3b3b3
+cursor-color = #53ae71
+selection-background = #4d52f8
+selection-foreground = #000000

--- a/ghostty/Whimsy
+++ b/ghostty/Whimsy
@@ -14,8 +14,8 @@ palette = 12=#65aef7
 palette = 13=#aa7ff0
 palette = 14=#43c1be
 palette = 15=#ffffff
-background = 29283b
-foreground = b3b0d6
-cursor-color = b3b0d6
-selection-background = 3d3c58
-selection-foreground = ffffff
+background = #29283b
+foreground = #b3b0d6
+cursor-color = #b3b0d6
+selection-background = #3d3c58
+selection-foreground = #ffffff

--- a/ghostty/WildCherry
+++ b/ghostty/WildCherry
@@ -14,8 +14,8 @@ palette = 12=#308cba
 palette = 13=#ae636b
 palette = 14=#ff919d
 palette = 15=#e4838d
-background = 1f1726
-foreground = dafaff
-cursor-color = dd00ff
-selection-background = 002831
-selection-foreground = e4ffff
+background = #1f1726
+foreground = #dafaff
+cursor-color = #dd00ff
+selection-background = #002831
+selection-foreground = #e4ffff

--- a/ghostty/Wombat
+++ b/ghostty/Wombat
@@ -14,8 +14,8 @@ palette = 12=#a5c7ff
 palette = 13=#ddaaff
 palette = 14=#b7fff9
 palette = 15=#ffffff
-background = 171717
-foreground = dedacf
-cursor-color = bbbbbb
-selection-background = 453b39
-selection-foreground = b6bbc0
+background = #171717
+foreground = #dedacf
+cursor-color = #bbbbbb
+selection-background = #453b39
+selection-foreground = #b6bbc0

--- a/ghostty/Wryan
+++ b/ghostty/Wryan
@@ -14,8 +14,8 @@ palette = 12=#477ab3
 palette = 13=#7e62b3
 palette = 14=#6096bf
 palette = 15=#c0c0c0
-background = 101010
-foreground = 999993
-cursor-color = 9e9ecb
-selection-background = 4d4d4d
-selection-foreground = ffffff
+background = #101010
+foreground = #999993
+cursor-color = #9e9ecb
+selection-background = #4d4d4d
+selection-foreground = #ffffff

--- a/ghostty/Zenburn
+++ b/ghostty/Zenburn
@@ -14,8 +14,8 @@ palette = 12=#94bff3
 palette = 13=#ec93d3
 palette = 14=#93e0e3
 palette = 15=#ffffff
-background = 3f3f3f
-foreground = dcdccc
-cursor-color = 73635a
-selection-background = 21322f
-selection-foreground = c2d87a
+background = #3f3f3f
+foreground = #dcdccc
+cursor-color = #73635a
+selection-background = #21322f
+selection-foreground = #c2d87a

--- a/ghostty/arcoiris
+++ b/ghostty/arcoiris
@@ -14,8 +14,8 @@ palette = 12=#b3e8f3
 palette = 13=#cbbaf9
 palette = 14=#bcffc7
 palette = 15=#efefef
-background = 201f1e
-foreground = eee4d9
-cursor-color = 7a1c1c
-selection-background = 25524a
-selection-foreground = f3fffd
+background = #201f1e
+foreground = #eee4d9
+cursor-color = #7a1c1c
+selection-background = #25524a
+selection-foreground = #f3fffd

--- a/ghostty/ayu
+++ b/ghostty/ayu
@@ -14,8 +14,8 @@ palette = 12=#68d5ff
 palette = 13=#ffa3aa
 palette = 14=#c7fffd
 palette = 15=#ffffff
-background = 0f1419
-foreground = e6e1cf
-cursor-color = f29718
-selection-background = 253340
-selection-foreground = e6e1cf
+background = #0f1419
+foreground = #e6e1cf
+cursor-color = #f29718
+selection-background = #253340
+selection-foreground = #e6e1cf

--- a/ghostty/ayu_light
+++ b/ghostty/ayu_light
@@ -14,8 +14,8 @@ palette = 12=#73d8ff
 palette = 13=#ffa3aa
 palette = 14=#7ff1cb
 palette = 15=#ffffff
-background = fafafa
-foreground = 5c6773
-cursor-color = ff6a00
-selection-background = f0eee4
-selection-foreground = 5c6773
+background = #fafafa
+foreground = #5c6773
+cursor-color = #ff6a00
+selection-background = #f0eee4
+selection-foreground = #5c6773

--- a/ghostty/catppuccin-frappe
+++ b/ghostty/catppuccin-frappe
@@ -14,8 +14,8 @@ palette = 12=#7b9ef0
 palette = 13=#f2a4db
 palette = 14=#5abfb5
 palette = 15=#b5bfe2
-background = 303446
-foreground = c6d0f5
-cursor-color = f2d5cf
-selection-background = 626880
-selection-foreground = c6d0f5
+background = #303446
+foreground = #c6d0f5
+cursor-color = #f2d5cf
+selection-background = #626880
+selection-foreground = #c6d0f5

--- a/ghostty/catppuccin-latte
+++ b/ghostty/catppuccin-latte
@@ -14,8 +14,8 @@ palette = 12=#456eff
 palette = 13=#fe85d8
 palette = 14=#2d9fa8
 palette = 15=#bcc0cc
-background = eff1f5
-foreground = 4c4f69
-cursor-color = dc8a78
-selection-background = acb0be
-selection-foreground = 4c4f69
+background = #eff1f5
+foreground = #4c4f69
+cursor-color = #dc8a78
+selection-background = #acb0be
+selection-foreground = #4c4f69

--- a/ghostty/catppuccin-macchiato
+++ b/ghostty/catppuccin-macchiato
@@ -14,8 +14,8 @@ palette = 12=#78a1f6
 palette = 13=#f2a9dd
 palette = 14=#63cbc0
 palette = 15=#b8c0e0
-background = 24273a
-foreground = cad3f5
-cursor-color = f4dbd6
-selection-background = 5b6078
-selection-foreground = cad3f5
+background = #24273a
+foreground = #cad3f5
+cursor-color = #f4dbd6
+selection-background = #5b6078
+selection-foreground = #cad3f5

--- a/ghostty/catppuccin-mocha
+++ b/ghostty/catppuccin-mocha
@@ -14,8 +14,8 @@ palette = 12=#74a8fc
 palette = 13=#f2aede
 palette = 14=#6bd7ca
 palette = 15=#bac2de
-background = 1e1e2e
-foreground = cdd6f4
-cursor-color = f5e0dc
-selection-background = 585b70
-selection-foreground = cdd6f4
+background = #1e1e2e
+foreground = #cdd6f4
+cursor-color = #f5e0dc
+selection-background = #585b70
+selection-foreground = #cdd6f4

--- a/ghostty/coffee_theme
+++ b/ghostty/coffee_theme
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = f5deb3
-foreground = 000000
-cursor-color = c7c7c7
-selection-background = c1deff
-selection-foreground = 000000
+background = #f5deb3
+foreground = #000000
+cursor-color = #c7c7c7
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/cyberpunk
+++ b/ghostty/cyberpunk
@@ -14,8 +14,8 @@ palette = 12=#1bccfd
 palette = 13=#e6aefe
 palette = 14=#99d6fc
 palette = 15=#ffffff
-background = 332a57
-foreground = e5e5e5
-cursor-color = 21f6bc
-selection-background = c1deff
-selection-foreground = 000000
+background = #332a57
+foreground = #e5e5e5
+cursor-color = #21f6bc
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/darkermatrix
+++ b/ghostty/darkermatrix
@@ -14,8 +14,8 @@ palette = 12=#00ff87
 palette = 13=#412a4d
 palette = 14=#176c73
 palette = 15=#00381e
-background = 070c0e
-foreground = 28380d
-cursor-color = 373a26
-selection-background = 0f191c
-selection-foreground = 00ff87
+background = #070c0e
+foreground = #28380d
+cursor-color = #373a26
+selection-background = #0f191c
+selection-foreground = #00ff87

--- a/ghostty/darkmatrix
+++ b/ghostty/darkmatrix
@@ -14,8 +14,8 @@ palette = 12=#46d8b8
 palette = 13=#4a3059
 palette = 14=#12545a
 palette = 15=#006536
-background = 070c0e
-foreground = 3e5715
-cursor-color = 9fa86e
-selection-background = 0f191c
-selection-foreground = 00ff87
+background = #070c0e
+foreground = #3e5715
+cursor-color = #9fa86e
+selection-background = #0f191c
+selection-foreground = #00ff87

--- a/ghostty/dayfox
+++ b/ghostty/dayfox
@@ -14,8 +14,8 @@ palette = 12=#4863b6
 palette = 13=#8452d5
 palette = 14=#488d93
 palette = 15=#f4ece6
-background = f6f2ee
-foreground = 3d2b5a
-cursor-color = 3d2b5a
-selection-background = e7d2be
-selection-foreground = 3d2b5a
+background = #f6f2ee
+foreground = #3d2b5a
+cursor-color = #3d2b5a
+selection-background = #e7d2be
+selection-foreground = #3d2b5a

--- a/ghostty/deep
+++ b/ghostty/deep
@@ -14,8 +14,8 @@ palette = 12=#9fa9ff
 palette = 13=#e09aff
 palette = 14=#8df9ff
 palette = 15=#ffffff
-background = 090909
-foreground = cdcdcd
-cursor-color = d0d0d0
-selection-background = 780002
-selection-foreground = ececec
+background = #090909
+foreground = #cdcdcd
+cursor-color = #d0d0d0
+selection-background = #780002
+selection-foreground = #ececec

--- a/ghostty/duckbones
+++ b/ghostty/duckbones
@@ -14,8 +14,8 @@ palette = 12=#00b4e0
 palette = 13=#b3a1e6
 palette = 14=#00b4e0
 palette = 15=#b3b692
-background = 0e101a
-foreground = ebefc0
-cursor-color = edf2c2
-selection-background = 37382d
-selection-foreground = ebefc0
+background = #0e101a
+foreground = #ebefc0
+cursor-color = #edf2c2
+selection-background = #37382d
+selection-foreground = #ebefc0

--- a/ghostty/embers-dark
+++ b/ghostty/embers-dark
@@ -14,8 +14,8 @@ palette = 12=#8a8075
 palette = 13=#beb6ae
 palette = 14=#825757
 palette = 15=#dbd6d1
-background = 16130f
-foreground = a39a90
-cursor-color = a39a90
-selection-background = 433b32
-selection-foreground = a39a90
+background = #16130f
+foreground = #a39a90
+cursor-color = #a39a90
+selection-background = #433b32
+selection-foreground = #a39a90

--- a/ghostty/farmhouse-dark
+++ b/ghostty/farmhouse-dark
@@ -14,8 +14,8 @@ palette = 12=#006efe
 palette = 13=#bf3b7f
 palette = 14=#19e062
 palette = 15=#f4eef0
-background = 1d2027
-foreground = e8e4e1
-cursor-color = 006efe
-selection-background = 4d5658
-selection-foreground = b3b1aa
+background = #1d2027
+foreground = #e8e4e1
+cursor-color = #006efe
+selection-background = #4d5658
+selection-foreground = #b3b1aa

--- a/ghostty/farmhouse-light
+++ b/ghostty/farmhouse-light
@@ -14,8 +14,8 @@ palette = 12=#006efe
 palette = 13=#bf3b7f
 palette = 14=#19e062
 palette = 15=#f4eef0
-background = e8e4e1
-foreground = 1d2027
-cursor-color = 006efe
-selection-background = b3b1aa
-selection-foreground = 4d5658
+background = #e8e4e1
+foreground = #1d2027
+cursor-color = #006efe
+selection-background = #b3b1aa
+selection-foreground = #4d5658

--- a/ghostty/flexoki-dark
+++ b/ghostty/flexoki-dark
@@ -14,8 +14,8 @@ palette = 12=#4385be
 palette = 13=#ce5d97
 palette = 14=#3aa99f
 palette = 15=#cecdc3
-background = 1c1b1a
-foreground = cecdc3
-cursor-color = cecdc3
-selection-background = cecdc3
-selection-foreground = 4385be
+background = #1c1b1a
+foreground = #cecdc3
+cursor-color = #cecdc3
+selection-background = #cecdc3
+selection-foreground = #4385be

--- a/ghostty/flexoki-light
+++ b/ghostty/flexoki-light
@@ -14,8 +14,8 @@ palette = 12=#4385be
 palette = 13=#ce5d97
 palette = 14=#3aa99f
 palette = 15=#fffcf0
-background = fffcf0
-foreground = 100f0f
-cursor-color = 100f0f
-selection-background = cecdc3
-selection-foreground = 100f0f
+background = #fffcf0
+foreground = #100f0f
+cursor-color = #100f0f
+selection-background = #cecdc3
+selection-foreground = #100f0f

--- a/ghostty/gruber-darker
+++ b/ghostty/gruber-darker
@@ -14,8 +14,8 @@ palette = 12=#96a6c8
 palette = 13=#afafd7
 palette = 14=#95a99f
 palette = 15=#f5f5f5
-background = 181818
-foreground = e4e4e4
-cursor-color = ffdd33
-selection-background = ffffff
-selection-foreground = 52494e
+background = #181818
+foreground = #e4e4e4
+cursor-color = #ffdd33
+selection-background = #ffffff
+selection-foreground = #52494e

--- a/ghostty/gruvbox-material
+++ b/ghostty/gruvbox-material
@@ -14,8 +14,8 @@ palette = 12=#7daea3
 palette = 13=#d3869b
 palette = 14=#89b482
 palette = 15=#ddc7a1
-background = 282828
-foreground = d4be98
-cursor-color = ffffff
-selection-background = 2b2c3f
-selection-foreground = 333e34
+background = #282828
+foreground = #d4be98
+cursor-color = #ffffff
+selection-background = #2b2c3f
+selection-foreground = #333e34

--- a/ghostty/heeler
+++ b/ghostty/heeler
@@ -14,8 +14,8 @@ palette = 12=#2c86ff
 palette = 13=#fd9bc1
 palette = 14=#92a5df
 palette = 15=#ffffff
-background = 211f44
-foreground = fdfdfd
-cursor-color = ffffff
-selection-background = 2b2c3f
-selection-foreground = 7cfb70
+background = #211f44
+foreground = #fdfdfd
+cursor-color = #ffffff
+selection-background = #2b2c3f
+selection-foreground = #7cfb70

--- a/ghostty/iTerm2 Dark Background
+++ b/ghostty/iTerm2 Dark Background
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 000000
-foreground = c7c7c7
-cursor-color = c7c7c7
-selection-background = c1deff
-selection-foreground = 000000
+background = #000000
+foreground = #c7c7c7
+cursor-color = #c7c7c7
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/iTerm2 Default
+++ b/ghostty/iTerm2 Default
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 000000
-foreground = ffffff
-cursor-color = e5e5e5
-selection-background = c1deff
-selection-foreground = 000000
+background = #000000
+foreground = #ffffff
+cursor-color = #e5e5e5
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/iTerm2 Light Background
+++ b/ghostty/iTerm2 Light Background
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = c1deff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/iTerm2 Pastel Dark Background
+++ b/ghostty/iTerm2 Pastel Dark Background
@@ -14,8 +14,8 @@ palette = 12=#c2e3ff
 palette = 13=#ffb2fe
 palette = 14=#e6e6fe
 palette = 15=#ffffff
-background = 000000
-foreground = c7c7c7
-cursor-color = ffb473
-selection-background = 454d96
-selection-foreground = f4f4f4
+background = #000000
+foreground = #c7c7c7
+cursor-color = #ffb473
+selection-background = #454d96
+selection-foreground = #f4f4f4

--- a/ghostty/iTerm2 Smoooooth
+++ b/ghostty/iTerm2 Smoooooth
@@ -14,8 +14,8 @@ palette = 12=#a7abf2
 palette = 13=#e17ee1
 palette = 14=#60fdff
 palette = 15=#ffffff
-background = 15191f
-foreground = dcdcdc
-cursor-color = ffffff
-selection-background = b3d7ff
-selection-foreground = 000000
+background = #15191f
+foreground = #dcdcdc
+cursor-color = #ffffff
+selection-background = #b3d7ff
+selection-foreground = #000000

--- a/ghostty/iTerm2 Solarized Dark
+++ b/ghostty/iTerm2 Solarized Dark
@@ -14,8 +14,8 @@ palette = 12=#839496
 palette = 13=#6c71c4
 palette = 14=#93a1a1
 palette = 15=#fdf6e3
-background = 002b36
-foreground = 839496
-cursor-color = 839496
-selection-background = 073642
-selection-foreground = 93a1a1
+background = #002b36
+foreground = #839496
+cursor-color = #839496
+selection-background = #073642
+selection-foreground = #93a1a1

--- a/ghostty/iTerm2 Solarized Light
+++ b/ghostty/iTerm2 Solarized Light
@@ -14,8 +14,8 @@ palette = 12=#839496
 palette = 13=#6c71c4
 palette = 14=#93a1a1
 palette = 15=#fdf6e3
-background = fdf6e3
-foreground = 657b83
-cursor-color = 657b83
-selection-background = eee8d5
-selection-foreground = 586e75
+background = #fdf6e3
+foreground = #657b83
+cursor-color = #657b83
+selection-background = #eee8d5
+selection-foreground = #586e75

--- a/ghostty/iTerm2 Tango Dark
+++ b/ghostty/iTerm2 Tango Dark
@@ -14,8 +14,8 @@ palette = 12=#84b0d8
 palette = 13=#bc94b7
 palette = 14=#37e6e8
 palette = 15=#f1f1f0
-background = 000000
-foreground = ffffff
-cursor-color = ffffff
-selection-background = c1deff
-selection-foreground = 000000
+background = #000000
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/iTerm2 Tango Light
+++ b/ghostty/iTerm2 Tango Light
@@ -14,8 +14,8 @@ palette = 12=#84b0d8
 palette = 13=#bc94b7
 palette = 14=#37e6e8
 palette = 15=#f1f1f0
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = c1deff
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/iceberg-dark
+++ b/ghostty/iceberg-dark
@@ -14,8 +14,8 @@ palette = 12=#91acd1
 palette = 13=#ada0d3
 palette = 14=#95c4ce
 palette = 15=#d2d4de
-background = 161821
-foreground = c6c8d1
-cursor-color = c6c8d1
-selection-background = c6c8d1
-selection-foreground = 161821
+background = #161821
+foreground = #c6c8d1
+cursor-color = #c6c8d1
+selection-background = #c6c8d1
+selection-foreground = #161821

--- a/ghostty/iceberg-light
+++ b/ghostty/iceberg-light
@@ -14,8 +14,8 @@ palette = 12=#22478e
 palette = 13=#6845ad
 palette = 14=#327698
 palette = 15=#262a3f
-background = e8e9ec
-foreground = 33374c
-cursor-color = 33374c
-selection-background = 33374c
-selection-foreground = e8e9ec
+background = #e8e9ec
+foreground = #33374c
+cursor-color = #33374c
+selection-background = #33374c
+selection-foreground = #e8e9ec

--- a/ghostty/idea
+++ b/ghostty/idea
@@ -14,8 +14,8 @@ palette = 12=#6c9ced
 palette = 13=#fc7eff
 palette = 14=#248887
 palette = 15=#181818
-background = 202020
-foreground = adadad
-cursor-color = bbbbbb
-selection-background = 44475a
-selection-foreground = ffffff
+background = #202020
+foreground = #adadad
+cursor-color = #bbbbbb
+selection-background = #44475a
+selection-foreground = #ffffff

--- a/ghostty/idleToes
+++ b/ghostty/idleToes
@@ -14,8 +14,8 @@ palette = 12=#5eb7f7
 palette = 13=#ff9dff
 palette = 14=#dcf4ff
 palette = 15=#ffffff
-background = 323232
-foreground = ffffff
-cursor-color = d6d6d6
-selection-background = 5b5b5b
-selection-foreground = 000000
+background = #323232
+foreground = #ffffff
+cursor-color = #d6d6d6
+selection-background = #5b5b5b
+selection-foreground = #000000

--- a/ghostty/jubi
+++ b/ghostty/jubi
@@ -14,8 +14,8 @@ palette = 12=#8c9fcd
 palette = 13=#e16c87
 palette = 14=#b7c9ef
 palette = 15=#d5e5f1
-background = 262b33
-foreground = c3d3de
-cursor-color = c3d3de
-selection-background = 5b5184
-selection-foreground = 1e1b2e
+background = #262b33
+foreground = #c3d3de
+cursor-color = #c3d3de
+selection-background = #5b5184
+selection-foreground = #1e1b2e

--- a/ghostty/kanagawabones
+++ b/ghostty/kanagawabones
@@ -14,8 +14,8 @@ palette = 12=#7bc2df
 palette = 13=#a98fd2
 palette = 14=#7bc2df
 palette = 15=#a8a48d
-background = 1f1f28
-foreground = ddd8bb
-cursor-color = e6e0c2
-selection-background = 49473e
-selection-foreground = ddd8bb
+background = #1f1f28
+foreground = #ddd8bb
+cursor-color = #e6e0c2
+selection-background = #49473e
+selection-foreground = #ddd8bb

--- a/ghostty/kurokula
+++ b/ghostty/kurokula
@@ -14,8 +14,8 @@ palette = 12=#a1d9ff
 palette = 13=#a994ff
 palette = 14=#f9cfb9
 palette = 15=#ffffff
-background = 141515
-foreground = ddd0c4
-cursor-color = 702420
-selection-background = 515151
-selection-foreground = ffc663
+background = #141515
+foreground = #ddd0c4
+cursor-color = #702420
+selection-background = #515151
+selection-foreground = #ffc663

--- a/ghostty/lovelace
+++ b/ghostty/lovelace
@@ -14,8 +14,8 @@ palette = 12=#556fff
 palette = 13=#b043d1
 palette = 14=#3fdcee
 palette = 15=#bebec1
-background = 1d1f28
-foreground = fdfdfd
-cursor-color = c574dd
-selection-background = c1deff
-selection-foreground = 000000
+background = #1d1f28
+foreground = #fdfdfd
+cursor-color = #c574dd
+selection-background = #c1deff
+selection-foreground = #000000

--- a/ghostty/matrix
+++ b/ghostty/matrix
@@ -14,8 +14,8 @@ palette = 12=#4f7e7e
 palette = 13=#11ff25
 palette = 14=#c1ff8a
 palette = 15=#678c61
-background = 0f191c
-foreground = 426644
-cursor-color = 384545
-selection-background = 18282e
-selection-foreground = 00ff87
+background = #0f191c
+foreground = #426644
+cursor-color = #384545
+selection-background = #18282e
+selection-foreground = #00ff87

--- a/ghostty/mellow
+++ b/ghostty/mellow
@@ -14,8 +14,8 @@ palette = 12=#b9aeda
 palette = 13=#ecaad6
 palette = 14=#f591b2
 palette = 15=#cac9dd
-background = 161617
-foreground = c9c7cd
-cursor-color = cac9dd
-selection-background = 2a2a2d
-selection-foreground = c1c0d4
+background = #161617
+foreground = #c9c7cd
+cursor-color = #cac9dd
+selection-background = #2a2a2d
+selection-foreground = #c1c0d4

--- a/ghostty/midnight-in-mojave
+++ b/ghostty/midnight-in-mojave
@@ -14,8 +14,8 @@ palette = 12=#0a84ff
 palette = 13=#bf5af2
 palette = 14=#5ac8fa
 palette = 15=#ffffff
-background = 1e1e1e
-foreground = ffffff
-cursor-color = 32d74b
-selection-background = 4a504d
-selection-foreground = ffffff
+background = #1e1e1e
+foreground = #ffffff
+cursor-color = #32d74b
+selection-background = #4a504d
+selection-foreground = #ffffff

--- a/ghostty/neobones_dark
+++ b/ghostty/neobones_dark
@@ -14,8 +14,8 @@ palette = 12=#92a0e2
 palette = 13=#cf86c1
 palette = 14=#65b8c1
 palette = 15=#98a39e
-background = 0f191f
-foreground = c6d5cf
-cursor-color = ceddd7
-selection-background = 3a3e3d
-selection-foreground = c6d5cf
+background = #0f191f
+foreground = #c6d5cf
+cursor-color = #ceddd7
+selection-background = #3a3e3d
+selection-foreground = #c6d5cf

--- a/ghostty/neobones_light
+++ b/ghostty/neobones_light
@@ -14,8 +14,8 @@ palette = 12=#1d5573
 palette = 13=#7b3b70
 palette = 14=#2b747c
 palette = 15=#415934
-background = e5ede6
-foreground = 202e18
-cursor-color = 202e18
-selection-background = ade48c
-selection-foreground = 202e18
+background = #e5ede6
+foreground = #202e18
+cursor-color = #202e18
+selection-background = #ade48c
+selection-foreground = #202e18

--- a/ghostty/nightfox
+++ b/ghostty/nightfox
@@ -14,8 +14,8 @@ palette = 12=#86abdc
 palette = 13=#baa1e2
 palette = 14=#7ad5d6
 palette = 15=#e4e4e5
-background = 192330
-foreground = cdcecf
-cursor-color = cdcecf
-selection-background = 2b3b51
-selection-foreground = cdcecf
+background = #192330
+foreground = #cdcecf
+cursor-color = #cdcecf
+selection-background = #2b3b51
+selection-foreground = #cdcecf

--- a/ghostty/niji
+++ b/ghostty/niji
@@ -14,8 +14,8 @@ palette = 12=#8efff3
 palette = 13=#ffa2ed
 palette = 14=#bcffc7
 palette = 15=#ffffff
-background = 141515
-foreground = ffffff
-cursor-color = ffc663
-selection-background = 515151
-selection-foreground = ffc663
+background = #141515
+foreground = #ffffff
+cursor-color = #ffc663
+selection-background = #515151
+selection-foreground = #ffc663

--- a/ghostty/nord
+++ b/ghostty/nord
@@ -14,8 +14,8 @@ palette = 12=#81a1c1
 palette = 13=#b48ead
 palette = 14=#8fbcbb
 palette = 15=#eceff4
-background = 2e3440
-foreground = d8dee9
-cursor-color = eceff4
-selection-background = eceff4
-selection-foreground = 4c566a
+background = #2e3440
+foreground = #d8dee9
+cursor-color = #eceff4
+selection-background = #eceff4
+selection-foreground = #4c566a

--- a/ghostty/nord-light
+++ b/ghostty/nord-light
@@ -14,8 +14,8 @@ palette = 12=#81a1c1
 palette = 13=#b48ead
 palette = 14=#8fbcbb
 palette = 15=#eceff4
-background = e5e9f0
-foreground = 414858
-cursor-color = 88c0d0
-selection-background = d8dee9
-selection-foreground = 4c556a
+background = #e5e9f0
+foreground = #414858
+cursor-color = #88c0d0
+selection-background = #d8dee9
+selection-foreground = #4c556a

--- a/ghostty/primary
+++ b/ghostty/primary
@@ -14,8 +14,8 @@ palette = 12=#4285f4
 palette = 13=#4285f4
 palette = 14=#0f9d58
 palette = 15=#ffffff
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = 656565
-selection-foreground = eeeeee
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #656565
+selection-foreground = #eeeeee

--- a/ghostty/purplepeter
+++ b/ghostty/purplepeter
@@ -14,8 +14,8 @@ palette = 12=#79daed
 palette = 13=#ba91d4
 palette = 14=#a0a0d6
 palette = 15=#b9aed3
-background = 2a1a4a
-foreground = ece7fa
-cursor-color = c7c7c7
-selection-background = 8689c2
-selection-foreground = 271c50
+background = #2a1a4a
+foreground = #ece7fa
+cursor-color = #c7c7c7
+selection-background = #8689c2
+selection-foreground = #271c50

--- a/ghostty/rebecca
+++ b/ghostty/rebecca
@@ -14,8 +14,8 @@ palette = 12=#69c0fa
 palette = 13=#c17ff8
 palette = 14=#8bfde1
 palette = 15=#f4f2f9
-background = 292a44
-foreground = e8e6ed
-cursor-color = b89bf9
-selection-background = 663399
-selection-foreground = f4f2f9
+background = #292a44
+foreground = #e8e6ed
+cursor-color = #b89bf9
+selection-background = #663399
+selection-foreground = #f4f2f9

--- a/ghostty/rose-pine
+++ b/ghostty/rose-pine
@@ -14,8 +14,8 @@ palette = 12=#31748f
 palette = 13=#c4a7e7
 palette = 14=#ebbcba
 palette = 15=#e0def4
-background = 191724
-foreground = e0def4
-cursor-color = e0def4
-selection-background = 191724
-selection-foreground = e0def4
+background = #191724
+foreground = #e0def4
+cursor-color = #e0def4
+selection-background = #191724
+selection-foreground = #e0def4

--- a/ghostty/rose-pine-dawn
+++ b/ghostty/rose-pine-dawn
@@ -14,8 +14,8 @@ palette = 12=#286983
 palette = 13=#907aa9
 palette = 14=#d7827e
 palette = 15=#575279
-background = faf4ed
-foreground = 575279
-cursor-color = 575279
-selection-background = faf4ed
-selection-foreground = 575279
+background = #faf4ed
+foreground = #575279
+cursor-color = #575279
+selection-background = #faf4ed
+selection-foreground = #575279

--- a/ghostty/rose-pine-moon
+++ b/ghostty/rose-pine-moon
@@ -14,8 +14,8 @@ palette = 12=#3e8fb0
 palette = 13=#c4a7e7
 palette = 14=#ea9a97
 palette = 15=#e0def4
-background = 232136
-foreground = e0def4
-cursor-color = e0def4
-selection-background = 232136
-selection-foreground = e0def4
+background = #232136
+foreground = #e0def4
+cursor-color = #e0def4
+selection-background = #232136
+selection-foreground = #e0def4

--- a/ghostty/seoulbones_dark
+++ b/ghostty/seoulbones_dark
@@ -14,8 +14,8 @@ palette = 12=#a2c8e9
 palette = 13=#b2b3da
 palette = 14=#6bcacb
 palette = 15=#a8a8a8
-background = 4b4b4b
-foreground = dddddd
-cursor-color = e2e2e2
-selection-background = 777777
-selection-foreground = dddddd
+background = #4b4b4b
+foreground = #dddddd
+cursor-color = #e2e2e2
+selection-background = #777777
+selection-foreground = #dddddd

--- a/ghostty/seoulbones_light
+++ b/ghostty/seoulbones_light
@@ -14,8 +14,8 @@ palette = 12=#006f89
 palette = 13=#7f4c7e
 palette = 14=#006f70
 palette = 15=#777777
-background = e2e2e2
-foreground = 555555
-cursor-color = 555555
-selection-background = cccccc
-selection-foreground = 555555
+background = #e2e2e2
+foreground = #555555
+cursor-color = #555555
+selection-background = #cccccc
+selection-foreground = #555555

--- a/ghostty/shades-of-purple
+++ b/ghostty/shades-of-purple
@@ -14,8 +14,8 @@ palette = 12=#6871ff
 palette = 13=#ff77ff
 palette = 14=#79e8fb
 palette = 15=#ffffff
-background = 1e1d40
-foreground = ffffff
-cursor-color = fad000
-selection-background = b362ff
-selection-foreground = c2c2c2
+background = #1e1d40
+foreground = #ffffff
+cursor-color = #fad000
+selection-background = #b362ff
+selection-foreground = #c2c2c2

--- a/ghostty/synthwave
+++ b/ghostty/synthwave
@@ -14,8 +14,8 @@ palette = 12=#2f9ded
 palette = 13=#f97137
 palette = 14=#19cde6
 palette = 15=#ffffff
-background = 000000
-foreground = dad9c7
-cursor-color = 19cde6
-selection-background = 19cde6
-selection-foreground = 000000
+background = #000000
+foreground = #dad9c7
+cursor-color = #19cde6
+selection-background = #19cde6
+selection-foreground = #000000

--- a/ghostty/synthwave-everything
+++ b/ghostty/synthwave-everything
@@ -14,8 +14,8 @@ palette = 12=#36f9f6
 palette = 13=#e1acff
 palette = 14=#f92aad
 palette = 15=#fefefe
-background = 2a2139
-foreground = f0eff1
-cursor-color = 72f1b8
-selection-background = 181521
-selection-foreground = f0eff1
+background = #2a2139
+foreground = #f0eff1
+cursor-color = #72f1b8
+selection-background = #181521
+selection-foreground = #f0eff1

--- a/ghostty/terafox
+++ b/ghostty/terafox
@@ -14,8 +14,8 @@ palette = 12=#73a3b7
 palette = 13=#b97490
 palette = 14=#afd4de
 palette = 15=#eeeeee
-background = 152528
-foreground = e6eaea
-cursor-color = e6eaea
-selection-background = 293e40
-selection-foreground = e6eaea
+background = #152528
+foreground = #e6eaea
+cursor-color = #e6eaea
+selection-background = #293e40
+selection-foreground = #e6eaea

--- a/ghostty/tokyonight
+++ b/ghostty/tokyonight
@@ -14,8 +14,8 @@ palette = 12=#7aa2f7
 palette = 13=#bb9af7
 palette = 14=#7dcfff
 palette = 15=#c0caf5
-background = 1a1b26
-foreground = c0caf5
-cursor-color = c0caf5
-selection-background = 33467c
-selection-foreground = c0caf5
+background = #1a1b26
+foreground = #c0caf5
+cursor-color = #c0caf5
+selection-background = #33467c
+selection-foreground = #c0caf5

--- a/ghostty/tokyonight-day
+++ b/ghostty/tokyonight-day
@@ -14,8 +14,8 @@ palette = 12=#2e7de9
 palette = 13=#9854f1
 palette = 14=#007197
 palette = 15=#3760bf
-background = e1e2e7
-foreground = 3760bf
-cursor-color = 3760bf
-selection-background = 99a7df
-selection-foreground = 3760bf
+background = #e1e2e7
+foreground = #3760bf
+cursor-color = #3760bf
+selection-background = #99a7df
+selection-foreground = #3760bf

--- a/ghostty/tokyonight-storm
+++ b/ghostty/tokyonight-storm
@@ -14,8 +14,8 @@ palette = 12=#7aa2f7
 palette = 13=#bb9af7
 palette = 14=#7dcfff
 palette = 15=#c0caf5
-background = 24283b
-foreground = c0caf5
-cursor-color = c0caf5
-selection-background = 364a82
-selection-foreground = c0caf5
+background = #24283b
+foreground = #c0caf5
+cursor-color = #c0caf5
+selection-background = #364a82
+selection-foreground = #c0caf5

--- a/ghostty/vesper
+++ b/ghostty/vesper
@@ -14,8 +14,8 @@ palette = 12=#b9aeda
 palette = 13=#ecaad6
 palette = 14=#f591b2
 palette = 15=#ffffff
-background = 101010
-foreground = ffffff
-cursor-color = acb1ab
-selection-background = 988049
-selection-foreground = acb1ab
+background = #101010
+foreground = #ffffff
+cursor-color = #acb1ab
+selection-background = #988049
+selection-foreground = #acb1ab

--- a/ghostty/vimbones
+++ b/ghostty/vimbones
@@ -14,8 +14,8 @@ palette = 12=#1d5573
 palette = 13=#7b3b70
 palette = 14=#2b747c
 palette = 15=#5c5c5c
-background = f0f0ca
-foreground = 353535
-cursor-color = 353535
-selection-background = d7d7d7
-selection-foreground = 353535
+background = #f0f0ca
+foreground = #353535
+cursor-color = #353535
+selection-background = #d7d7d7
+selection-foreground = #353535

--- a/ghostty/wilmersdorf
+++ b/ghostty/wilmersdorf
@@ -14,8 +14,8 @@ palette = 12=#b2cff0
 palette = 13=#efccfd
 palette = 14=#69abc5
 palette = 15=#d3d3d3
-background = 282b33
-foreground = c6c6c6
-cursor-color = 7ebebd
-selection-background = 1f2024
-selection-foreground = c6c6c6
+background = #282b33
+foreground = #c6c6c6
+cursor-color = #7ebebd
+selection-background = #1f2024
+selection-foreground = #c6c6c6

--- a/ghostty/xcodedark
+++ b/ghostty/xcodedark
@@ -14,8 +14,8 @@ palette = 12=#6bdfff
 palette = 13=#ff7ab2
 palette = 14=#dabaff
 palette = 15=#dfdfe0
-background = 292a30
-foreground = dfdfe0
-cursor-color = dfdfe0
-selection-background = 414453
-selection-foreground = dfdfe0
+background = #292a30
+foreground = #dfdfe0
+cursor-color = #dfdfe0
+selection-background = #414453
+selection-foreground = #dfdfe0

--- a/ghostty/xcodedarkhc
+++ b/ghostty/xcodedarkhc
@@ -14,8 +14,8 @@ palette = 12=#6bdfff
 palette = 13=#ff85b8
 palette = 14=#e5cfff
 palette = 15=#ffffff
-background = 1f1f24
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 43454b
-selection-foreground = ffffff
+background = #1f1f24
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #43454b
+selection-foreground = #ffffff

--- a/ghostty/xcodelight
+++ b/ghostty/xcodelight
@@ -14,8 +14,8 @@ palette = 12=#0b4f79
 palette = 13=#ad3da4
 palette = 14=#4b21b0
 palette = 15=#262626
-background = ffffff
-foreground = 262626
-cursor-color = 262626
-selection-background = b4d8fd
-selection-foreground = 262626
+background = #ffffff
+foreground = #262626
+cursor-color = #262626
+selection-background = #b4d8fd
+selection-foreground = #262626

--- a/ghostty/xcodelighthc
+++ b/ghostty/xcodelighthc
@@ -14,8 +14,8 @@ palette = 12=#003f73
 palette = 13=#9c2191
 palette = 14=#441ea1
 palette = 15=#000000
-background = ffffff
-foreground = 000000
-cursor-color = 000000
-selection-background = b4d8fd
-selection-foreground = 000000
+background = #ffffff
+foreground = #000000
+cursor-color = #000000
+selection-background = #b4d8fd
+selection-foreground = #000000

--- a/ghostty/xcodewwdc
+++ b/ghostty/xcodewwdc
@@ -14,8 +14,8 @@ palette = 12=#8884c5
 palette = 13=#b73999
 palette = 14=#00aba4
 palette = 15=#e7e8eb
-background = 292c36
-foreground = e7e8eb
-cursor-color = e7e8eb
-selection-background = 494d5c
-selection-foreground = e7e8eb
+background = #292c36
+foreground = #e7e8eb
+cursor-color = #e7e8eb
+selection-background = #494d5c
+selection-foreground = #e7e8eb

--- a/ghostty/zenbones
+++ b/ghostty/zenbones
@@ -14,8 +14,8 @@ palette = 12=#1d5573
 palette = 13=#7b3b70
 palette = 14=#2b747c
 palette = 15=#4f5e68
-background = f0edec
-foreground = 2c363c
-cursor-color = 2c363c
-selection-background = cbd9e3
-selection-foreground = 2c363c
+background = #f0edec
+foreground = #2c363c
+cursor-color = #2c363c
+selection-background = #cbd9e3
+selection-foreground = #2c363c

--- a/ghostty/zenbones_dark
+++ b/ghostty/zenbones_dark
@@ -14,8 +14,8 @@ palette = 12=#61abda
 palette = 13=#cf86c1
 palette = 14=#65b8c1
 palette = 15=#888f94
-background = 1c1917
-foreground = b4bdc3
-cursor-color = c4cacf
-selection-background = 3d4042
-selection-foreground = b4bdc3
+background = #1c1917
+foreground = #b4bdc3
+cursor-color = #c4cacf
+selection-background = #3d4042
+selection-foreground = #b4bdc3

--- a/ghostty/zenbones_light
+++ b/ghostty/zenbones_light
@@ -14,8 +14,8 @@ palette = 12=#1d5573
 palette = 13=#7b3b70
 palette = 14=#2b747c
 palette = 15=#4f5e68
-background = f0edec
-foreground = 2c363c
-cursor-color = 2c363c
-selection-background = cbd9e3
-selection-foreground = 2c363c
+background = #f0edec
+foreground = #2c363c
+cursor-color = #2c363c
+selection-background = #cbd9e3
+selection-foreground = #2c363c

--- a/ghostty/zenburned
+++ b/ghostty/zenburned
@@ -14,8 +14,8 @@ palette = 12=#61abda
 palette = 13=#cf86c1
 palette = 14=#65b8c1
 palette = 15=#c0ab86
-background = 404040
-foreground = f0e4cf
-cursor-color = f3eadb
-selection-background = 746956
-selection-foreground = f0e4cf
+background = #404040
+foreground = #f0e4cf
+cursor-color = #f3eadb
+selection-background = #746956
+selection-foreground = #f0e4cf

--- a/ghostty/zenwritten_dark
+++ b/ghostty/zenwritten_dark
@@ -14,8 +14,8 @@ palette = 12=#61abda
 palette = 13=#cf86c1
 palette = 14=#65b8c1
 palette = 15=#8e8e8e
-background = 191919
-foreground = bbbbbb
-cursor-color = c9c9c9
-selection-background = 404040
-selection-foreground = bbbbbb
+background = #191919
+foreground = #bbbbbb
+cursor-color = #c9c9c9
+selection-background = #404040
+selection-foreground = #bbbbbb

--- a/ghostty/zenwritten_light
+++ b/ghostty/zenwritten_light
@@ -14,8 +14,8 @@ palette = 12=#1d5573
 palette = 13=#7b3b70
 palette = 14=#2b747c
 palette = 15=#5c5c5c
-background = eeeeee
-foreground = 353535
-cursor-color = 353535
-selection-background = d7d7d7
-selection-foreground = 353535
+background = #eeeeee
+foreground = #353535
+cursor-color = #353535
+selection-background = #d7d7d7
+selection-foreground = #353535

--- a/tools/templates/ghostty
+++ b/tools/templates/ghostty
@@ -14,8 +14,8 @@ palette = 12=#{{ Ansi_12_Color.hex }}
 palette = 13=#{{ Ansi_13_Color.hex }}
 palette = 14=#{{ Ansi_14_Color.hex }}
 palette = 15=#{{ Ansi_15_Color.hex }}
-background = {{ Background_Color.hex }}
-foreground = {{ Foreground_Color.hex }}
-cursor-color = {{ Cursor_Color.hex }}
-selection-background = {{ Selection_Color.hex }}
-selection-foreground = {{ Selected_Text_Color.hex }}
+background = #{{ Background_Color.hex }}
+foreground = #{{ Foreground_Color.hex }}
+cursor-color = #{{ Cursor_Color.hex }}
+selection-background = #{{ Selection_Color.hex }}
+selection-foreground = #{{ Selected_Text_Color.hex }}


### PR DESCRIPTION
This patch updates all the Ghostty themes to use `#`-prefixed colors for consistency.

This was done using the following `sed` command. I ran the `sed` command before I found `tools/gen.py`.

```
sed -i -- 's/ \([0-9a-fA-F]\{6\}\)/ #\1/g' ghostty/*
```

It also updates the `ghostty` template so that future themes use `#`-prefixed colors by default.