### PR TITLE
fix: invalid escape sequence in converter.py:11

### DIFF
--- a/tools/converter.py
+++ b/tools/converter.py
@@ -8,7 +8,7 @@ import sys
 from jinja2 import Environment
 from rich.progress import Progress
 
-iterm_re = re.compile("(.+)\.itermcolors$")
+iterm_re = re.compile("(.+)\\.itermcolors$")
 iterm_ext = ".itermcolors"
 hex_format = "%02x%02x%02x"
 


### PR DESCRIPTION
## Description

When runing the generate tools I noticed:

```text
/colors/tools/converter.py:11: SyntaxWarning: invalid escape sequence '\.'
  iterm_re = re.compile("(.+)\.itermcolors$")
```

Since it's a double quoted string I strongly assume it has to be "\\.".

Fixed with this PR.