### PR TITLE
Add OSC-4-based "generic" theme format to support more terminal emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Alacritty color schemes](#alacritty-color-schemes)
   - [Ghostty color schemes](#ghostty-color-schemes)
   - [Termux color schemes](#termux-color-schemes)
+  - [Generic color schemes](#generic-color-schemes)
 
 ## Intro
 
@@ -2056,6 +2057,13 @@ Then specify the name of your theme in the `theme` field in the [config file](ht
 ### Termux color schemes
 
 Copy the theme content from `termux/` and paste the content to `~/.termux` directory as `~/.termux/colors.properties` file and run `termux-reload-settings` to apply the theme.
+
+### Generic color schemes
+
+These schemes work with any terminal emulator with support for the OSC 4 escape code (including the Linux console, GNOME Terminal, and more).
+
+Copy the shell script from `generic/` and paste the script to `~/bin/set-colors.sh`, or wherever you prefer to put shell scripts.
+Then add `bash ~/bin/set-colors.sh` to your shell's config file (`~/.bashrc`, `~/.zshrc`, etc).
 
 ### Previewing color schemes
 

--- a/generic/0x96f.sh
+++ b/generic/0x96f.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# 0x96f
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "26/24/27"
+put_template 1  "ff/72/72"
+put_template 2  "bc/df/59"
+put_template 3  "ff/ca/58"
+put_template 4  "49/ca/e4"
+put_template 5  "a0/93/e2"
+put_template 6  "ae/e8/f4"
+put_template 7  "fc/fc/fa"
+put_template 8  "54/54/52"
+put_template 9  "ff/87/87"
+put_template 10 "c6/e4/72"
+put_template 11 "ff/d2/71"
+put_template 12 "64/d2/e8"
+put_template 13 "ae/a3/e6"
+put_template 14 "ba/eb/f6"
+put_template 15 "fc/fc/fa"
+
+color_foreground="fc/fc/fa"
+color_background="26/24/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fcfcfa"
+  put_template_custom Ph "262427"
+  put_template_custom Pi "fcfcfa"
+  put_template_custom Pj "fcfcfa"
+  put_template_custom Pk "262427"
+  put_template_custom Pl "fcfcfa"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/12-bit Rainbow.sh
+++ b/generic/12-bit Rainbow.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# 12-bit Rainbow
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "a0/30/50"
+put_template 2  "40/d0/80"
+put_template 3  "e0/90/40"
+put_template 4  "30/60/b0"
+put_template 5  "60/30/90"
+put_template 6  "00/90/c0"
+put_template 7  "db/de/d8"
+put_template 8  "68/56/56"
+put_template 9  "c0/60/60"
+put_template 10 "90/d0/50"
+put_template 11 "e0/d0/00"
+put_template 12 "00/b0/c0"
+put_template 13 "80/10/70"
+put_template 14 "20/b0/c0"
+put_template 15 "ff/ff/ff"
+
+color_foreground="fe/ff/ff"
+color_background="04/04/04"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "feffff"
+  put_template_custom Ph "040404"
+  put_template_custom Pi "feffff"
+  put_template_custom Pj "606060"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "e0d000"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/3024 Day.sh
+++ b/generic/3024 Day.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# 3024 Day
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/03/00"
+put_template 1  "db/2d/20"
+put_template 2  "01/a2/52"
+put_template 3  "fd/ed/02"
+put_template 4  "01/a0/e4"
+put_template 5  "a1/6a/94"
+put_template 6  "b5/e4/f4"
+put_template 7  "a5/a2/a2"
+put_template 8  "5c/58/55"
+put_template 9  "e8/bb/d0"
+put_template 10 "3a/34/32"
+put_template 11 "4a/45/43"
+put_template 12 "80/7d/7c"
+put_template 13 "d6/d5/d4"
+put_template 14 "cd/ab/53"
+put_template 15 "f7/f7/f7"
+
+color_foreground="4a/45/43"
+color_background="f7/f7/f7"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "4a4543"
+  put_template_custom Ph "f7f7f7"
+  put_template_custom Pi "4a4543"
+  put_template_custom Pj "a5a2a2"
+  put_template_custom Pk "4a4543"
+  put_template_custom Pl "4a4543"
+  put_template_custom Pm "f7f7f7"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/3024 Night.sh
+++ b/generic/3024 Night.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# 3024 Night
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/03/00"
+put_template 1  "db/2d/20"
+put_template 2  "01/a2/52"
+put_template 3  "fd/ed/02"
+put_template 4  "01/a0/e4"
+put_template 5  "a1/6a/94"
+put_template 6  "b5/e4/f4"
+put_template 7  "a5/a2/a2"
+put_template 8  "5c/58/55"
+put_template 9  "e8/bb/d0"
+put_template 10 "3a/34/32"
+put_template 11 "4a/45/43"
+put_template 12 "80/7d/7c"
+put_template 13 "d6/d5/d4"
+put_template 14 "cd/ab/53"
+put_template 15 "f7/f7/f7"
+
+color_foreground="a5/a2/a2"
+color_background="09/03/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a5a2a2"
+  put_template_custom Ph "090300"
+  put_template_custom Pi "a5a2a2"
+  put_template_custom Pj "4a4543"
+  put_template_custom Pk "a5a2a2"
+  put_template_custom Pl "a5a2a2"
+  put_template_custom Pm "090300"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Aardvark Blue.sh
+++ b/generic/Aardvark Blue.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Aardvark Blue
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/19/19"
+put_template 1  "aa/34/2e"
+put_template 2  "4b/8c/0f"
+put_template 3  "db/ba/00"
+put_template 4  "13/70/d3"
+put_template 5  "c4/3a/c3"
+put_template 6  "00/8e/b0"
+put_template 7  "be/be/be"
+put_template 8  "45/45/45"
+put_template 9  "f0/5b/50"
+put_template 10 "95/dc/55"
+put_template 11 "ff/e7/63"
+put_template 12 "60/a4/ec"
+put_template 13 "e2/6b/e2"
+put_template 14 "60/b6/cb"
+put_template 15 "f7/f7/f7"
+
+color_foreground="dd/dd/dd"
+color_background="10/20/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dddddd"
+  put_template_custom Ph "102040"
+  put_template_custom Pi "f7f7f7"
+  put_template_custom Pj "bfdbfe"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "007acc"
+  put_template_custom Pm "bfdbfe"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Abernathy.sh
+++ b/generic/Abernathy.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Abernathy
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cd/00/00"
+put_template 2  "00/cd/00"
+put_template 3  "cd/cd/00"
+put_template 4  "10/93/f5"
+put_template 5  "cd/00/cd"
+put_template 6  "00/cd/cd"
+put_template 7  "fa/eb/d7"
+put_template 8  "40/40/40"
+put_template 9  "ff/00/00"
+put_template 10 "00/ff/00"
+put_template 11 "ff/ff/00"
+put_template 12 "11/b5/f6"
+put_template 13 "ff/00/ff"
+put_template 14 "00/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ee/ee/ec"
+color_background="11/14/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eeeeec"
+  put_template_custom Ph "111416"
+  put_template_custom Pi "abb2bf"
+  put_template_custom Pj "eeeeec"
+  put_template_custom Pk "333333"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Adventure.sh
+++ b/generic/Adventure.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Adventure
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "04/04/04"
+put_template 1  "d8/4a/33"
+put_template 2  "5d/a6/02"
+put_template 3  "ee/bb/6e"
+put_template 4  "41/7a/b3"
+put_template 5  "e5/c4/99"
+put_template 6  "bd/cf/e5"
+put_template 7  "db/de/d8"
+put_template 8  "68/56/56"
+put_template 9  "d7/6b/42"
+put_template 10 "99/b5/2c"
+put_template 11 "ff/b6/70"
+put_template 12 "97/d7/ef"
+put_template 13 "aa/79/00"
+put_template 14 "bd/cf/e5"
+put_template 15 "e4/d5/c7"
+
+color_foreground="fe/ff/ff"
+color_background="04/04/04"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "feffff"
+  put_template_custom Ph "040404"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "606060"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "feffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/AdventureTime.sh
+++ b/generic/AdventureTime.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# AdventureTime
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "05/04/04"
+put_template 1  "bd/00/13"
+put_template 2  "4a/b1/18"
+put_template 3  "e7/74/1e"
+put_template 4  "0f/4a/c6"
+put_template 5  "66/59/93"
+put_template 6  "70/a5/98"
+put_template 7  "f8/dc/c0"
+put_template 8  "4e/7c/bf"
+put_template 9  "fc/5f/5a"
+put_template 10 "9e/ff/6e"
+put_template 11 "ef/c1/1a"
+put_template 12 "19/97/c6"
+put_template 13 "9b/59/53"
+put_template 14 "c8/fa/f4"
+put_template 15 "f6/f5/fb"
+
+color_foreground="f8/dc/c0"
+color_background="1f/1d/45"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8dcc0"
+  put_template_custom Ph "1f1d45"
+  put_template_custom Pi "bd0013"
+  put_template_custom Pj "706b4e"
+  put_template_custom Pk "f3d9c4"
+  put_template_custom Pl "efbf38"
+  put_template_custom Pm "08080a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Adwaita Dark.sh
+++ b/generic/Adwaita Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Adwaita Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/1f/31"
+put_template 1  "c0/1c/28"
+put_template 2  "2e/c2/7e"
+put_template 3  "f5/c2/11"
+put_template 4  "1e/78/e4"
+put_template 5  "98/41/bb"
+put_template 6  "0a/b9/dc"
+put_template 7  "c0/bf/bc"
+put_template 8  "5e/5c/64"
+put_template 9  "ed/33/3b"
+put_template 10 "57/e3/89"
+put_template 11 "f8/e4/5c"
+put_template 12 "51/a1/ff"
+put_template 13 "c0/61/cb"
+put_template 14 "4f/d2/fd"
+put_template 15 "f6/f5/f4"
+
+color_foreground="ff/ff/ff"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "5e5c64"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "1e1e1e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Adwaita.sh
+++ b/generic/Adwaita.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Adwaita
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/1f/31"
+put_template 1  "c0/1c/28"
+put_template 2  "2e/c2/7e"
+put_template 3  "f5/c2/11"
+put_template 4  "1e/78/e4"
+put_template 5  "98/41/bb"
+put_template 6  "0a/b9/dc"
+put_template 7  "c0/bf/bc"
+put_template 8  "5e/5c/64"
+put_template 9  "ed/33/3b"
+put_template 10 "57/e3/89"
+put_template 11 "f8/e4/5c"
+put_template 12 "51/a1/ff"
+put_template 13 "c0/61/cb"
+put_template 14 "4f/d2/fd"
+put_template 15 "f6/f5/f4"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c0bfbc"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Afterglow.sh
+++ b/generic/Afterglow.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Afterglow
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/15/15"
+put_template 1  "ac/41/42"
+put_template 2  "7e/8e/50"
+put_template 3  "e5/b5/67"
+put_template 4  "6c/99/bb"
+put_template 5  "9f/4e/85"
+put_template 6  "7d/d6/cf"
+put_template 7  "d0/d0/d0"
+put_template 8  "50/50/50"
+put_template 9  "ac/41/42"
+put_template 10 "7e/8e/50"
+put_template 11 "e5/b5/67"
+put_template 12 "6c/99/bb"
+put_template 13 "9f/4e/85"
+put_template 14 "7d/d6/cf"
+put_template 15 "f5/f5/f5"
+
+color_foreground="d0/d0/d0"
+color_background="21/21/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d0d0d0"
+  put_template_custom Ph "212121"
+  put_template_custom Pi "d0d0d0"
+  put_template_custom Pj "303030"
+  put_template_custom Pk "d0d0d0"
+  put_template_custom Pl "d0d0d0"
+  put_template_custom Pm "151515"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Alabaster.sh
+++ b/generic/Alabaster.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Alabaster
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "aa/37/31"
+put_template 2  "44/8c/27"
+put_template 3  "cb/90/00"
+put_template 4  "32/5c/c0"
+put_template 5  "7a/3e/9d"
+put_template 6  "00/83/b2"
+put_template 7  "f7/f7/f7"
+put_template 8  "77/77/77"
+put_template 9  "f0/50/50"
+put_template 10 "60/cb/00"
+put_template 11 "ff/bc/5d"
+put_template 12 "00/7a/cc"
+put_template 13 "e6/4c/e6"
+put_template 14 "00/aa/cb"
+put_template 15 "f7/f7/f7"
+
+color_foreground="00/00/00"
+color_background="f7/f7/f7"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "f7f7f7"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "bfdbfe"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "007acc"
+  put_template_custom Pm "bfdbfe"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/AlienBlood.sh
+++ b/generic/AlienBlood.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# AlienBlood
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "11/26/16"
+put_template 1  "7f/2b/27"
+put_template 2  "2f/7e/25"
+put_template 3  "71/7f/24"
+put_template 4  "2f/6a/7f"
+put_template 5  "47/58/7f"
+put_template 6  "32/7f/77"
+put_template 7  "64/7d/75"
+put_template 8  "3c/48/12"
+put_template 9  "e0/80/09"
+put_template 10 "18/e0/00"
+put_template 11 "bd/e0/00"
+put_template 12 "00/aa/e0"
+put_template 13 "00/58/e0"
+put_template 14 "00/e0/c4"
+put_template 15 "73/fa/91"
+
+color_foreground="63/7d/75"
+color_background="0f/16/10"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "637d75"
+  put_template_custom Ph "0f1610"
+  put_template_custom Pi "7afa87"
+  put_template_custom Pj "1d4125"
+  put_template_custom Pk "73fa91"
+  put_template_custom Pl "73fa91"
+  put_template_custom Pm "0f1610"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Andromeda.sh
+++ b/generic/Andromeda.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Andromeda
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cd/31/31"
+put_template 2  "05/bc/79"
+put_template 3  "e5/e5/12"
+put_template 4  "24/72/c8"
+put_template 5  "bc/3f/bc"
+put_template 6  "0f/a8/cd"
+put_template 7  "e5/e5/e5"
+put_template 8  "66/66/66"
+put_template 9  "cd/31/31"
+put_template 10 "05/bc/79"
+put_template 11 "e5/e5/12"
+put_template 12 "24/72/c8"
+put_template 13 "bc/3f/bc"
+put_template 14 "0f/a8/cd"
+put_template 15 "e5/e5/e5"
+
+color_foreground="e5/e5/e5"
+color_background="26/2a/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e5e5e5"
+  put_template_custom Ph "262a33"
+  put_template_custom Pi "e5e5e5"
+  put_template_custom Pj "5a5c62"
+  put_template_custom Pk "ece7e7"
+  put_template_custom Pl "f8f8f0"
+  put_template_custom Pm "cfcfc2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Apple Classic.sh
+++ b/generic/Apple Classic.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Apple Classic
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c9/1b/00"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "02/25/c7"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d5/a2/00"
+color_background="2c/2b/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d5a200"
+  put_template_custom Ph "2c2b2b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "6b5b02"
+  put_template_custom Pk "67e000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Apple System Colors Light.sh
+++ b/generic/Apple System Colors Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Apple System Colors Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/1a/1a"
+put_template 1  "bc/44/37"
+put_template 2  "51/a1/48"
+put_template 3  "c7/ad/3a"
+put_template 4  "2e/68/c5"
+put_template 5  "8c/4b/b8"
+put_template 6  "5e/9c/be"
+put_template 7  "98/98/9d"
+put_template 8  "46/46/46"
+put_template 9  "eb/55/45"
+put_template 10 "6b/d4/5f"
+put_template 11 "f8/d8/4a"
+put_template 12 "3b/82/f7"
+put_template 13 "b2/60/ea"
+put_template 14 "8d/d3/fb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="fe/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "feffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "b4d7ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "98989d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Apple System Colors.sh
+++ b/generic/Apple System Colors.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Apple System Colors
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/1a/1a"
+put_template 1  "cc/37/2e"
+put_template 2  "26/a4/39"
+put_template 3  "cd/ac/08"
+put_template 4  "08/69/cb"
+put_template 5  "96/47/bf"
+put_template 6  "47/9e/c2"
+put_template 7  "98/98/9d"
+put_template 8  "46/46/46"
+put_template 9  "ff/45/3a"
+put_template 10 "32/d7/4b"
+put_template 11 "ff/d6/0a"
+put_template 12 "0a/84/ff"
+put_template 13 "bf/5a/f2"
+put_template 14 "76/d6/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3f638b"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "98989d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ardoise.sh
+++ b/generic/Ardoise.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ardoise
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2c/2c/2c"
+put_template 1  "d3/32/2d"
+put_template 2  "58/8b/35"
+put_template 3  "fc/a9/3a"
+put_template 4  "24/65/c2"
+put_template 5  "73/32/b4"
+put_template 6  "64/e1/b8"
+put_template 7  "f7/f7/f7"
+put_template 8  "53/53/53"
+put_template 9  "fa/58/52"
+put_template 10 "8d/c2/52"
+put_template 11 "ff/ea/51"
+put_template 12 "6a/b5/f8"
+put_template 13 "be/68/ca"
+put_template 14 "89/ff/db"
+put_template 15 "fe/fe/fe"
+
+color_foreground="ea/ea/ea"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eaeaea"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "46515e"
+  put_template_custom Pk "f1f3f5"
+  put_template_custom Pl "f7f7f7"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Argonaut.sh
+++ b/generic/Argonaut.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Argonaut
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "23/23/23"
+put_template 1  "ff/00/0f"
+put_template 2  "8c/e1/0b"
+put_template 3  "ff/b9/00"
+put_template 4  "00/8d/f8"
+put_template 5  "6d/43/a6"
+put_template 6  "00/d8/eb"
+put_template 7  "ff/ff/ff"
+put_template 8  "44/44/44"
+put_template 9  "ff/27/40"
+put_template 10 "ab/e1/5b"
+put_template 11 "ff/d2/42"
+put_template 12 "00/92/ff"
+put_template 13 "9a/5f/eb"
+put_template 14 "67/ff/f0"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/fa/f4"
+color_background="0e/10/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fffaf4"
+  put_template_custom Ph "0e1019"
+  put_template_custom Pi "9e9c9a"
+  put_template_custom Pj "002a3b"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ff0018"
+  put_template_custom Pm "ff0018"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Arthur.sh
+++ b/generic/Arthur.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Arthur
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3d/35/2a"
+put_template 1  "cd/5c/5c"
+put_template 2  "86/af/80"
+put_template 3  "e8/ae/5b"
+put_template 4  "64/95/ed"
+put_template 5  "de/b8/87"
+put_template 6  "b0/c4/de"
+put_template 7  "bb/aa/99"
+put_template 8  "55/44/44"
+put_template 9  "cc/55/33"
+put_template 10 "88/aa/22"
+put_template 11 "ff/a7/5d"
+put_template 12 "87/ce/eb"
+put_template 13 "99/66/00"
+put_template 14 "b0/c4/de"
+put_template 15 "dd/cc/bb"
+
+color_foreground="dd/ee/dd"
+color_background="1c/1c/1c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ddeedd"
+  put_template_custom Ph "1c1c1c"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "e2bbef"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/AtelierSulphurpool.sh
+++ b/generic/AtelierSulphurpool.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# AtelierSulphurpool
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "20/27/46"
+put_template 1  "c9/49/22"
+put_template 2  "ac/97/39"
+put_template 3  "c0/8b/30"
+put_template 4  "3d/8f/d1"
+put_template 5  "66/79/cc"
+put_template 6  "22/a2/c9"
+put_template 7  "97/9d/b4"
+put_template 8  "6b/73/94"
+put_template 9  "c7/6b/29"
+put_template 10 "29/32/56"
+put_template 11 "5e/66/87"
+put_template 12 "89/8e/a4"
+put_template 13 "df/e2/f1"
+put_template 14 "9c/63/7a"
+put_template 15 "f5/f7/ff"
+
+color_foreground="97/9d/b4"
+color_background="20/27/46"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "979db4"
+  put_template_custom Ph "202746"
+  put_template_custom Pi "979db4"
+  put_template_custom Pj "5e6687"
+  put_template_custom Pk "979db4"
+  put_template_custom Pl "979db4"
+  put_template_custom Pm "202746"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Atom.sh
+++ b/generic/Atom.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Atom
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fd/5f/f1"
+put_template 2  "87/c3/8a"
+put_template 3  "ff/d7/b1"
+put_template 4  "85/be/fd"
+put_template 5  "b9/b6/fc"
+put_template 6  "85/be/fd"
+put_template 7  "e0/e0/e0"
+put_template 8  "00/00/00"
+put_template 9  "fd/5f/f1"
+put_template 10 "94/fa/36"
+put_template 11 "f5/ff/a8"
+put_template 12 "96/cb/fe"
+put_template 13 "b9/b6/fc"
+put_template 14 "85/be/fd"
+put_template 15 "e0/e0/e0"
+
+color_foreground="c5/c8/c6"
+color_background="16/17/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c5c8c6"
+  put_template_custom Ph "161719"
+  put_template_custom Pi "c5c8c6"
+  put_template_custom Pj "444444"
+  put_template_custom Pk "c5c8c6"
+  put_template_custom Pl "d0d0d0"
+  put_template_custom Pm "151515"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/AtomOneDark.sh
+++ b/generic/AtomOneDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# AtomOneDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/25/2b"
+put_template 1  "e0/6c/75"
+put_template 2  "98/c3/79"
+put_template 3  "e5/c0/7b"
+put_template 4  "61/af/ef"
+put_template 5  "c6/78/dd"
+put_template 6  "56/b6/c2"
+put_template 7  "ab/b2/bf"
+put_template 8  "76/76/76"
+put_template 9  "e0/6c/75"
+put_template 10 "98/c3/79"
+put_template 11 "e5/c0/7b"
+put_template 12 "61/af/ef"
+put_template 13 "c6/78/dd"
+put_template 14 "56/b6/c2"
+put_template 15 "ab/b2/bf"
+
+color_foreground="ab/b2/bf"
+color_background="21/25/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "abb2bf"
+  put_template_custom Ph "21252b"
+  put_template_custom Pi "abb2bf"
+  put_template_custom Pj "323844"
+  put_template_custom Pk "abb2bf"
+  put_template_custom Pl "abb2bf"
+  put_template_custom Pm "abb2bf"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/AtomOneLight.sh
+++ b/generic/AtomOneLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# AtomOneLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "de/3e/35"
+put_template 2  "3f/95/3a"
+put_template 3  "d2/b6/7c"
+put_template 4  "2f/5a/f3"
+put_template 5  "95/00/95"
+put_template 6  "3f/95/3a"
+put_template 7  "bb/bb/bb"
+put_template 8  "00/00/00"
+put_template 9  "de/3e/35"
+put_template 10 "3f/95/3a"
+put_template 11 "d2/b6/7c"
+put_template 12 "2f/5a/f3"
+put_template 13 "a0/00/95"
+put_template 14 "3f/95/3a"
+put_template 15 "ff/ff/ff"
+
+color_foreground="2a/2c/33"
+color_background="f9/f9/f9"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "2a2c33"
+  put_template_custom Ph "f9f9f9"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "ededed"
+  put_template_custom Pk "2a2c33"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Aura.sh
+++ b/generic/Aura.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Aura
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "11/0f/18"
+put_template 1  "ff/67/67"
+put_template 2  "61/ff/ca"
+put_template 3  "ff/ca/85"
+put_template 4  "a2/77/ff"
+put_template 5  "a2/77/ff"
+put_template 6  "61/ff/ca"
+put_template 7  "ed/ec/ee"
+put_template 8  "4d/4d/4d"
+put_template 9  "ff/ca/85"
+put_template 10 "a2/77/ff"
+put_template 11 "ff/ca/85"
+put_template 12 "a2/77/ff"
+put_template 13 "a2/77/ff"
+put_template 14 "61/ff/ca"
+put_template 15 "ed/ec/ee"
+
+color_foreground="ed/ec/ee"
+color_background="15/14/1b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "edecee"
+  put_template_custom Ph "15141b"
+  put_template_custom Pi "edecee"
+  put_template_custom Pj "a277ff"
+  put_template_custom Pk "edecee"
+  put_template_custom Pl "a277ff"
+  put_template_custom Pm "edecee"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Aurora.sh
+++ b/generic/Aurora.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Aurora
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "23/26/2e"
+put_template 1  "f0/26/6f"
+put_template 2  "8f/d4/6d"
+put_template 3  "ff/e6/6d"
+put_template 4  "03/21/d7"
+put_template 5  "ee/5d/43"
+put_template 6  "03/d6/b8"
+put_template 7  "c7/4d/ed"
+put_template 8  "29/2e/38"
+put_template 9  "f9/26/72"
+put_template 10 "8f/d4/6d"
+put_template 11 "ff/e6/6d"
+put_template 12 "03/d6/b8"
+put_template 13 "ee/5d/43"
+put_template 14 "03/d6/b8"
+put_template 15 "c7/4d/ed"
+
+color_foreground="ff/ca/28"
+color_background="23/26/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffca28"
+  put_template_custom Ph "23262e"
+  put_template_custom Pi "fbfbff"
+  put_template_custom Pj "292e38"
+  put_template_custom Pk "00e8c6"
+  put_template_custom Pl "ee5d43"
+  put_template_custom Pm "ffd29c"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ayu Mirage.sh
+++ b/generic/Ayu Mirage.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ayu Mirage
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/1e/2a"
+put_template 1  "ed/82/74"
+put_template 2  "a6/cc/70"
+put_template 3  "fa/d0/7b"
+put_template 4  "6d/cb/fa"
+put_template 5  "cf/ba/fa"
+put_template 6  "90/e1/c6"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "f2/87/79"
+put_template 10 "ba/e6/7e"
+put_template 11 "ff/d5/80"
+put_template 12 "73/d0/ff"
+put_template 13 "d4/bf/ff"
+put_template 14 "95/e6/cb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cb/cc/c6"
+color_background="1f/24/30"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cbccc6"
+  put_template_custom Ph "1f2430"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "33415e"
+  put_template_custom Pk "cbccc6"
+  put_template_custom Pl "ffcc66"
+  put_template_custom Pm "1f2430"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Banana Blueberry.sh
+++ b/generic/Banana Blueberry.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Banana Blueberry
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "17/14/1f"
+put_template 1  "ff/6b/7f"
+put_template 2  "00/bd/9c"
+put_template 3  "e6/c6/2f"
+put_template 4  "22/e8/df"
+put_template 5  "dc/39/6a"
+put_template 6  "56/b6/c2"
+put_template 7  "f1/f1/f1"
+put_template 8  "49/51/62"
+put_template 9  "fe/9e/a1"
+put_template 10 "98/c3/79"
+put_template 11 "f9/e4/6b"
+put_template 12 "91/ff/f4"
+put_template 13 "da/70/d6"
+put_template 14 "bc/f3/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cc/cc/cc"
+color_background="19/13/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cccccc"
+  put_template_custom Ph "191323"
+  put_template_custom Pi "00bbc3"
+  put_template_custom Pj "220525"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "e07d13"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Batman.sh
+++ b/generic/Batman.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Batman
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/1e"
+put_template 1  "e6/dc/44"
+put_template 2  "c8/be/46"
+put_template 3  "f4/fd/22"
+put_template 4  "73/71/74"
+put_template 5  "74/72/71"
+put_template 6  "62/60/5f"
+put_template 7  "c6/c5/bf"
+put_template 8  "50/53/54"
+put_template 9  "ff/f7/8e"
+put_template 10 "ff/f2/7d"
+put_template 11 "fe/ed/6c"
+put_template 12 "91/94/95"
+put_template 13 "9a/9a/9d"
+put_template 14 "a3/a3/a6"
+put_template 15 "da/db/d6"
+
+color_foreground="6f/6f/6f"
+color_background="1b/1d/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "6f6f6f"
+  put_template_custom Ph "1b1d1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d504c"
+  put_template_custom Pk "f0e04a"
+  put_template_custom Pl "fcef0c"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Belafonte Day.sh
+++ b/generic/Belafonte Day.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Belafonte Day
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "20/11/1b"
+put_template 1  "be/10/0e"
+put_template 2  "85/81/62"
+put_template 3  "ea/a5/49"
+put_template 4  "42/6a/79"
+put_template 5  "97/52/2c"
+put_template 6  "98/9a/9c"
+put_template 7  "96/8c/83"
+put_template 8  "5e/52/52"
+put_template 9  "be/10/0e"
+put_template 10 "85/81/62"
+put_template 11 "ea/a5/49"
+put_template 12 "42/6a/79"
+put_template 13 "97/52/2c"
+put_template 14 "98/9a/9c"
+put_template 15 "d5/cc/ba"
+
+color_foreground="45/37/3c"
+color_background="d5/cc/ba"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "45373c"
+  put_template_custom Ph "d5ccba"
+  put_template_custom Pi "45373c"
+  put_template_custom Pj "968c83"
+  put_template_custom Pk "45373c"
+  put_template_custom Pl "45373c"
+  put_template_custom Pm "d5ccba"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Belafonte Night.sh
+++ b/generic/Belafonte Night.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Belafonte Night
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "20/11/1b"
+put_template 1  "be/10/0e"
+put_template 2  "85/81/62"
+put_template 3  "ea/a5/49"
+put_template 4  "42/6a/79"
+put_template 5  "97/52/2c"
+put_template 6  "98/9a/9c"
+put_template 7  "96/8c/83"
+put_template 8  "5e/52/52"
+put_template 9  "be/10/0e"
+put_template 10 "85/81/62"
+put_template 11 "ea/a5/49"
+put_template 12 "42/6a/79"
+put_template 13 "97/52/2c"
+put_template 14 "98/9a/9c"
+put_template 15 "d5/cc/ba"
+
+color_foreground="96/8c/83"
+color_background="20/11/1b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "968c83"
+  put_template_custom Ph "20111b"
+  put_template_custom Pi "968c83"
+  put_template_custom Pj "45373c"
+  put_template_custom Pk "968c83"
+  put_template_custom Pl "968c83"
+  put_template_custom Pm "20111b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/BirdsOfParadise.sh
+++ b/generic/BirdsOfParadise.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# BirdsOfParadise
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "57/3d/26"
+put_template 1  "be/2d/26"
+put_template 2  "6b/a1/8a"
+put_template 3  "e9/9d/2a"
+put_template 4  "5a/86/ad"
+put_template 5  "ac/80/a6"
+put_template 6  "74/a6/ad"
+put_template 7  "e0/db/b7"
+put_template 8  "9b/6c/4a"
+put_template 9  "e8/46/27"
+put_template 10 "95/d8/ba"
+put_template 11 "d0/d1/50"
+put_template 12 "b8/d3/ed"
+put_template 13 "d1/9e/cb"
+put_template 14 "93/cf/d7"
+put_template 15 "ff/f9/d5"
+
+color_foreground="e0/db/b7"
+color_background="2a/1f/1d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e0dbb7"
+  put_template_custom Ph "2a1f1d"
+  put_template_custom Pi "fff8d8"
+  put_template_custom Pj "563c27"
+  put_template_custom Pk "e0dbbb"
+  put_template_custom Pl "573d26"
+  put_template_custom Pm "573d26"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Bathory).sh
+++ b/generic/Black Metal (Bathory).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Bathory)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "fb/cb/97"
+put_template 3  "e7/8a/53"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "fb/cb/97"
+put_template 11 "e7/8a/53"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Burzum).sh
+++ b/generic/Black Metal (Burzum).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Burzum)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "dd/ee/cc"
+put_template 3  "99/bb/aa"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "dd/ee/cc"
+put_template 11 "99/bb/aa"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Dark Funeral).sh
+++ b/generic/Black Metal (Dark Funeral).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Dark Funeral)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "d0/df/ee"
+put_template 3  "5f/81/a5"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "d0/df/ee"
+put_template 11 "5f/81/a5"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Gorgoroth).sh
+++ b/generic/Black Metal (Gorgoroth).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Gorgoroth)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "9b/8d/7f"
+put_template 3  "8c/7f/70"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "9b/8d/7f"
+put_template 11 "8c/7f/70"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Immortal).sh
+++ b/generic/Black Metal (Immortal).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Immortal)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "77/99/bb"
+put_template 3  "55/66/77"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "77/99/bb"
+put_template 11 "55/66/77"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Khold).sh
+++ b/generic/Black Metal (Khold).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Khold)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "ec/ee/e3"
+put_template 3  "97/4b/46"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "ec/ee/e3"
+put_template 11 "97/4b/46"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Marduk).sh
+++ b/generic/Black Metal (Marduk).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Marduk)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "a5/aa/a7"
+put_template 3  "62/6b/67"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "a5/aa/a7"
+put_template 11 "62/6b/67"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Mayhem).sh
+++ b/generic/Black Metal (Mayhem).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Mayhem)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "f3/ec/d4"
+put_template 3  "ee/cc/6c"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "f3/ec/d4"
+put_template 11 "ee/cc/6c"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Nile).sh
+++ b/generic/Black Metal (Nile).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Nile)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "aa/99/88"
+put_template 3  "77/77/55"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "aa/99/88"
+put_template 11 "77/77/55"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal (Venom).sh
+++ b/generic/Black Metal (Venom).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal (Venom)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "5f/87/87"
+put_template 2  "f8/f7/f2"
+put_template 3  "79/24/1f"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "5f/87/87"
+put_template 10 "f8/f7/f2"
+put_template 11 "79/24/1f"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Black Metal.sh
+++ b/generic/Black Metal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Black Metal
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "48/6e/6f"
+put_template 2  "dd/99/99"
+put_template 3  "a0/66/66"
+put_template 4  "88/88/88"
+put_template 5  "99/99/99"
+put_template 6  "aa/aa/aa"
+put_template 7  "c1/c1/c1"
+put_template 8  "33/33/33"
+put_template 9  "48/6e/6f"
+put_template 10 "dd/99/99"
+put_template 11 "a0/66/66"
+put_template 12 "88/88/88"
+put_template 13 "99/99/99"
+put_template 14 "aa/aa/aa"
+put_template 15 "c1/c1/c1"
+
+color_foreground="c1/c1/c1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "c1c1c1"
+  put_template_custom Pj "c1c1c1"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "c1c1c1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Blazer.sh
+++ b/generic/Blazer.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Blazer
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b8/7a/7a"
+put_template 2  "7a/b8/7a"
+put_template 3  "b8/b8/7a"
+put_template 4  "7a/7a/b8"
+put_template 5  "b8/7a/b8"
+put_template 6  "7a/b8/b8"
+put_template 7  "d9/d9/d9"
+put_template 8  "26/26/26"
+put_template 9  "db/bd/bd"
+put_template 10 "bd/db/bd"
+put_template 11 "db/db/bd"
+put_template 12 "bd/bd/db"
+put_template 13 "db/bd/db"
+put_template 14 "bd/db/db"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d9/e6/f2"
+color_background="0d/19/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d9e6f2"
+  put_template_custom Ph "0d1926"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1ddff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "d9e6f2"
+  put_template_custom Pm "0d1926"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Blue Matrix.sh
+++ b/generic/Blue Matrix.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Blue Matrix
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/11/16"
+put_template 1  "ff/56/80"
+put_template 2  "00/ff/9c"
+put_template 3  "ff/fc/58"
+put_template 4  "00/b0/ff"
+put_template 5  "d5/7b/ff"
+put_template 6  "76/c1/ff"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "d6/82/ec"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/a2/ff"
+color_background="10/11/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "00a2ff"
+  put_template_custom Ph "101116"
+  put_template_custom Pi "00ffc8"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "76ff9f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/BlueBerryPie.sh
+++ b/generic/BlueBerryPie.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# BlueBerryPie
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0a/4c/62"
+put_template 1  "99/24/6e"
+put_template 2  "5c/b1/b3"
+put_template 3  "ea/b9/a8"
+put_template 4  "90/a5/bd"
+put_template 5  "9d/54/a7"
+put_template 6  "7e/83/cc"
+put_template 7  "f0/e8/d6"
+put_template 8  "20/16/37"
+put_template 9  "c8/72/72"
+put_template 10 "0a/6c/7e"
+put_template 11 "7a/31/88"
+put_template 12 "39/17/3d"
+put_template 13 "bc/94/b7"
+put_template 14 "5e/60/71"
+put_template 15 "0a/6c/7e"
+
+color_foreground="ba/ba/b9"
+color_background="1c/0c/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "babab9"
+  put_template_custom Ph "1c0c28"
+  put_template_custom Pi "eaeaea"
+  put_template_custom Pj "606060"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fcfad6"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/BlueDolphin.sh
+++ b/generic/BlueDolphin.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# BlueDolphin
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "29/2d/3e"
+put_template 1  "ff/82/88"
+put_template 2  "b4/e8/8d"
+put_template 3  "f4/d6/9f"
+put_template 4  "82/aa/ff"
+put_template 5  "e9/c1/ff"
+put_template 6  "89/eb/ff"
+put_template 7  "d0/d0/d0"
+put_template 8  "43/47/58"
+put_template 9  "ff/8b/92"
+put_template 10 "dd/ff/a7"
+put_template 11 "ff/e5/85"
+put_template 12 "9c/c4/ff"
+put_template 13 "dd/b0/f6"
+put_template 14 "a3/f7/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c5/f2/ff"
+color_background="00/69/84"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c5f2ff"
+  put_template_custom Ph "006984"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "2baeca"
+  put_template_custom Pk "eceff1"
+  put_template_custom Pl "ffcc00"
+  put_template_custom Pm "292d3e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/BlulocoDark.sh
+++ b/generic/BlulocoDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# BlulocoDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "41/44/4d"
+put_template 1  "fc/2f/52"
+put_template 2  "25/a4/5c"
+put_template 3  "ff/93/6a"
+put_template 4  "34/76/ff"
+put_template 5  "7a/82/da"
+put_template 6  "44/83/aa"
+put_template 7  "cd/d4/e0"
+put_template 8  "8f/9a/ae"
+put_template 9  "ff/64/80"
+put_template 10 "3f/c5/6b"
+put_template 11 "f9/c8/59"
+put_template 12 "10/b1/fe"
+put_template 13 "ff/78/f8"
+put_template 14 "5f/b9/bc"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b9/c0/cb"
+color_background="28/2c/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b9c0cb"
+  put_template_custom Ph "282c34"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b9c0ca"
+  put_template_custom Pk "272b33"
+  put_template_custom Pl "ffcc00"
+  put_template_custom Pm "282c34"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/BlulocoLight.sh
+++ b/generic/BlulocoLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# BlulocoLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "37/3a/41"
+put_template 1  "d5/27/53"
+put_template 2  "23/97/4a"
+put_template 3  "df/63/1c"
+put_template 4  "27/5f/e4"
+put_template 5  "82/3f/f1"
+put_template 6  "27/61/8d"
+put_template 7  "ba/bb/c2"
+put_template 8  "67/6a/77"
+put_template 9  "ff/64/80"
+put_template 10 "3c/bc/66"
+put_template 11 "c5/a3/32"
+put_template 12 "00/99/e1"
+put_template 13 "ce/33/c0"
+put_template 14 "6d/93/bb"
+put_template 15 "d3/d3/d3"
+
+color_foreground="37/3a/41"
+color_background="f9/f9/f9"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "373a41"
+  put_template_custom Ph "f9f9f9"
+  put_template_custom Pi "383a42"
+  put_template_custom Pj "daf0ff"
+  put_template_custom Pk "373a41"
+  put_template_custom Pl "f32759"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Borland.sh
+++ b/generic/Borland.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Borland
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4f/4f/4f"
+put_template 1  "ff/6c/60"
+put_template 2  "a8/ff/60"
+put_template 3  "ff/ff/b6"
+put_template 4  "96/cb/fe"
+put_template 5  "ff/73/fd"
+put_template 6  "c6/c5/fe"
+put_template 7  "ee/ee/ee"
+put_template 8  "7c/7c/7c"
+put_template 9  "ff/b6/b0"
+put_template 10 "ce/ff/ac"
+put_template 11 "ff/ff/cc"
+put_template 12 "b5/dc/ff"
+put_template 13 "ff/9c/fe"
+put_template 14 "df/df/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/4e"
+color_background="00/00/a4"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffff4e"
+  put_template_custom Ph "0000a4"
+  put_template_custom Pi "ffff4e"
+  put_template_custom Pj "a4a4a4"
+  put_template_custom Pk "0000a4"
+  put_template_custom Pl "ffa560"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Box.sh
+++ b/generic/Box.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Box
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/04/03"
+put_template 2  "19/cb/00"
+put_template 3  "ce/cb/00"
+put_template 4  "0d/73/cc"
+put_template 5  "cb/1e/d1"
+put_template 6  "0d/cd/cd"
+put_template 7  "dd/dd/dd"
+put_template 8  "76/76/76"
+put_template 9  "f2/20/1f"
+put_template 10 "23/fd/00"
+put_template 11 "ff/fd/00"
+put_template 12 "1a/8f/ff"
+put_template 13 "fd/28/ff"
+put_template 14 "14/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="9f/ef/00"
+color_background="14/1d/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "9fef00"
+  put_template_custom Ph "141d2b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "a4b1cd"
+  put_template_custom Pk "141d2b"
+  put_template_custom Pl "9fef00"
+  put_template_custom Pm "111111"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Breeze.sh
+++ b/generic/Breeze.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Breeze
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "31/36/3b"
+put_template 1  "ed/15/15"
+put_template 2  "11/d1/16"
+put_template 3  "f6/74/00"
+put_template 4  "1d/99/f3"
+put_template 5  "9b/59/b6"
+put_template 6  "1a/bc/9c"
+put_template 7  "ef/f0/f1"
+put_template 8  "7f/8c/8d"
+put_template 9  "c0/39/2b"
+put_template 10 "1c/dc/9a"
+put_template 11 "fd/bc/4b"
+put_template 12 "3d/ae/e9"
+put_template 13 "8e/44/ad"
+put_template 14 "16/a0/85"
+put_template 15 "fc/fc/fc"
+
+color_foreground="ef/f0/f1"
+color_background="31/36/3b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eff0f1"
+  put_template_custom Ph "31363b"
+  put_template_custom Pi "fcfcfc"
+  put_template_custom Pj "eff0f1"
+  put_template_custom Pk "31363b"
+  put_template_custom Pl "eff0f1"
+  put_template_custom Pm "31363b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Bright Lights.sh
+++ b/generic/Bright Lights.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Bright Lights
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/19/19"
+put_template 1  "ff/35/5b"
+put_template 2  "b7/e8/76"
+put_template 3  "ff/c2/51"
+put_template 4  "76/d4/ff"
+put_template 5  "ba/76/e7"
+put_template 6  "6c/bf/b5"
+put_template 7  "c2/c8/d7"
+put_template 8  "19/19/19"
+put_template 9  "ff/35/5b"
+put_template 10 "b7/e8/76"
+put_template 11 "ff/c2/51"
+put_template 12 "76/d5/ff"
+put_template 13 "ba/76/e7"
+put_template 14 "6c/bf/b5"
+put_template 15 "c2/c8/d7"
+
+color_foreground="b3/c9/d7"
+color_background="19/19/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b3c9d7"
+  put_template_custom Ph "191919"
+  put_template_custom Pi "9fb3c1"
+  put_template_custom Pj "b3c9d7"
+  put_template_custom Pk "191919"
+  put_template_custom Pl "f34b00"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Broadcast.sh
+++ b/generic/Broadcast.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Broadcast
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "da/49/39"
+put_template 2  "51/9f/50"
+put_template 3  "ff/d2/4a"
+put_template 4  "6d/9c/be"
+put_template 5  "d0/d0/ff"
+put_template 6  "6e/9c/be"
+put_template 7  "ff/ff/ff"
+put_template 8  "32/32/32"
+put_template 9  "ff/7b/6b"
+put_template 10 "83/d1/82"
+put_template 11 "ff/ff/7c"
+put_template 12 "9f/ce/f0"
+put_template 13 "ff/ff/ff"
+put_template 14 "a0/ce/f0"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e6/e1/dc"
+color_background="2b/2b/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6e1dc"
+  put_template_custom Ph "2b2b2b"
+  put_template_custom Pi "e6e1dc"
+  put_template_custom Pj "5a647e"
+  put_template_custom Pk "e6e1dc"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "e6e1dc"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Brogrammer.sh
+++ b/generic/Brogrammer.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Brogrammer
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1f/1f/1f"
+put_template 1  "f8/11/18"
+put_template 2  "2d/c5/5e"
+put_template 3  "ec/ba/0f"
+put_template 4  "2a/84/d2"
+put_template 5  "4e/5a/b7"
+put_template 6  "10/81/d6"
+put_template 7  "d6/db/e5"
+put_template 8  "d6/db/e5"
+put_template 9  "de/35/2e"
+put_template 10 "1d/d3/61"
+put_template 11 "f3/bd/09"
+put_template 12 "10/81/d6"
+put_template 13 "53/50/b9"
+put_template 14 "0f/7d/db"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d6/db/e5"
+color_background="13/13/13"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d6dbe5"
+  put_template_custom Ph "131313"
+  put_template_custom Pi "d6dbe5"
+  put_template_custom Pj "1f1f1f"
+  put_template_custom Pk "d6dbe5"
+  put_template_custom Pl "b9b9b9"
+  put_template_custom Pm "101010"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Dark.sh
+++ b/generic/Builtin Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "bb/00/00"
+put_template 2  "00/bb/00"
+put_template 3  "bb/bb/00"
+put_template 4  "00/00/bb"
+put_template 5  "bb/00/bb"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Light.sh
+++ b/generic/Builtin Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "bb/00/00"
+put_template 2  "00/bb/00"
+put_template 3  "bb/bb/00"
+put_template 4  "00/00/bb"
+put_template 5  "bb/00/bb"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Pastel Dark.sh
+++ b/generic/Builtin Pastel Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Pastel Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4f/4f/4f"
+put_template 1  "ff/6c/60"
+put_template 2  "a8/ff/60"
+put_template 3  "ff/ff/b6"
+put_template 4  "96/cb/fe"
+put_template 5  "ff/73/fd"
+put_template 6  "c6/c5/fe"
+put_template 7  "ee/ee/ee"
+put_template 8  "7c/7c/7c"
+put_template 9  "ff/b6/b0"
+put_template 10 "ce/ff/ac"
+put_template 11 "ff/ff/cc"
+put_template 12 "b5/dc/ff"
+put_template 13 "ff/9c/fe"
+put_template 14 "df/df/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "363983"
+  put_template_custom Pk "f2f2f2"
+  put_template_custom Pl "ffa560"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Solarized Dark.sh
+++ b/generic/Builtin Solarized Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Solarized Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/36/42"
+put_template 1  "dc/32/2f"
+put_template 2  "85/99/00"
+put_template 3  "b5/89/00"
+put_template 4  "26/8b/d2"
+put_template 5  "d3/36/82"
+put_template 6  "2a/a1/98"
+put_template 7  "ee/e8/d5"
+put_template 8  "00/2b/36"
+put_template 9  "cb/4b/16"
+put_template 10 "58/6e/75"
+put_template 11 "65/7b/83"
+put_template 12 "83/94/96"
+put_template 13 "6c/71/c4"
+put_template 14 "93/a1/a1"
+put_template 15 "fd/f6/e3"
+
+color_foreground="83/94/96"
+color_background="00/2b/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "839496"
+  put_template_custom Ph "002b36"
+  put_template_custom Pi "93a1a1"
+  put_template_custom Pj "073642"
+  put_template_custom Pk "93a1a1"
+  put_template_custom Pl "839496"
+  put_template_custom Pm "073642"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Solarized Light.sh
+++ b/generic/Builtin Solarized Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Solarized Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/36/42"
+put_template 1  "dc/32/2f"
+put_template 2  "85/99/00"
+put_template 3  "b5/89/00"
+put_template 4  "26/8b/d2"
+put_template 5  "d3/36/82"
+put_template 6  "2a/a1/98"
+put_template 7  "ee/e8/d5"
+put_template 8  "00/2b/36"
+put_template 9  "cb/4b/16"
+put_template 10 "58/6e/75"
+put_template 11 "65/7b/83"
+put_template 12 "83/94/96"
+put_template 13 "6c/71/c4"
+put_template 14 "93/a1/a1"
+put_template 15 "fd/f6/e3"
+
+color_foreground="65/7b/83"
+color_background="fd/f6/e3"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "657b83"
+  put_template_custom Ph "fdf6e3"
+  put_template_custom Pi "586e75"
+  put_template_custom Pj "eee8d5"
+  put_template_custom Pk "586e75"
+  put_template_custom Pl "657b83"
+  put_template_custom Pm "eee8d5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Tango Dark.sh
+++ b/generic/Builtin Tango Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Tango Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/00/00"
+put_template 2  "4e/9a/06"
+put_template 3  "c4/a0/00"
+put_template 4  "34/65/a4"
+put_template 5  "75/50/7b"
+put_template 6  "06/98/9a"
+put_template 7  "d3/d7/cf"
+put_template 8  "55/57/53"
+put_template 9  "ef/29/29"
+put_template 10 "8a/e2/34"
+put_template 11 "fc/e9/4f"
+put_template 12 "72/9f/cf"
+put_template 13 "ad/7f/a8"
+put_template 14 "34/e2/e2"
+put_template 15 "ee/ee/ec"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Builtin Tango Light.sh
+++ b/generic/Builtin Tango Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Builtin Tango Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/00/00"
+put_template 2  "4e/9a/06"
+put_template 3  "c4/a0/00"
+put_template 4  "34/65/a4"
+put_template 5  "75/50/7b"
+put_template 6  "06/98/9a"
+put_template 7  "d3/d7/cf"
+put_template 8  "55/57/53"
+put_template 9  "ef/29/29"
+put_template 10 "8a/e2/34"
+put_template 11 "fc/e9/4f"
+put_template 12 "72/9f/cf"
+put_template 13 "ad/7f/a8"
+put_template 14 "34/e2/e2"
+put_template 15 "ee/ee/ec"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/C64.sh
+++ b/generic/C64.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# C64
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/03/00"
+put_template 1  "88/39/32"
+put_template 2  "55/a0/49"
+put_template 3  "bf/ce/72"
+put_template 4  "40/31/8d"
+put_template 5  "8b/3f/96"
+put_template 6  "67/b6/bd"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "88/39/32"
+put_template 10 "55/a0/49"
+put_template 11 "bf/ce/72"
+put_template 12 "40/31/8d"
+put_template 13 "8b/3f/96"
+put_template 14 "67/b6/bd"
+put_template 15 "f7/f7/f7"
+
+color_foreground="78/69/c4"
+color_background="40/31/8d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "7869c4"
+  put_template_custom Ph "40318d"
+  put_template_custom Pi "a5a2a2"
+  put_template_custom Pj "7869c4"
+  put_template_custom Pk "40318d"
+  put_template_custom Pl "7869c4"
+  put_template_custom Pm "40318d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CGA.sh
+++ b/generic/CGA.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CGA
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "aa/00/00"
+put_template 2  "00/aa/00"
+put_template 3  "aa/55/00"
+put_template 4  "00/00/aa"
+put_template 5  "aa/00/aa"
+put_template 6  "00/aa/aa"
+put_template 7  "aa/aa/aa"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="aa/aa/aa"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "aaaaaa"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "b8b8b8"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CLRS.sh
+++ b/generic/CLRS.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CLRS
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f8/28/2a"
+put_template 2  "32/8a/5d"
+put_template 3  "fa/70/1d"
+put_template 4  "13/5c/d0"
+put_template 5  "9f/00/bd"
+put_template 6  "33/c3/c1"
+put_template 7  "b3/b3/b3"
+put_template 8  "55/57/53"
+put_template 9  "fb/04/16"
+put_template 10 "2c/c6/31"
+put_template 11 "fd/d7/27"
+put_template 12 "16/70/ff"
+put_template 13 "e9/00/b0"
+put_template 14 "3a/d5/ce"
+put_template 15 "ee/ee/ec"
+
+color_foreground="26/26/26"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "262626"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "1a1a1a"
+  put_template_custom Pj "6fd3fc"
+  put_template_custom Pk "041730"
+  put_template_custom Pl "6fd3fc"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Calamity.sh
+++ b/generic/Calamity.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Calamity
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2f/28/33"
+put_template 1  "fc/64/4d"
+put_template 2  "a5/f6/9c"
+put_template 3  "e9/d7/a5"
+put_template 4  "3b/79/c7"
+put_template 5  "f9/26/72"
+put_template 6  "74/d3/de"
+put_template 7  "d5/ce/d9"
+put_template 8  "7e/6c/88"
+put_template 9  "fc/64/4d"
+put_template 10 "a5/f6/9c"
+put_template 11 "e9/d7/a5"
+put_template 12 "3b/79/c7"
+put_template 13 "f9/26/72"
+put_template 14 "74/d3/de"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d5/ce/d9"
+color_background="2f/28/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d5ced9"
+  put_template_custom Ph "2f2833"
+  put_template_custom Pi "d5ced9"
+  put_template_custom Pj "7e6c88"
+  put_template_custom Pk "d5ced9"
+  put_template_custom Pl "d5ced9"
+  put_template_custom Pm "2f2833"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Chalk.sh
+++ b/generic/Chalk.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Chalk
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "7d/8b/8f"
+put_template 1  "b2/3a/52"
+put_template 2  "78/9b/6a"
+put_template 3  "b9/ac/4a"
+put_template 4  "2a/7f/ac"
+put_template 5  "bd/4f/5a"
+put_template 6  "44/a7/99"
+put_template 7  "d2/d8/d9"
+put_template 8  "88/88/88"
+put_template 9  "f2/48/40"
+put_template 10 "80/c4/70"
+put_template 11 "ff/eb/62"
+put_template 12 "41/96/ff"
+put_template 13 "fc/52/75"
+put_template 14 "53/cd/bd"
+put_template 15 "d2/d8/d9"
+
+color_foreground="d2/d8/d9"
+color_background="2b/2d/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d2d8d9"
+  put_template_custom Ph "2b2d2e"
+  put_template_custom Pi "ececec"
+  put_template_custom Pj "e4e8ed"
+  put_template_custom Pk "3f4041"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Chalkboard.sh
+++ b/generic/Chalkboard.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Chalkboard
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c3/73/72"
+put_template 2  "72/c3/73"
+put_template 3  "c2/c3/72"
+put_template 4  "73/72/c3"
+put_template 5  "c3/72/c2"
+put_template 6  "72/c2/c3"
+put_template 7  "d9/d9/d9"
+put_template 8  "32/32/32"
+put_template 9  "db/aa/aa"
+put_template 10 "aa/db/aa"
+put_template 11 "da/db/aa"
+put_template 12 "aa/aa/db"
+put_template 13 "db/aa/da"
+put_template 14 "aa/da/db"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d9/e6/f2"
+color_background="29/26/2f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d9e6f2"
+  put_template_custom Ph "29262f"
+  put_template_custom Pi "d96f5f"
+  put_template_custom Pj "073642"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "d9e6f2"
+  put_template_custom Pm "29262f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ChallengerDeep.sh
+++ b/generic/ChallengerDeep.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ChallengerDeep
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/12/28"
+put_template 1  "ff/54/58"
+put_template 2  "62/d1/96"
+put_template 3  "ff/b3/78"
+put_template 4  "65/b2/ff"
+put_template 5  "90/6c/ff"
+put_template 6  "63/f2/f1"
+put_template 7  "a6/b3/cc"
+put_template 8  "56/55/75"
+put_template 9  "ff/80/80"
+put_template 10 "95/ff/a4"
+put_template 11 "ff/e9/aa"
+put_template 12 "91/dd/ff"
+put_template 13 "c9/91/e1"
+put_template 14 "aa/ff/e4"
+put_template 15 "cb/e3/e7"
+
+color_foreground="cb/e1/e7"
+color_background="1e/1c/31"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cbe1e7"
+  put_template_custom Ph "1e1c31"
+  put_template_custom Pi "b6e6f7"
+  put_template_custom Pj "cbe1e7"
+  put_template_custom Pk "1e1c31"
+  put_template_custom Pl "fbfcfc"
+  put_template_custom Pm "ff271d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Chester.sh
+++ b/generic/Chester.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Chester
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "08/02/00"
+put_template 1  "fa/5e/5b"
+put_template 2  "16/c9/8d"
+put_template 3  "ff/c8/3f"
+put_template 4  "28/8a/d6"
+put_template 5  "d3/45/90"
+put_template 6  "28/dd/de"
+put_template 7  "e7/e7/e7"
+put_template 8  "6f/6b/68"
+put_template 9  "fa/5e/5b"
+put_template 10 "16/c9/8d"
+put_template 11 "fe/ef/6d"
+put_template 12 "27/8a/d6"
+put_template 13 "d3/45/90"
+put_template 14 "27/de/de"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="2c/36/43"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "2c3643"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "67747c"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "b4b1b1"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ciapre.sh
+++ b/generic/Ciapre.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ciapre
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "18/18/18"
+put_template 1  "81/00/09"
+put_template 2  "48/51/3b"
+put_template 3  "cc/8b/3f"
+put_template 4  "57/6d/8c"
+put_template 5  "72/4d/7c"
+put_template 6  "5c/4f/4b"
+put_template 7  "ae/a4/7f"
+put_template 8  "55/55/55"
+put_template 9  "ac/38/35"
+put_template 10 "a6/a7/5d"
+put_template 11 "dc/df/7c"
+put_template 12 "30/97/c6"
+put_template 13 "d3/30/61"
+put_template 14 "f3/db/b2"
+put_template 15 "f4/f4/f4"
+
+color_foreground="ae/a4/7a"
+color_background="19/1c/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "aea47a"
+  put_template_custom Ph "191c27"
+  put_template_custom Pi "f4f4f4"
+  put_template_custom Pj "172539"
+  put_template_custom Pk "aea47f"
+  put_template_custom Pl "92805b"
+  put_template_custom Pm "181818"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Cobalt Neon.sh
+++ b/generic/Cobalt Neon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Cobalt Neon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/26/31"
+put_template 1  "ff/23/20"
+put_template 2  "3b/a5/ff"
+put_template 3  "e9/e7/5c"
+put_template 4  "8f/f5/86"
+put_template 5  "78/1a/a0"
+put_template 6  "8f/f5/86"
+put_template 7  "ba/46/b2"
+put_template 8  "ff/f6/88"
+put_template 9  "d4/31/2e"
+put_template 10 "8f/f5/86"
+put_template 11 "e9/f0/6d"
+put_template 12 "3c/7d/d2"
+put_template 13 "82/30/a7"
+put_template 14 "6c/bc/67"
+put_template 15 "8f/f5/86"
+
+color_foreground="8f/f5/86"
+color_background="14/28/38"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "8ff586"
+  put_template_custom Ph "142838"
+  put_template_custom Pi "248b70"
+  put_template_custom Pj "094fb1"
+  put_template_custom Pk "8ff586"
+  put_template_custom Pl "c4206f"
+  put_template_custom Pm "8ff586"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Cobalt2.sh
+++ b/generic/Cobalt2.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Cobalt2
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/00/00"
+put_template 2  "38/de/21"
+put_template 3  "ff/e5/0a"
+put_template 4  "14/60/d2"
+put_template 5  "ff/00/5d"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "f4/0e/17"
+put_template 10 "3b/d0/1d"
+put_template 11 "ed/c8/09"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "6a/e3/fa"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="13/27/38"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "132738"
+  put_template_custom Pi "f7fcff"
+  put_template_custom Pj "18354f"
+  put_template_custom Pk "b5b5b5"
+  put_template_custom Pl "f0cc09"
+  put_template_custom Pm "fefff2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CobaltNext-Dark.sh
+++ b/generic/CobaltNext-Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CobaltNext-Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "28/2f/36"
+put_template 1  "e6/57/6a"
+put_template 2  "99/c7/94"
+put_template 3  "fa/c8/63"
+put_template 4  "5a/9b/cf"
+put_template 5  "c5/a5/c5"
+put_template 6  "5f/b3/b3"
+put_template 7  "d8/de/e9"
+put_template 8  "65/73/7e"
+put_template 9  "d6/83/8c"
+put_template 10 "c1/dc/be"
+put_template 11 "ff/de/9b"
+put_template 12 "8a/be/e7"
+put_template 13 "ed/cd/ed"
+put_template 14 "9b/e2/e2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d8/de/e9"
+color_background="0f/1c/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "0f1c23"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "5fb3b3"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fac863"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CobaltNext-Minimal.sh
+++ b/generic/CobaltNext-Minimal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CobaltNext-Minimal
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "34/3d/46"
+put_template 1  "ed/6f/7d"
+put_template 2  "99/c7/94"
+put_template 3  "fa/c8/63"
+put_template 4  "5a/9b/cf"
+put_template 5  "c5/a5/c5"
+put_template 6  "5f/b3/b3"
+put_template 7  "d8/de/e9"
+put_template 8  "65/73/7e"
+put_template 9  "d6/83/8c"
+put_template 10 "c1/dc/be"
+put_template 11 "ff/de/9b"
+put_template 12 "8a/be/e7"
+put_template 13 "ed/cd/ed"
+put_template 14 "9b/e2/e2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d8/de/e9"
+color_background="0f/1c/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "0f1c23"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "5fb3b3"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "5fb3b3"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CobaltNext.sh
+++ b/generic/CobaltNext.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CobaltNext
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ed/5f/7d"
+put_template 2  "99/c7/94"
+put_template 3  "fa/c8/63"
+put_template 4  "5a/9b/cf"
+put_template 5  "c5/a5/c5"
+put_template 6  "5f/b3/b3"
+put_template 7  "d8/de/e9"
+put_template 8  "65/73/7e"
+put_template 9  "d6/83/8c"
+put_template 10 "c1/dc/be"
+put_template 11 "ff/de/9b"
+put_template 12 "8a/be/e7"
+put_template 13 "ed/cd/ed"
+put_template 14 "9b/e2/e2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d8/de/e9"
+color_background="1b/2b/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "1b2b34"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4f5b66"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fac863"
+  put_template_custom Pm "d8dee9"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CrayonPonyFish.sh
+++ b/generic/CrayonPonyFish.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CrayonPonyFish
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2b/1b/1d"
+put_template 1  "91/00/2b"
+put_template 2  "57/95/24"
+put_template 3  "ab/31/1b"
+put_template 4  "8c/87/b0"
+put_template 5  "69/2f/50"
+put_template 6  "e8/a8/66"
+put_template 7  "68/52/5a"
+put_template 8  "3d/2b/2e"
+put_template 9  "c5/25/5d"
+put_template 10 "8d/ff/57"
+put_template 11 "c8/38/1d"
+put_template 12 "cf/c9/ff"
+put_template 13 "fc/6c/ba"
+put_template 14 "ff/ce/af"
+put_template 15 "b0/94/9d"
+
+color_foreground="68/52/5a"
+color_background="15/07/07"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "68525a"
+  put_template_custom Ph "150707"
+  put_template_custom Pi "c8381d"
+  put_template_custom Pj "2b1b1d"
+  put_template_custom Pk "69525a"
+  put_template_custom Pl "68525a"
+  put_template_custom Pm "140707"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CutiePro.sh
+++ b/generic/CutiePro.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CutiePro
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f5/6e/7f"
+put_template 2  "be/c9/75"
+put_template 3  "f5/86/69"
+put_template 4  "42/d9/c5"
+put_template 5  "d2/86/b7"
+put_template 6  "37/cb/8a"
+put_template 7  "d5/c3/c3"
+put_template 8  "88/84/7f"
+put_template 9  "e5/a1/a3"
+put_template 10 "e8/d6/a7"
+put_template 11 "f1/bb/79"
+put_template 12 "80/c5/de"
+put_template 13 "b2/94/bb"
+put_template 14 "9d/cc/bb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d5/d0/c9"
+color_background="18/18/18"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d5d0c9"
+  put_template_custom Ph "181818"
+  put_template_custom Pi "d5d0c9"
+  put_template_custom Pj "363636"
+  put_template_custom Pk "d5d0c9"
+  put_template_custom Pl "efc4cd"
+  put_template_custom Pm "181818"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Cyberdyne.sh
+++ b/generic/Cyberdyne.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Cyberdyne
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "08/08/08"
+put_template 1  "ff/83/73"
+put_template 2  "00/c1/72"
+put_template 3  "d2/a7/00"
+put_template 4  "00/71/cf"
+put_template 5  "ff/90/fe"
+put_template 6  "6b/ff/dd"
+put_template 7  "f1/f1/f1"
+put_template 8  "2e/2e/2e"
+put_template 9  "ff/c4/be"
+put_template 10 "d6/fc/ba"
+put_template 11 "ff/fe/d5"
+put_template 12 "c2/e3/ff"
+put_template 13 "ff/b2/fe"
+put_template 14 "e6/e7/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/ff/92"
+color_background="15/11/44"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "00ff92"
+  put_template_custom Ph "151144"
+  put_template_custom Pi "8b93ff"
+  put_template_custom Pj "454d96"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "00ff9c"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/CyberpunkScarletProtocol.sh
+++ b/generic/CyberpunkScarletProtocol.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# CyberpunkScarletProtocol
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/11/16"
+put_template 1  "ea/33/56"
+put_template 2  "64/d9/8c"
+put_template 3  "fa/f9/68"
+put_template 4  "30/6f/b1"
+put_template 5  "ba/3e/c1"
+put_template 6  "59/c2/c6"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ed/77/6d"
+put_template 10 "8d/f7/7a"
+put_template 11 "fe/fc/7f"
+put_template 12 "6a/71/f6"
+put_template 13 "ae/40/e4"
+put_template 14 "8e/fa/fd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d1/35/54"
+color_background="10/11/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d13554"
+  put_template_custom Ph "101116"
+  put_template_custom Pi "f5f466"
+  put_template_custom Pj "c7ddfc"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "9bfca8"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dark Modern.sh
+++ b/generic/Dark Modern.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dark Modern
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "27/27/27"
+put_template 1  "f7/49/49"
+put_template 2  "2e/a0/43"
+put_template 3  "9e/6a/03"
+put_template 4  "00/78/d4"
+put_template 5  "d0/12/73"
+put_template 6  "1d/b4/d6"
+put_template 7  "cc/cc/cc"
+put_template 8  "5d/5d/5d"
+put_template 9  "dc/54/52"
+put_template 10 "23/d1/8b"
+put_template 11 "f5/f5/43"
+put_template 12 "3b/8e/ea"
+put_template 13 "d6/70/d6"
+put_template 14 "29/b8/db"
+put_template 15 "e5/e5/e5"
+
+color_foreground="cc/cc/cc"
+color_background="1f/1f/1f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cccccc"
+  put_template_custom Ph "1f1f1f"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3a3d41"
+  put_template_custom Pk "e0e0e0"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dark Pastel.sh
+++ b/generic/Dark Pastel.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dark Pastel
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/55/55"
+put_template 2  "55/ff/55"
+put_template 3  "ff/ff/55"
+put_template 4  "55/55/ff"
+put_template 5  "ff/55/ff"
+put_template 6  "55/ff/ff"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ff5e7d"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dark+.sh
+++ b/generic/Dark+.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dark+
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cd/31/31"
+put_template 2  "0d/bc/79"
+put_template 3  "e5/e5/10"
+put_template 4  "24/72/c8"
+put_template 5  "bc/3f/bc"
+put_template 6  "11/a8/cd"
+put_template 7  "e5/e5/e5"
+put_template 8  "66/66/66"
+put_template 9  "f1/4c/4c"
+put_template 10 "23/d1/8b"
+put_template 11 "f5/f5/43"
+put_template 12 "3b/8e/ea"
+put_template 13 "d6/70/d6"
+put_template 14 "29/b8/db"
+put_template 15 "e5/e5/e5"
+
+color_foreground="cc/cc/cc"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cccccc"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3a3d41"
+  put_template_custom Pk "e0e0e0"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Darkside.sh
+++ b/generic/Darkside.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Darkside
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "e8/34/1c"
+put_template 2  "68/c2/56"
+put_template 3  "f2/d4/2c"
+put_template 4  "1c/98/e8"
+put_template 5  "8e/69/c9"
+put_template 6  "1c/98/e8"
+put_template 7  "ba/ba/ba"
+put_template 8  "00/00/00"
+put_template 9  "e0/5a/4f"
+put_template 10 "77/b8/69"
+put_template 11 "ef/d6/4b"
+put_template 12 "38/7c/d3"
+put_template 13 "95/7b/be"
+put_template 14 "3d/97/e2"
+put_template 15 "ba/ba/ba"
+
+color_foreground="ba/ba/ba"
+color_background="22/23/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bababa"
+  put_template_custom Ph "222324"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "303333"
+  put_template_custom Pk "bababa"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Desert.sh
+++ b/generic/Desert.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Desert
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4d/4d/4d"
+put_template 1  "ff/2b/2b"
+put_template 2  "98/fb/98"
+put_template 3  "f0/e6/8c"
+put_template 4  "cd/85/3f"
+put_template 5  "ff/de/ad"
+put_template 6  "ff/a0/a0"
+put_template 7  "f5/de/b3"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "87/ce/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "ff/d7/00"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="33/33/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "333333"
+  put_template_custom Pi "ffd700"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "00ff00"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dimidium.sh
+++ b/generic/Dimidium.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dimidium
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cf/49/4c"
+put_template 2  "60/b4/42"
+put_template 3  "db/9c/11"
+put_template 4  "05/75/d8"
+put_template 5  "af/5e/d2"
+put_template 6  "1d/b6/bb"
+put_template 7  "ba/b7/b6"
+put_template 8  "81/7e/7e"
+put_template 9  "ff/64/3b"
+put_template 10 "37/e5/7b"
+put_template 11 "fc/cd/1a"
+put_template 12 "68/8d/fd"
+put_template 13 "ed/6f/e9"
+put_template 14 "32/e0/fb"
+put_template 15 "d3/d8/d9"
+
+color_foreground="ba/b7/b6"
+color_background="14/14/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bab7b6"
+  put_template_custom Ph "141414"
+  put_template_custom Pi "d3d8d9"
+  put_template_custom Pj "8db8e5"
+  put_template_custom Pk "141414"
+  put_template_custom Pl "37e57b"
+  put_template_custom Pm "141414"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/DimmedMonokai.sh
+++ b/generic/DimmedMonokai.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# DimmedMonokai
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3a/3d/43"
+put_template 1  "be/3f/48"
+put_template 2  "87/9a/3b"
+put_template 3  "c5/a6/35"
+put_template 4  "4f/76/a1"
+put_template 5  "85/5c/8d"
+put_template 6  "57/8f/a4"
+put_template 7  "b9/bc/ba"
+put_template 8  "88/89/87"
+put_template 9  "fb/00/1f"
+put_template 10 "0f/72/2f"
+put_template 11 "c4/70/33"
+put_template 12 "18/6d/e3"
+put_template 13 "fb/00/67"
+put_template 14 "2e/70/6d"
+put_template 15 "fd/ff/b9"
+
+color_foreground="b9/bc/ba"
+color_background="1f/1f/1f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b9bcba"
+  put_template_custom Ph "1f1f1f"
+  put_template_custom Pi "feffb2"
+  put_template_custom Pj "2a2d32"
+  put_template_custom Pk "b9bcba"
+  put_template_custom Pl "f83e19"
+  put_template_custom Pm "171717"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Django.sh
+++ b/generic/Django.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Django
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fd/62/09"
+put_template 2  "41/a8/3e"
+put_template 3  "ff/e8/62"
+put_template 4  "24/50/32"
+put_template 5  "f8/f8/f8"
+put_template 6  "9d/f3/9f"
+put_template 7  "ff/ff/ff"
+put_template 8  "32/32/32"
+put_template 9  "ff/94/3b"
+put_template 10 "73/da/70"
+put_template 11 "ff/ff/94"
+put_template 12 "56/82/64"
+put_template 13 "ff/ff/ff"
+put_template 14 "cf/ff/d1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f8/f8/f8"
+color_background="0b/2f/20"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f8"
+  put_template_custom Ph "0b2f20"
+  put_template_custom Pi "f8f8f8"
+  put_template_custom Pj "245032"
+  put_template_custom Pk "f8f8f8"
+  put_template_custom Pl "336442"
+  put_template_custom Pm "f8f8f8"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/DjangoRebornAgain.sh
+++ b/generic/DjangoRebornAgain.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# DjangoRebornAgain
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fd/62/09"
+put_template 2  "41/a8/3e"
+put_template 3  "ff/e8/62"
+put_template 4  "24/50/32"
+put_template 5  "f8/f8/f8"
+put_template 6  "9d/f3/9f"
+put_template 7  "ff/ff/ff"
+put_template 8  "32/32/32"
+put_template 9  "ff/94/3b"
+put_template 10 "73/da/70"
+put_template 11 "ff/ff/94"
+put_template 12 "56/82/64"
+put_template 13 "ff/ff/ff"
+put_template 14 "cf/ff/d1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="da/de/dc"
+color_background="05/1f/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dadedc"
+  put_template_custom Ph "051f14"
+  put_template_custom Pi "dadedc"
+  put_template_custom Pj "203727"
+  put_template_custom Pk "dadedc"
+  put_template_custom Pl "ffcc00"
+  put_template_custom Pm "dadedc"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/DjangoSmooth.sh
+++ b/generic/DjangoSmooth.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# DjangoSmooth
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fd/62/09"
+put_template 2  "41/a8/3e"
+put_template 3  "ff/e8/62"
+put_template 4  "98/98/98"
+put_template 5  "f8/f8/f8"
+put_template 6  "9d/f3/9f"
+put_template 7  "e8/e8/e7"
+put_template 8  "32/32/32"
+put_template 9  "ff/94/3b"
+put_template 10 "73/da/70"
+put_template 11 "ff/ff/94"
+put_template 12 "ca/ca/ca"
+put_template 13 "ff/ff/ff"
+put_template 14 "cf/ff/d1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f8/f8/f8"
+color_background="24/50/32"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f8"
+  put_template_custom Ph "245032"
+  put_template_custom Pi "f8f8f8"
+  put_template_custom Pj "336442"
+  put_template_custom Pk "f8f8f8"
+  put_template_custom Pl "336442"
+  put_template_custom Pm "f8f8f8"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Doom Peacock.sh
+++ b/generic/Doom Peacock.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Doom Peacock
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1c/1f/24"
+put_template 1  "cb/4b/16"
+put_template 2  "26/a6/a6"
+put_template 3  "bc/d4/2a"
+put_template 4  "2a/6c/c6"
+put_template 5  "a9/a1/e1"
+put_template 6  "56/99/af"
+put_template 7  "ed/e0/ce"
+put_template 8  "2b/2a/27"
+put_template 9  "ff/5d/38"
+put_template 10 "98/be/65"
+put_template 11 "e6/f9/72"
+put_template 12 "51/af/ef"
+put_template 13 "c6/78/dd"
+put_template 14 "46/d9/ff"
+put_template 15 "df/df/df"
+
+color_foreground="ed/e0/ce"
+color_background="2b/2a/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ede0ce"
+  put_template_custom Ph "2b2a27"
+  put_template_custom Pi "ede0ce"
+  put_template_custom Pj "a60033"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "9c9c9d"
+  put_template_custom Pm "36312b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/DoomOne.sh
+++ b/generic/DoomOne.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# DoomOne
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/6c/6b"
+put_template 2  "98/be/65"
+put_template 3  "ec/be/7b"
+put_template 4  "a9/a1/e1"
+put_template 5  "c6/78/dd"
+put_template 6  "51/af/ef"
+put_template 7  "bb/c2/cf"
+put_template 8  "00/00/00"
+put_template 9  "ff/66/55"
+put_template 10 "99/bb/66"
+put_template 11 "ec/be/7b"
+put_template 12 "a9/a1/e1"
+put_template 13 "c6/78/dd"
+put_template 14 "51/af/ef"
+put_template 15 "bf/bf/bf"
+
+color_foreground="bb/c2/cf"
+color_background="28/2c/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbc2cf"
+  put_template_custom Ph "282c34"
+  put_template_custom Pi "bbc2cf"
+  put_template_custom Pj "42444b"
+  put_template_custom Pk "bbc2cf"
+  put_template_custom Pl "51afef"
+  put_template_custom Pm "1b1b1b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/DotGov.sh
+++ b/generic/DotGov.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# DotGov
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/19/19"
+put_template 1  "bf/09/1d"
+put_template 2  "3d/97/51"
+put_template 3  "f6/bb/34"
+put_template 4  "17/b2/e0"
+put_template 5  "78/30/b0"
+put_template 6  "8b/d2/ed"
+put_template 7  "ff/ff/ff"
+put_template 8  "19/19/19"
+put_template 9  "bf/09/1d"
+put_template 10 "3d/97/51"
+put_template 11 "f6/bb/34"
+put_template 12 "17/b2/e0"
+put_template 13 "78/30/b0"
+put_template 14 "8b/d2/ed"
+put_template 15 "ff/ff/ff"
+
+color_foreground="eb/eb/eb"
+color_background="26/2c/35"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebebeb"
+  put_template_custom Ph "262c35"
+  put_template_custom Pi "fbab19"
+  put_template_custom Pj "1a4080"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "d9002f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dracula+.sh
+++ b/generic/Dracula+.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dracula+
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/22/2c"
+put_template 1  "ff/55/55"
+put_template 2  "50/fa/7b"
+put_template 3  "ff/cb/6b"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "8b/e9/fd"
+put_template 7  "f8/f8/f2"
+put_template 8  "54/54/54"
+put_template 9  "ff/6e/6e"
+put_template 10 "69/ff/94"
+put_template 11 "ff/cb/6b"
+put_template 12 "d6/ac/ff"
+put_template 13 "ff/92/df"
+put_template 14 "a4/ff/ff"
+put_template 15 "f8/f8/f2"
+
+color_foreground="f8/f8/f2"
+color_background="21/21/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f2"
+  put_template_custom Ph "212121"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "f8f8f2"
+  put_template_custom Pk "545454"
+  put_template_custom Pl "eceff4"
+  put_template_custom Pm "282828"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Dracula.sh
+++ b/generic/Dracula.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Dracula
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/22/2c"
+put_template 1  "ff/55/55"
+put_template 2  "50/fa/7b"
+put_template 3  "f1/fa/8c"
+put_template 4  "bd/93/f9"
+put_template 5  "ff/79/c6"
+put_template 6  "8b/e9/fd"
+put_template 7  "f8/f8/f2"
+put_template 8  "62/72/a4"
+put_template 9  "ff/6e/6e"
+put_template 10 "69/ff/94"
+put_template 11 "ff/ff/a5"
+put_template 12 "d6/ac/ff"
+put_template 13 "ff/92/df"
+put_template 14 "a4/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f8/f8/f2"
+color_background="28/2a/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f2"
+  put_template_custom Ph "282a36"
+  put_template_custom Pi "f8f8f2"
+  put_template_custom Pj "44475a"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "f8f8f2"
+  put_template_custom Pm "282a36"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Duotone Dark.sh
+++ b/generic/Duotone Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Duotone Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1f/1d/27"
+put_template 1  "d9/39/3e"
+put_template 2  "2d/cd/73"
+put_template 3  "d9/b7/6e"
+put_template 4  "ff/c2/84"
+put_template 5  "de/8d/40"
+put_template 6  "24/88/ff"
+put_template 7  "b7/a1/ff"
+put_template 8  "35/31/47"
+put_template 9  "d9/39/3e"
+put_template 10 "2d/cd/73"
+put_template 11 "d9/b7/6e"
+put_template 12 "ff/c2/84"
+put_template 13 "de/8d/40"
+put_template 14 "24/88/ff"
+put_template 15 "ea/e5/ff"
+
+color_foreground="b7/a1/ff"
+color_background="1f/1d/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b7a1ff"
+  put_template_custom Ph "1f1d27"
+  put_template_custom Pi "b7a2ff"
+  put_template_custom Pj "353147"
+  put_template_custom Pk "b7a2ff"
+  put_template_custom Pl "ff9839"
+  put_template_custom Pm "1f1d27"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ENCOM.sh
+++ b/generic/ENCOM.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ENCOM
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "9f/00/00"
+put_template 2  "00/8b/00"
+put_template 3  "ff/d0/00"
+put_template 4  "00/81/ff"
+put_template 5  "bc/00/ca"
+put_template 6  "00/8b/8b"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/00/00"
+put_template 10 "00/ee/00"
+put_template 11 "ff/ff/00"
+put_template 12 "00/00/ff"
+put_template 13 "ff/00/ff"
+put_template 14 "00/cd/cd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/a5/95"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "00a595"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "4cf1e1"
+  put_template_custom Pj "00a48c"
+  put_template_custom Pk "3de1c9"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Earthsong.sh
+++ b/generic/Earthsong.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Earthsong
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "12/14/18"
+put_template 1  "c9/42/34"
+put_template 2  "85/c5/4c"
+put_template 3  "f5/ae/2e"
+put_template 4  "13/98/b9"
+put_template 5  "d0/63/3d"
+put_template 6  "50/95/52"
+put_template 7  "e5/c6/aa"
+put_template 8  "67/5f/54"
+put_template 9  "ff/64/5a"
+put_template 10 "98/e0/36"
+put_template 11 "e0/d5/61"
+put_template 12 "5f/da/ff"
+put_template 13 "ff/92/69"
+put_template 14 "84/f0/88"
+put_template 15 "f6/f7/ec"
+
+color_foreground="e5/c7/a9"
+color_background="29/25/20"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e5c7a9"
+  put_template_custom Ph "292520"
+  put_template_custom Pi "f6f7ec"
+  put_template_custom Pj "121418"
+  put_template_custom Pk "e5c7a9"
+  put_template_custom Pl "f6f7ec"
+  put_template_custom Pm "292520"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Elegant.sh
+++ b/generic/Elegant.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Elegant
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0c/12/21"
+put_template 1  "ea/33/5b"
+put_template 2  "95/ca/9a"
+put_template 3  "f7/cd/94"
+put_template 4  "93/aa/dd"
+put_template 5  "bf/94/e5"
+put_template 6  "8c/ca/ec"
+put_template 7  "ff/ff/ff"
+put_template 8  "57/56/56"
+put_template 9  "ea/33/5b"
+put_template 10 "95/ca/9a"
+put_template 11 "f7/cd/94"
+put_template 12 "93/aa/dd"
+put_template 13 "bf/94/e5"
+put_template 14 "5f/aa/e9"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cf/d2/d6"
+color_background="29/2b/31"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cfd2d6"
+  put_template_custom Ph "292b31"
+  put_template_custom Pi "f7cd94"
+  put_template_custom Pj "d5d5d5"
+  put_template_custom Pk "224281"
+  put_template_custom Pl "55bbf9"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Elemental.sh
+++ b/generic/Elemental.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Elemental
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3c/3c/30"
+put_template 1  "98/29/0f"
+put_template 2  "47/9a/43"
+put_template 3  "7f/71/11"
+put_template 4  "49/7f/7d"
+put_template 5  "7f/4e/2f"
+put_template 6  "38/7f/58"
+put_template 7  "80/79/74"
+put_template 8  "55/54/45"
+put_template 9  "e0/50/2a"
+put_template 10 "61/e0/70"
+put_template 11 "d6/99/27"
+put_template 12 "79/d9/d9"
+put_template 13 "cd/7c/54"
+put_template 14 "59/d5/99"
+put_template 15 "ff/f1/e9"
+
+color_foreground="80/7a/74"
+color_background="22/21/1d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "807a74"
+  put_template_custom Ph "22211d"
+  put_template_custom Pi "fae679"
+  put_template_custom Pj "413829"
+  put_template_custom Pk "facd77"
+  put_template_custom Pl "facb80"
+  put_template_custom Pm "161611"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Elementary.sh
+++ b/generic/Elementary.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Elementary
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/24/24"
+put_template 1  "d7/1c/15"
+put_template 2  "5a/a5/13"
+put_template 3  "fd/b4/0c"
+put_template 4  "06/3b/8c"
+put_template 5  "e4/00/38"
+put_template 6  "25/95/e1"
+put_template 7  "ef/ef/ef"
+put_template 8  "4b/4b/4b"
+put_template 9  "fc/1c/18"
+put_template 10 "6b/c2/19"
+put_template 11 "fe/c8/0e"
+put_template 12 "09/55/ff"
+put_template 13 "fb/00/50"
+put_template 14 "3e/a8/fc"
+put_template 15 "8c/00/ec"
+
+color_foreground="ef/ef/ef"
+color_background="18/18/18"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "efefef"
+  put_template_custom Ph "181818"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Embark.sh
+++ b/generic/Embark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Embark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1e/1c/31"
+put_template 1  "f0/71/9b"
+put_template 2  "a1/ef/d3"
+put_template 3  "ff/e9/aa"
+put_template 4  "57/c7/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "87/df/eb"
+put_template 7  "f8/f8/f2"
+put_template 8  "58/52/73"
+put_template 9  "f0/2e/6e"
+put_template 10 "2c/e5/92"
+put_template 11 "ff/b3/78"
+put_template 12 "1d/a0/e2"
+put_template 13 "a7/42/ea"
+put_template 14 "63/f2/f1"
+put_template 15 "a6/b3/cc"
+
+color_foreground="ee/ff/ff"
+color_background="1e/1c/31"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eeffff"
+  put_template_custom Ph "1e1c31"
+  put_template_custom Pi "c4c9ff"
+  put_template_custom Pj "fbfcfc"
+  put_template_custom Pk "1e1c31"
+  put_template_custom Pl "a1efd3"
+  put_template_custom Pm "1e1c31"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Espresso Libre.sh
+++ b/generic/Espresso Libre.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Espresso Libre
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/00/00"
+put_template 2  "1a/92/1c"
+put_template 3  "f0/e5/3a"
+put_template 4  "00/66/ff"
+put_template 5  "c5/65/6b"
+put_template 6  "06/98/9a"
+put_template 7  "d3/d7/cf"
+put_template 8  "55/57/53"
+put_template 9  "ef/29/29"
+put_template 10 "9a/ff/87"
+put_template 11 "ff/fb/5c"
+put_template 12 "43/a8/ed"
+put_template 13 "ff/81/8a"
+put_template 14 "34/e2/e2"
+put_template 15 "ee/ee/ec"
+
+color_foreground="b8/a8/98"
+color_background="2a/21/1c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b8a898"
+  put_template_custom Ph "2a211c"
+  put_template_custom Pi "d3c1af"
+  put_template_custom Pj "c3dcff"
+  put_template_custom Pk "b8a898"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Espresso.sh
+++ b/generic/Espresso.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Espresso
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "35/35/35"
+put_template 1  "d2/52/52"
+put_template 2  "a5/c2/61"
+put_template 3  "ff/c6/6d"
+put_template 4  "6c/99/bb"
+put_template 5  "d1/97/d9"
+put_template 6  "be/d6/ff"
+put_template 7  "ee/ee/ec"
+put_template 8  "53/53/53"
+put_template 9  "f0/0c/0c"
+put_template 10 "c2/e0/75"
+put_template 11 "e1/e4/8b"
+put_template 12 "8a/b7/d9"
+put_template 13 "ef/b5/f7"
+put_template 14 "dc/f4/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="32/32/32"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "323232"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "5b5b5b"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "d6d6d6"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Everblush.sh
+++ b/generic/Everblush.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Everblush
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "23/2a/2d"
+put_template 1  "e5/74/74"
+put_template 2  "8c/cf/7e"
+put_template 3  "e5/c7/6b"
+put_template 4  "67/b0/e8"
+put_template 5  "c4/7f/d5"
+put_template 6  "6c/bf/bf"
+put_template 7  "b3/b9/b8"
+put_template 8  "2d/34/37"
+put_template 9  "ef/7e/7e"
+put_template 10 "96/d9/88"
+put_template 11 "f4/d6/7a"
+put_template 12 "71/ba/f2"
+put_template 13 "ce/89/df"
+put_template 14 "67/cb/e7"
+put_template 15 "bd/c3/c2"
+
+color_foreground="da/da/da"
+color_background="14/1b/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dadada"
+  put_template_custom Ph "141b1e"
+  put_template_custom Pi "dadada"
+  put_template_custom Pj "141b1e"
+  put_template_custom Pk "dadada"
+  put_template_custom Pl "dadada"
+  put_template_custom Pm "141b1e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Everforest Dark - Hard.sh
+++ b/generic/Everforest Dark - Hard.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Everforest Dark - Hard
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "7a/84/78"
+put_template 1  "e6/7e/80"
+put_template 2  "a7/c0/80"
+put_template 3  "db/bc/7f"
+put_template 4  "7f/bb/b3"
+put_template 5  "d6/99/b6"
+put_template 6  "83/c0/92"
+put_template 7  "f2/ef/df"
+put_template 8  "a6/b0/a0"
+put_template 9  "f8/55/52"
+put_template 10 "8d/a1/01"
+put_template 11 "df/a0/00"
+put_template 12 "3a/94/c5"
+put_template 13 "df/69/ba"
+put_template 14 "35/a7/7c"
+put_template 15 "ff/fb/ef"
+
+color_foreground="d3/c6/aa"
+color_background="1e/23/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d3c6aa"
+  put_template_custom Ph "1e2326"
+  put_template_custom Pi "dbbc7f"
+  put_template_custom Pj "4c3743"
+  put_template_custom Pk "d3c6aa"
+  put_template_custom Pl "e69875"
+  put_template_custom Pm "4c3743"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Everforest Light - Med.sh
+++ b/generic/Everforest Light - Med.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Everforest Light - Med
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "7a/84/78"
+put_template 1  "e6/7e/80"
+put_template 2  "a7/c0/80"
+put_template 3  "db/bc/7f"
+put_template 4  "7f/bb/b3"
+put_template 5  "d6/99/b6"
+put_template 6  "83/c0/92"
+put_template 7  "f2/ef/df"
+put_template 8  "a6/b0/a0"
+put_template 9  "f8/55/52"
+put_template 10 "8d/a1/01"
+put_template 11 "df/a0/00"
+put_template 12 "3a/94/c5"
+put_template 13 "df/69/ba"
+put_template 14 "35/a7/7c"
+put_template 15 "ff/fb/ef"
+
+color_foreground="5c/6a/72"
+color_background="ef/eb/d4"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "5c6a72"
+  put_template_custom Ph "efebd4"
+  put_template_custom Pi "dfa000"
+  put_template_custom Pj "eaedc8"
+  put_template_custom Pk "5c6a72"
+  put_template_custom Pl "f57d26"
+  put_template_custom Pm "eaedc8"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Fahrenheit.sh
+++ b/generic/Fahrenheit.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Fahrenheit
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1d/1d"
+put_template 1  "cd/a0/74"
+put_template 2  "9e/74/4d"
+put_template 3  "fe/cf/75"
+put_template 4  "72/01/02"
+put_template 5  "73/4c/4d"
+put_template 6  "97/97/97"
+put_template 7  "ff/ff/ce"
+put_template 8  "00/00/00"
+put_template 9  "fe/ce/a0"
+put_template 10 "cc/73/4d"
+put_template 11 "fd/9f/4d"
+put_template 12 "cb/4a/05"
+put_template 13 "4e/73/9f"
+put_template 14 "fe/d0/4d"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ce"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffce"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4e739f"
+  put_template_custom Pk "ffffce"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Fairyfloss.sh
+++ b/generic/Fairyfloss.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Fairyfloss
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "04/03/03"
+put_template 1  "f9/26/72"
+put_template 2  "c2/ff/df"
+put_template 3  "e6/c0/00"
+put_template 4  "c2/ff/df"
+put_template 5  "ff/b8/d1"
+put_template 6  "c5/a3/ff"
+put_template 7  "f8/f8/f0"
+put_template 8  "60/90/cb"
+put_template 9  "ff/85/7f"
+put_template 10 "c2/ff/df"
+put_template 11 "ff/ea/00"
+put_template 12 "c2/ff/df"
+put_template 13 "ff/b8/d1"
+put_template 14 "c5/a3/ff"
+put_template 15 "f8/f8/f0"
+
+color_foreground="f8/f8/f2"
+color_background="5a/54/75"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f2"
+  put_template_custom Ph "5a5475"
+  put_template_custom Pi "ff857f"
+  put_template_custom Pj "8077a8"
+  put_template_custom Pk "f6e1ce"
+  put_template_custom Pl "f8f8f0"
+  put_template_custom Pm "060709"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Fideloper.sh
+++ b/generic/Fideloper.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Fideloper
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "29/2f/33"
+put_template 1  "cb/1e/2d"
+put_template 2  "ed/b8/ac"
+put_template 3  "b7/ab/9b"
+put_template 4  "2e/78/c2"
+put_template 5  "c0/23/6f"
+put_template 6  "30/91/86"
+put_template 7  "ea/e3/ce"
+put_template 8  "09/20/28"
+put_template 9  "d4/60/5a"
+put_template 10 "d4/60/5a"
+put_template 11 "a8/66/71"
+put_template 12 "7c/85/c4"
+put_template 13 "5c/5d/b2"
+put_template 14 "81/90/90"
+put_template 15 "fc/f4/df"
+
+color_foreground="db/da/e0"
+color_background="29/2f/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dbdae0"
+  put_template_custom Ph "292f33"
+  put_template_custom Pi "6b7c7c"
+  put_template_custom Pj "efb8ac"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "d4605a"
+  put_template_custom Pm "fefff2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Firefly Traditional.sh
+++ b/generic/Firefly Traditional.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Firefly Traditional
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c2/37/20"
+put_template 2  "33/bc/26"
+put_template 3  "af/ad/24"
+put_template 4  "5a/63/ff"
+put_template 5  "d5/3a/d2"
+put_template 6  "33/bb/c7"
+put_template 7  "cc/cc/cc"
+put_template 8  "82/82/82"
+put_template 9  "ff/3b/1e"
+put_template 10 "2e/e7/20"
+put_template 11 "ec/ec/16"
+put_template 12 "83/8d/ff"
+put_template 13 "ff/5c/fe"
+put_template 14 "29/f0/f0"
+put_template 15 "eb/eb/eb"
+
+color_foreground="f5/f5/f5"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f5f5f5"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "cfeac6"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "00f900"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/FirefoxDev.sh
+++ b/generic/FirefoxDev.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# FirefoxDev
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/28/31"
+put_template 1  "e6/38/53"
+put_template 2  "5e/b8/3c"
+put_template 3  "a5/77/06"
+put_template 4  "35/9d/df"
+put_template 5  "d7/5c/ff"
+put_template 6  "4b/73/a2"
+put_template 7  "dc/dc/dc"
+put_template 8  "00/1e/27"
+put_template 9  "e1/00/3f"
+put_template 10 "1d/90/00"
+put_template 11 "cd/94/09"
+put_template 12 "00/6f/c0"
+put_template 13 "a2/00/da"
+put_template 14 "00/57/94"
+put_template 15 "e2/e2/e2"
+
+color_foreground="7c/8f/a4"
+color_background="0e/10/11"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "7c8fa4"
+  put_template_custom Ph "0e1011"
+  put_template_custom Pi "a7acb2"
+  put_template_custom Pj "163c61"
+  put_template_custom Pk "f2f5f9"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Firewatch.sh
+++ b/generic/Firewatch.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Firewatch
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "58/5f/6d"
+put_template 1  "d9/53/60"
+put_template 2  "5a/b9/77"
+put_template 3  "df/b5/63"
+put_template 4  "4d/89/c4"
+put_template 5  "d5/51/19"
+put_template 6  "44/a8/b6"
+put_template 7  "e6/e5/ff"
+put_template 8  "58/5f/6d"
+put_template 9  "d9/53/60"
+put_template 10 "5a/b9/77"
+put_template 11 "df/b5/63"
+put_template 12 "4c/89/c5"
+put_template 13 "d5/51/19"
+put_template 14 "44/a8/b6"
+put_template 15 "e6/e5/ff"
+
+color_foreground="9b/a2/b2"
+color_background="1e/20/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "9ba2b2"
+  put_template_custom Ph "1e2027"
+  put_template_custom Pi "e6e5ff"
+  put_template_custom Pj "2f363e"
+  put_template_custom Pk "7d8fa4"
+  put_template_custom Pl "f6f7ec"
+  put_template_custom Pm "c4c5b5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/FishTank.sh
+++ b/generic/FishTank.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# FishTank
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "03/07/3c"
+put_template 1  "c6/00/4a"
+put_template 2  "ac/f1/57"
+put_template 3  "fe/cd/5e"
+put_template 4  "52/5f/b8"
+put_template 5  "98/6f/82"
+put_template 6  "96/87/63"
+put_template 7  "ec/f0/fc"
+put_template 8  "6c/5b/30"
+put_template 9  "da/4b/8a"
+put_template 10 "db/ff/a9"
+put_template 11 "fe/e6/a9"
+put_template 12 "b2/be/fa"
+put_template 13 "fd/a5/cd"
+put_template 14 "a5/bd/86"
+put_template 15 "f6/ff/ec"
+
+color_foreground="ec/f0/fe"
+color_background="23/25/37"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ecf0fe"
+  put_template_custom Ph "232537"
+  put_template_custom Pi "f6ffeb"
+  put_template_custom Pj "fcf7e9"
+  put_template_custom Pk "232537"
+  put_template_custom Pl "fecd5e"
+  put_template_custom Pm "232537"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Flat.sh
+++ b/generic/Flat.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Flat
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "22/2d/3f"
+put_template 1  "a8/23/20"
+put_template 2  "32/a5/48"
+put_template 3  "e5/8d/11"
+put_template 4  "31/67/ac"
+put_template 5  "78/1a/a0"
+put_template 6  "2c/93/70"
+put_template 7  "b0/b6/ba"
+put_template 8  "21/2c/3c"
+put_template 9  "d4/31/2e"
+put_template 10 "2d/94/40"
+put_template 11 "e5/be/0c"
+put_template 12 "3c/7d/d2"
+put_template 13 "82/30/a7"
+put_template 14 "35/b3/87"
+put_template 15 "e7/ec/ed"
+
+color_foreground="2c/c5/5d"
+color_background="00/22/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "2cc55d"
+  put_template_custom Ph "002240"
+  put_template_custom Pi "e7eced"
+  put_template_custom Pj "792b9c"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "e5be0c"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Flatland.sh
+++ b/generic/Flatland.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Flatland
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1d/19"
+put_template 1  "f1/83/39"
+put_template 2  "9f/d3/64"
+put_template 3  "f4/ef/6d"
+put_template 4  "50/96/be"
+put_template 5  "69/5a/bc"
+put_template 6  "d6/38/65"
+put_template 7  "ff/ff/ff"
+put_template 8  "1d/1d/19"
+put_template 9  "d2/2a/24"
+put_template 10 "a7/d4/2c"
+put_template 11 "ff/89/49"
+put_template 12 "61/b9/d0"
+put_template 13 "69/5a/bc"
+put_template 14 "d6/38/65"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b8/db/ef"
+color_background="1d/1f/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b8dbef"
+  put_template_custom Ph "1d1f21"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "2b2a24"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Floraverse.sh
+++ b/generic/Floraverse.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Floraverse
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "08/00/2e"
+put_template 1  "64/00/2c"
+put_template 2  "5d/73/1a"
+put_template 3  "cd/75/1c"
+put_template 4  "1d/6d/a1"
+put_template 5  "b7/07/7e"
+put_template 6  "42/a3/8c"
+put_template 7  "f3/e0/b8"
+put_template 8  "33/1e/4d"
+put_template 9  "d0/20/63"
+put_template 10 "b4/ce/59"
+put_template 11 "fa/c3/57"
+put_template 12 "40/a4/cf"
+put_template 13 "f1/2a/ae"
+put_template 14 "62/ca/a8"
+put_template 15 "ff/f5/db"
+
+color_foreground="db/d1/b9"
+color_background="0e/0d/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dbd1b9"
+  put_template_custom Ph "0e0d15"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "f3e0b8"
+  put_template_custom Pk "08002e"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ForestBlue.sh
+++ b/generic/ForestBlue.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ForestBlue
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "33/33/33"
+put_template 1  "f8/81/8e"
+put_template 2  "92/d3/a2"
+put_template 3  "1a/8e/63"
+put_template 4  "8e/d0/ce"
+put_template 5  "5e/46/8c"
+put_template 6  "31/65/8c"
+put_template 7  "e2/d8/cd"
+put_template 8  "3d/3d/3d"
+put_template 9  "fb/3d/66"
+put_template 10 "6b/b4/8d"
+put_template 11 "30/c8/5a"
+put_template 12 "39/a7/a2"
+put_template 13 "7e/62/b3"
+put_template 14 "60/96/bf"
+put_template 15 "e2/d8/cd"
+
+color_foreground="e2/d8/cd"
+color_background="05/15/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e2d8cd"
+  put_template_custom Ph "051519"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "9e9ecb"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Framer.sh
+++ b/generic/Framer.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Framer
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/14/14"
+put_template 1  "ff/55/55"
+put_template 2  "98/ec/65"
+put_template 3  "ff/cc/33"
+put_template 4  "00/aa/ff"
+put_template 5  "aa/88/ff"
+put_template 6  "88/dd/ff"
+put_template 7  "cc/cc/cc"
+put_template 8  "41/41/41"
+put_template 9  "ff/88/88"
+put_template 10 "b6/f2/92"
+put_template 11 "ff/d9/66"
+put_template 12 "33/bb/ff"
+put_template 13 "ce/bb/ff"
+put_template 14 "bb/ec/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="77/77/77"
+color_background="11/11/11"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "777777"
+  put_template_custom Ph "111111"
+  put_template_custom Pi "fefdbf"
+  put_template_custom Pj "666666"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fcdc08"
+  put_template_custom Pm "161616"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/FrontEndDelight.sh
+++ b/generic/FrontEndDelight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# FrontEndDelight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/25/26"
+put_template 1  "f8/51/1b"
+put_template 2  "56/57/47"
+put_template 3  "fa/77/1d"
+put_template 4  "2c/70/b7"
+put_template 5  "f0/2e/4f"
+put_template 6  "3c/a1/a6"
+put_template 7  "ad/ad/ad"
+put_template 8  "5f/ac/6d"
+put_template 9  "f7/43/19"
+put_template 10 "74/ec/4c"
+put_template 11 "fd/c3/25"
+put_template 12 "33/93/ca"
+put_template 13 "e7/5e/4f"
+put_template 14 "4f/bc/e6"
+put_template 15 "8c/73/5b"
+
+color_foreground="ad/ad/ad"
+color_background="1b/1c/1d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "adadad"
+  put_template_custom Ph "1b1c1d"
+  put_template_custom Pi "cdcdcd"
+  put_template_custom Pj "ea6154"
+  put_template_custom Pk "1b1c1d"
+  put_template_custom Pl "cdcdcd"
+  put_template_custom Pm "1b1c1d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/FunForrest.sh
+++ b/generic/FunForrest.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# FunForrest
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d6/26/2b"
+put_template 2  "91/9c/00"
+put_template 3  "be/8a/13"
+put_template 4  "46/99/a3"
+put_template 5  "8d/43/31"
+put_template 6  "da/82/13"
+put_template 7  "dd/c2/65"
+put_template 8  "7f/6a/55"
+put_template 9  "e5/5a/1c"
+put_template 10 "bf/c6/5a"
+put_template 11 "ff/cb/1b"
+put_template 12 "7c/c9/cf"
+put_template 13 "d2/63/49"
+put_template 14 "e6/a9/6b"
+put_template 15 "ff/ea/a3"
+
+color_foreground="de/c1/65"
+color_background="25/12/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dec165"
+  put_template_custom Ph "251200"
+  put_template_custom Pi "ffeaa3"
+  put_template_custom Pj "e5591c"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "e5591c"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Galaxy.sh
+++ b/generic/Galaxy.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Galaxy
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f9/55/5f"
+put_template 2  "21/b0/89"
+put_template 3  "fe/f0/2a"
+put_template 4  "58/9d/f6"
+put_template 5  "94/4d/95"
+put_template 6  "1f/9e/e7"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "fa/8c/8f"
+put_template 10 "35/bb/9a"
+put_template 11 "ff/ff/55"
+put_template 12 "58/9d/f6"
+put_template 13 "e7/56/99"
+put_template 14 "39/79/bc"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1d/28/37"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1d2837"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Galizur.sh
+++ b/generic/Galizur.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Galizur
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "22/33/44"
+put_template 1  "aa/11/22"
+put_template 2  "33/aa/11"
+put_template 3  "cc/aa/22"
+put_template 4  "22/55/cc"
+put_template 5  "77/55/aa"
+put_template 6  "22/bb/dd"
+put_template 7  "88/99/aa"
+put_template 8  "55/66/77"
+put_template 9  "ff/11/33"
+put_template 10 "33/ff/11"
+put_template 11 "ff/dd/33"
+put_template 12 "33/77/ff"
+put_template 13 "aa/77/ff"
+put_template 14 "33/dd/ff"
+put_template 15 "bb/cc/dd"
+
+color_foreground="dd/ee/ff"
+color_background="07/13/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ddeeff"
+  put_template_custom Ph "071317"
+  put_template_custom Pi "ddeeff"
+  put_template_custom Pj "071317"
+  put_template_custom Pk "ddeeff"
+  put_template_custom Pl "ddeeff"
+  put_template_custom Pm "071317"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ghostty Default StyleDark.sh
+++ b/generic/Ghostty Default StyleDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ghostty Default StyleDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1f/21"
+put_template 1  "bf/6b/69"
+put_template 2  "b7/bd/73"
+put_template 3  "e9/c8/80"
+put_template 4  "88/a1/bb"
+put_template 5  "ad/95/b8"
+put_template 6  "95/bd/b7"
+put_template 7  "c5/c8/c6"
+put_template 8  "66/66/66"
+put_template 9  "c5/57/57"
+put_template 10 "bc/c9/5f"
+put_template 11 "e1/c6/5e"
+put_template 12 "83/a5/d6"
+put_template 13 "bc/99/d4"
+put_template 14 "83/be/b1"
+put_template 15 "ea/ea/ea"
+
+color_foreground="ff/ff/ff"
+color_background="29/2c/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "292c33"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "292c33"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "363a43"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub Dark.sh
+++ b/generic/GitHub Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f7/81/66"
+put_template 2  "56/d3/64"
+put_template 3  "e3/b3/41"
+put_template 4  "6c/a4/f8"
+put_template 5  "db/61/a2"
+put_template 6  "2b/74/89"
+put_template 7  "ff/ff/ff"
+put_template 8  "4d/4d/4d"
+put_template 9  "f7/81/66"
+put_template 10 "56/d3/64"
+put_template 11 "e3/b3/41"
+put_template 12 "6c/a4/f8"
+put_template 13 "db/61/a2"
+put_template 14 "2b/74/89"
+put_template 15 "ff/ff/ff"
+
+color_foreground="8b/94/9e"
+color_background="10/12/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "8b949e"
+  put_template_custom Ph "101216"
+  put_template_custom Pi "c9d1d9"
+  put_template_custom Pj "3b5070"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "c9d1d9"
+  put_template_custom Pm "101216"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Dark-Colorblind.sh
+++ b/generic/GitHub-Dark-Colorblind.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Dark-Colorblind
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "48/4f/58"
+put_template 1  "ec/8e/2c"
+put_template 2  "58/a6/ff"
+put_template 3  "d2/99/22"
+put_template 4  "58/a6/ff"
+put_template 5  "bc/8c/ff"
+put_template 6  "39/c5/cf"
+put_template 7  "b1/ba/c4"
+put_template 8  "6e/76/81"
+put_template 9  "fd/ac/54"
+put_template 10 "79/c0/ff"
+put_template 11 "e3/b3/41"
+put_template 12 "79/c0/ff"
+put_template 13 "d2/a8/ff"
+put_template 14 "56/d4/dd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c9/d1/d9"
+color_background="0d/11/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c9d1d9"
+  put_template_custom Ph "0d1117"
+  put_template_custom Pi "c9d1d9"
+  put_template_custom Pj "c9d1d9"
+  put_template_custom Pk "0d1117"
+  put_template_custom Pl "58a6ff"
+  put_template_custom Pm "58a6ff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Dark-Default.sh
+++ b/generic/GitHub-Dark-Default.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Dark-Default
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "48/4f/58"
+put_template 1  "ff/7b/72"
+put_template 2  "3f/b9/50"
+put_template 3  "d2/99/22"
+put_template 4  "58/a6/ff"
+put_template 5  "bc/8c/ff"
+put_template 6  "39/c5/cf"
+put_template 7  "b1/ba/c4"
+put_template 8  "6e/76/81"
+put_template 9  "ff/a1/98"
+put_template 10 "56/d3/64"
+put_template 11 "e3/b3/41"
+put_template 12 "79/c0/ff"
+put_template 13 "d2/a8/ff"
+put_template 14 "56/d4/dd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e6/ed/f3"
+color_background="0d/11/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6edf3"
+  put_template_custom Ph "0d1117"
+  put_template_custom Pi "e6edf3"
+  put_template_custom Pj "e6edf3"
+  put_template_custom Pk "0d1117"
+  put_template_custom Pl "2f81f7"
+  put_template_custom Pm "2f81f7"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Dark-Dimmed.sh
+++ b/generic/GitHub-Dark-Dimmed.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Dark-Dimmed
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "54/5d/68"
+put_template 1  "f4/70/67"
+put_template 2  "57/ab/5a"
+put_template 3  "c6/90/26"
+put_template 4  "53/9b/f5"
+put_template 5  "b0/83/f0"
+put_template 6  "39/c5/cf"
+put_template 7  "90/9d/ab"
+put_template 8  "63/6e/7b"
+put_template 9  "ff/93/8a"
+put_template 10 "6b/c4/6d"
+put_template 11 "da/aa/3f"
+put_template 12 "6c/b6/ff"
+put_template 13 "dc/bd/fb"
+put_template 14 "56/d4/dd"
+put_template 15 "cd/d9/e5"
+
+color_foreground="ad/ba/c7"
+color_background="22/27/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "adbac7"
+  put_template_custom Ph "22272e"
+  put_template_custom Pi "adbac7"
+  put_template_custom Pj "adbac7"
+  put_template_custom Pk "22272e"
+  put_template_custom Pl "539bf5"
+  put_template_custom Pm "539bf5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Dark-High-Contrast.sh
+++ b/generic/GitHub-Dark-High-Contrast.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Dark-High-Contrast
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "7a/82/8e"
+put_template 1  "ff/94/92"
+put_template 2  "26/cd/4d"
+put_template 3  "f0/b7/2f"
+put_template 4  "71/b7/ff"
+put_template 5  "cb/9e/ff"
+put_template 6  "39/c5/cf"
+put_template 7  "d9/de/e3"
+put_template 8  "9e/a7/b3"
+put_template 9  "ff/b1/af"
+put_template 10 "4a/e1/68"
+put_template 11 "f7/c8/43"
+put_template 12 "91/cb/ff"
+put_template 13 "db/b7/ff"
+put_template 14 "56/d4/dd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f0/f3/f6"
+color_background="0a/0c/10"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f0f3f6"
+  put_template_custom Ph "0a0c10"
+  put_template_custom Pi "f0f3f6"
+  put_template_custom Pj "f0f3f6"
+  put_template_custom Pk "0a0c10"
+  put_template_custom Pl "71b7ff"
+  put_template_custom Pm "71b7ff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Light-Colorblind.sh
+++ b/generic/GitHub-Light-Colorblind.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Light-Colorblind
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/29/2f"
+put_template 1  "b3/59/00"
+put_template 2  "05/50/ae"
+put_template 3  "4d/2d/00"
+put_template 4  "09/69/da"
+put_template 5  "82/50/df"
+put_template 6  "1b/7c/83"
+put_template 7  "6e/77/81"
+put_template 8  "57/60/6a"
+put_template 9  "8a/46/00"
+put_template 10 "09/69/da"
+put_template 11 "63/3c/01"
+put_template 12 "21/8b/ff"
+put_template 13 "a4/75/f9"
+put_template 14 "31/92/aa"
+put_template 15 "8c/95/9f"
+
+color_foreground="24/29/2f"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "24292f"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "24292f"
+  put_template_custom Pj "24292f"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "0969da"
+  put_template_custom Pm "0969da"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Light-Default.sh
+++ b/generic/GitHub-Light-Default.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Light-Default
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/29/2f"
+put_template 1  "cf/22/2e"
+put_template 2  "11/63/29"
+put_template 3  "4d/2d/00"
+put_template 4  "09/69/da"
+put_template 5  "82/50/df"
+put_template 6  "1b/7c/83"
+put_template 7  "6e/77/81"
+put_template 8  "57/60/6a"
+put_template 9  "a4/0e/26"
+put_template 10 "1a/7f/37"
+put_template 11 "63/3c/01"
+put_template 12 "21/8b/ff"
+put_template 13 "a4/75/f9"
+put_template 14 "31/92/aa"
+put_template 15 "8c/95/9f"
+
+color_foreground="1f/23/28"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "1f2328"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "1f2328"
+  put_template_custom Pj "1f2328"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "0969da"
+  put_template_custom Pm "0969da"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitHub-Light-High-Contrast.sh
+++ b/generic/GitHub-Light-High-Contrast.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitHub-Light-High-Contrast
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0e/11/16"
+put_template 1  "a0/11/1f"
+put_template 2  "02/4c/1a"
+put_template 3  "3f/22/00"
+put_template 4  "03/49/b4"
+put_template 5  "62/2c/bc"
+put_template 6  "1b/7c/83"
+put_template 7  "66/70/7b"
+put_template 8  "4b/53/5d"
+put_template 9  "86/06/1d"
+put_template 10 "05/5d/20"
+put_template 11 "4e/2c/00"
+put_template 12 "11/68/e3"
+put_template 13 "84/4a/e7"
+put_template 14 "31/92/aa"
+put_template 15 "88/92/9d"
+
+color_foreground="0e/11/16"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "0e1116"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "0e1116"
+  put_template_custom Pj "0e1116"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "0349b4"
+  put_template_custom Pm "0349b4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitLab-Dark-Grey.sh
+++ b/generic/GitLab-Dark-Grey.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitLab-Dark-Grey
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f5/7f/6c"
+put_template 2  "52/b8/7a"
+put_template 3  "d9/95/30"
+put_template 4  "7f/b6/ed"
+put_template 5  "f8/8a/af"
+put_template 6  "32/c5/d2"
+put_template 7  "ff/ff/ff"
+put_template 8  "66/66/66"
+put_template 9  "fc/b5/aa"
+put_template 10 "91/d4/a8"
+put_template 11 "e9/be/74"
+put_template 12 "49/8d/d1"
+put_template 13 "fc/ac/c5"
+put_template 14 "5e/de/e3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ad95e9"
+  put_template_custom Pk "222222"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitLab-Dark.sh
+++ b/generic/GitLab-Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitLab-Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f5/7f/6c"
+put_template 2  "52/b8/7a"
+put_template 3  "d9/95/30"
+put_template 4  "7f/b6/ed"
+put_template 5  "f8/8a/af"
+put_template 6  "32/c5/d2"
+put_template 7  "ff/ff/ff"
+put_template 8  "66/66/66"
+put_template 9  "fc/b5/aa"
+put_template 10 "91/d4/a8"
+put_template 11 "e9/be/74"
+put_template 12 "49/8d/d1"
+put_template 13 "fc/ac/c5"
+put_template 14 "5e/de/e3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="28/26/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "28262b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ad95e9"
+  put_template_custom Pk "28262b"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GitLab-Light.sh
+++ b/generic/GitLab-Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GitLab-Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "30/30/30"
+put_template 1  "a3/17/00"
+put_template 2  "0a/7f/3d"
+put_template 3  "af/55/1d"
+put_template 4  "00/6c/d8"
+put_template 5  "58/3c/ac"
+put_template 6  "00/79/8a"
+put_template 7  "30/30/30"
+put_template 8  "30/30/30"
+put_template 9  "a3/17/00"
+put_template 10 "0a/7f/3d"
+put_template 11 "af/55/1d"
+put_template 12 "00/6c/d8"
+put_template 13 "58/3c/ac"
+put_template 14 "00/79/8a"
+put_template 15 "30/30/30"
+
+color_foreground="30/30/30"
+color_background="fa/fa/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "303030"
+  put_template_custom Ph "fafaff"
+  put_template_custom Pi "303030"
+  put_template_custom Pj "ad95e9"
+  put_template_custom Pk "fafaff"
+  put_template_custom Pl "303030"
+  put_template_custom Pm "303030"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Github.sh
+++ b/generic/Github.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Github
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3e/3e/3e"
+put_template 1  "97/0b/16"
+put_template 2  "07/96/2a"
+put_template 3  "f8/ee/c7"
+put_template 4  "00/3e/8a"
+put_template 5  "e9/46/91"
+put_template 6  "89/d1/ec"
+put_template 7  "ff/ff/ff"
+put_template 8  "66/66/66"
+put_template 9  "de/00/00"
+put_template 10 "87/d5/a2"
+put_template 11 "f1/d0/07"
+put_template 12 "2e/6c/ba"
+put_template 13 "ff/a2/9f"
+put_template 14 "1c/fa/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="3e/3e/3e"
+color_background="f4/f4/f4"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3e3e3e"
+  put_template_custom Ph "f4f4f4"
+  put_template_custom Pi "c95500"
+  put_template_custom Pj "a9c1e2"
+  put_template_custom Pk "535353"
+  put_template_custom Pl "3f3f3f"
+  put_template_custom Pm "f4f4f4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Glacier.sh
+++ b/generic/Glacier.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Glacier
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2e/34/3c"
+put_template 1  "bd/0f/2f"
+put_template 2  "35/a7/70"
+put_template 3  "fb/94/35"
+put_template 4  "1f/58/72"
+put_template 5  "bd/25/23"
+put_template 6  "77/83/97"
+put_template 7  "ff/ff/ff"
+put_template 8  "40/4a/55"
+put_template 9  "bd/0f/2f"
+put_template 10 "49/e9/98"
+put_template 11 "fd/df/6e"
+put_template 12 "2a/8b/c1"
+put_template 13 "ea/47/27"
+put_template 14 "a0/b6/d3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="0c/11/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "0c1115"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "bd2523"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "6c6c6c"
+  put_template_custom Pm "6c6c6c"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Grape.sh
+++ b/generic/Grape.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Grape
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2d/28/3f"
+put_template 1  "ed/22/61"
+put_template 2  "1f/a9/1b"
+put_template 3  "8d/dc/20"
+put_template 4  "48/7d/f4"
+put_template 5  "8d/35/c9"
+put_template 6  "3b/de/ed"
+put_template 7  "9e/9e/a0"
+put_template 8  "59/51/6a"
+put_template 9  "f0/72/9a"
+put_template 10 "53/aa/5e"
+put_template 11 "b2/dc/87"
+put_template 12 "a9/bc/ec"
+put_template 13 "ad/81/c2"
+put_template 14 "9d/e3/eb"
+put_template 15 "a2/88/f7"
+
+color_foreground="9f/9f/a1"
+color_background="17/14/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "9f9fa1"
+  put_template_custom Ph "171423"
+  put_template_custom Pi "9f87ff"
+  put_template_custom Pj "493d70"
+  put_template_custom Pk "171422"
+  put_template_custom Pl "a288f7"
+  put_template_custom Pm "171422"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Grass.sh
+++ b/generic/Grass.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Grass
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "bb/00/00"
+put_template 2  "00/bb/00"
+put_template 3  "e7/b0/00"
+put_template 4  "00/00/a3"
+put_template 5  "95/00/62"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "bb/00/00"
+put_template 10 "00/bb/00"
+put_template 11 "e7/b0/00"
+put_template 12 "00/00/bb"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/f0/a5"
+color_background="13/77/3d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fff0a5"
+  put_template_custom Ph "13773d"
+  put_template_custom Pi "ffb03b"
+  put_template_custom Pj "b64926"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "8c2800"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Grey-green.sh
+++ b/generic/Grey-green.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Grey-green
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fe/14/14"
+put_template 2  "74/ff/00"
+put_template 3  "f1/ff/01"
+put_template 4  "00/de/ff"
+put_template 5  "ff/00/f0"
+put_template 6  "00/ff/bc"
+put_template 7  "ff/ff/ff"
+put_template 8  "66/66/66"
+put_template 9  "ff/39/39"
+put_template 10 "00/ff/44"
+put_template 11 "ff/d1/00"
+put_template 12 "00/af/ff"
+put_template 13 "ff/00/8a"
+put_template 14 "00/ff/d3"
+put_template 15 "f5/ec/ec"
+
+color_foreground="ff/ff/ff"
+color_background="00/2a/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "002a1a"
+  put_template_custom Pi "e1e4e3"
+  put_template_custom Pj "517e50"
+  put_template_custom Pk "e2e2e2"
+  put_template_custom Pl "fff400"
+  put_template_custom Pm "e1e4e3"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GruvboxDark.sh
+++ b/generic/GruvboxDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GruvboxDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "28/28/28"
+put_template 1  "cc/24/1d"
+put_template 2  "98/97/1a"
+put_template 3  "d7/99/21"
+put_template 4  "45/85/88"
+put_template 5  "b1/62/86"
+put_template 6  "68/9d/6a"
+put_template 7  "a8/99/84"
+put_template 8  "92/83/74"
+put_template 9  "fb/49/34"
+put_template 10 "b8/bb/26"
+put_template 11 "fa/bd/2f"
+put_template 12 "83/a5/98"
+put_template 13 "d3/86/9b"
+put_template 14 "8e/c0/7c"
+put_template 15 "eb/db/b2"
+
+color_foreground="eb/db/b2"
+color_background="28/28/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebdbb2"
+  put_template_custom Ph "282828"
+  put_template_custom Pi "ebdbb2"
+  put_template_custom Pj "665c54"
+  put_template_custom Pk "ebdbb2"
+  put_template_custom Pl "ebdbb2"
+  put_template_custom Pm "282828"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GruvboxDarkHard.sh
+++ b/generic/GruvboxDarkHard.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GruvboxDarkHard
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/20/21"
+put_template 1  "cc/24/1d"
+put_template 2  "98/97/1a"
+put_template 3  "d7/99/21"
+put_template 4  "45/85/88"
+put_template 5  "b1/62/86"
+put_template 6  "68/9d/6a"
+put_template 7  "a8/99/84"
+put_template 8  "92/83/74"
+put_template 9  "fb/49/34"
+put_template 10 "b8/bb/26"
+put_template 11 "fa/bd/2f"
+put_template 12 "83/a5/98"
+put_template 13 "d3/86/9b"
+put_template 14 "8e/c0/7c"
+put_template 15 "eb/db/b2"
+
+color_foreground="eb/db/b2"
+color_background="1d/20/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebdbb2"
+  put_template_custom Ph "1d2021"
+  put_template_custom Pi "ebdbb2"
+  put_template_custom Pj "665c54"
+  put_template_custom Pk "ebdbb2"
+  put_template_custom Pl "ebdbb2"
+  put_template_custom Pm "1d2021"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GruvboxLight.sh
+++ b/generic/GruvboxLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GruvboxLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "fb/f1/c7"
+put_template 1  "9d/00/06"
+put_template 2  "79/74/0e"
+put_template 3  "b5/76/14"
+put_template 4  "07/66/78"
+put_template 5  "8f/3f/71"
+put_template 6  "42/7b/58"
+put_template 7  "3c/38/36"
+put_template 8  "9d/83/74"
+put_template 9  "cc/24/1d"
+put_template 10 "98/97/1a"
+put_template 11 "d7/99/21"
+put_template 12 "45/85/88"
+put_template 13 "b1/61/86"
+put_template 14 "68/9d/69"
+put_template 15 "7c/6f/64"
+
+color_foreground="28/28/28"
+color_background="fb/f1/c7"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "282828"
+  put_template_custom Ph "fbf1c7"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "d5c4a1"
+  put_template_custom Pk "665c54"
+  put_template_custom Pl "282828"
+  put_template_custom Pm "fbf1c7"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/GruvboxLightHard.sh
+++ b/generic/GruvboxLightHard.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# GruvboxLightHard
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f8/f4/d6"
+put_template 1  "9d/00/06"
+put_template 2  "79/74/0e"
+put_template 3  "b5/76/14"
+put_template 4  "07/66/78"
+put_template 5  "8f/3f/71"
+put_template 6  "42/7b/58"
+put_template 7  "3c/38/36"
+put_template 8  "9d/83/74"
+put_template 9  "cc/24/1d"
+put_template 10 "98/97/1a"
+put_template 11 "d7/99/21"
+put_template 12 "45/85/88"
+put_template 13 "b1/61/86"
+put_template 14 "68/9d/69"
+put_template 15 "7c/6f/64"
+
+color_foreground="28/28/28"
+color_background="f8/f4/d6"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "282828"
+  put_template_custom Ph "f8f4d6"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "d5c4a1"
+  put_template_custom Pk "665c54"
+  put_template_custom Pl "282828"
+  put_template_custom Pm "f8f4d6"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Guezwhoz.sh
+++ b/generic/Guezwhoz.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Guezwhoz
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "08/08/08"
+put_template 1  "ff/5f/5f"
+put_template 2  "87/d7/af"
+put_template 3  "d7/d7/87"
+put_template 4  "5f/af/d7"
+put_template 5  "af/af/ff"
+put_template 6  "5f/d7/d7"
+put_template 7  "da/da/da"
+put_template 8  "8a/8a/8a"
+put_template 9  "d7/5f/5f"
+put_template 10 "af/d7/af"
+put_template 11 "d7/d7/af"
+put_template 12 "87/af/d7"
+put_template 13 "af/af/d7"
+put_template 14 "87/d7/d7"
+put_template 15 "da/da/da"
+
+color_foreground="d0/d0/d0"
+color_background="1c/1c/1c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d0d0d0"
+  put_template_custom Ph "1c1c1c"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "005f5f"
+  put_template_custom Pk "eeeeee"
+  put_template_custom Pl "eeeeee"
+  put_template_custom Pm "eeeeee"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/HaX0R_BLUE.sh
+++ b/generic/HaX0R_BLUE.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# HaX0R_BLUE
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/09/21"
+put_template 1  "10/b6/ff"
+put_template 2  "10/b6/ff"
+put_template 3  "10/b6/ff"
+put_template 4  "10/b6/ff"
+put_template 5  "10/b6/ff"
+put_template 6  "10/b6/ff"
+put_template 7  "fa/fa/fa"
+put_template 8  "08/01/17"
+put_template 9  "00/b3/f7"
+put_template 10 "00/b3/f7"
+put_template 11 "00/b3/f7"
+put_template 12 "00/b3/f7"
+put_template 13 "00/b3/f7"
+put_template 14 "00/b3/f7"
+put_template 15 "fe/fe/fe"
+
+color_foreground="11/b7/ff"
+color_background="01/05/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "11b7ff"
+  put_template_custom Ph "010515"
+  put_template_custom Pi "00b4f8"
+  put_template_custom Pj "c1e4ff"
+  put_template_custom Pk "f6f6f6"
+  put_template_custom Pl "10b6ff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/HaX0R_GR33N.sh
+++ b/generic/HaX0R_GR33N.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# HaX0R_GR33N
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/1f/0b"
+put_template 1  "15/d0/0d"
+put_template 2  "15/d0/0d"
+put_template 3  "15/d0/0d"
+put_template 4  "15/d0/0d"
+put_template 5  "15/d0/0d"
+put_template 6  "15/d0/0d"
+put_template 7  "fa/fa/fa"
+put_template 8  "00/15/10"
+put_template 9  "19/e2/0e"
+put_template 10 "19/e2/0e"
+put_template 11 "19/e2/0e"
+put_template 12 "19/e2/0e"
+put_template 13 "19/e2/0e"
+put_template 14 "19/e2/0e"
+put_template 15 "fe/fe/fe"
+
+color_foreground="16/b1/0e"
+color_background="02/0f/01"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "16b10e"
+  put_template_custom Ph "020f01"
+  put_template_custom Pi "19e30f"
+  put_template_custom Pj "d4ffc1"
+  put_template_custom Pk "fdfdfd"
+  put_template_custom Pl "15d00d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/HaX0R_R3D.sh
+++ b/generic/HaX0R_R3D.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# HaX0R_R3D
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1f/00/00"
+put_template 1  "b0/0d/0d"
+put_template 2  "b0/0d/0d"
+put_template 3  "b0/0d/0d"
+put_template 4  "b0/0d/0d"
+put_template 5  "b0/0d/0d"
+put_template 6  "b0/0d/0d"
+put_template 7  "fa/fa/fa"
+put_template 8  "15/00/00"
+put_template 9  "ff/11/11"
+put_template 10 "ff/10/10"
+put_template 11 "ff/10/10"
+put_template 12 "ff/10/10"
+put_template 13 "ff/10/10"
+put_template 14 "ff/10/10"
+put_template 15 "fe/fe/fe"
+
+color_foreground="b1/0e/0e"
+color_background="20/01/01"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b10e0e"
+  put_template_custom Ph "200101"
+  put_template_custom Pi "ff0000"
+  put_template_custom Pj "ebc1ff"
+  put_template_custom Pk "fdfdfd"
+  put_template_custom Pl "b00d0d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hacktober.sh
+++ b/generic/Hacktober.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hacktober
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/19/18"
+put_template 1  "b3/45/38"
+put_template 2  "58/77/44"
+put_template 3  "d0/89/49"
+put_template 4  "20/6e/c5"
+put_template 5  "86/46/51"
+put_template 6  "ac/91/66"
+put_template 7  "f1/ee/e7"
+put_template 8  "2c/2b/2a"
+put_template 9  "b3/33/23"
+put_template 10 "42/82/4a"
+put_template 11 "c7/5a/22"
+put_template 12 "53/89/c5"
+put_template 13 "e7/95/a5"
+put_template 14 "eb/c5/87"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c9/c9/c9"
+color_background="14/14/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c9c9c9"
+  put_template_custom Ph "141414"
+  put_template_custom Pi "c9c9c9"
+  put_template_custom Pj "141414"
+  put_template_custom Pk "c9c9c9"
+  put_template_custom Pl "c9c9c9"
+  put_template_custom Pm "141414"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hardcore.sh
+++ b/generic/Hardcore.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hardcore
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/1e"
+put_template 1  "f9/26/72"
+put_template 2  "a6/e2/2e"
+put_template 3  "fd/97/1f"
+put_template 4  "66/d9/ef"
+put_template 5  "9e/6f/fe"
+put_template 6  "5e/71/75"
+put_template 7  "cc/cc/c6"
+put_template 8  "50/53/54"
+put_template 9  "ff/66/9d"
+put_template 10 "be/ed/5f"
+put_template 11 "e6/db/74"
+put_template 12 "66/d9/ef"
+put_template 13 "9e/6f/fe"
+put_template 14 "a3/ba/bf"
+put_template 15 "f8/f8/f2"
+
+color_foreground="a0/a0/a0"
+color_background="12/12/12"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a0a0a0"
+  put_template_custom Ph "121212"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "453b39"
+  put_template_custom Pk "b6bbc0"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Harper.sh
+++ b/generic/Harper.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Harper
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/01/01"
+put_template 1  "f8/b6/3f"
+put_template 2  "7f/b5/e1"
+put_template 3  "d6/da/25"
+put_template 4  "48/9e/48"
+put_template 5  "b2/96/c6"
+put_template 6  "f5/bf/d7"
+put_template 7  "a8/a4/9d"
+put_template 8  "72/6e/6a"
+put_template 9  "f8/b6/3f"
+put_template 10 "7f/b5/e1"
+put_template 11 "d6/da/25"
+put_template 12 "48/9e/48"
+put_template 13 "b2/96/c6"
+put_template 14 "f5/bf/d7"
+put_template 15 "fe/fb/ea"
+
+color_foreground="a8/a4/9d"
+color_background="01/01/01"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a8a49d"
+  put_template_custom Ph "010101"
+  put_template_custom Pi "a8a49d"
+  put_template_custom Pj "5a5753"
+  put_template_custom Pk "a8a49d"
+  put_template_custom Pl "a8a49d"
+  put_template_custom Pm "010101"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Havn Daggry.sh
+++ b/generic/Havn Daggry.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Havn Daggry
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/28/40"
+put_template 1  "8f/56/4b"
+put_template 2  "5c/70/5b"
+put_template 3  "b3/6f/00"
+put_template 4  "40/56/7a"
+put_template 5  "77/5d/93"
+put_template 6  "8a/5a/7e"
+put_template 7  "d7/db/ea"
+put_template 8  "21/28/40"
+put_template 9  "bd/53/3e"
+put_template 10 "79/95/7b"
+put_template 11 "f3/b5/50"
+put_template 12 "69/88/bc"
+put_template 13 "7b/73/93"
+put_template 14 "a4/87/9c"
+put_template 15 "d7/db/ea"
+
+color_foreground="3e/4a/77"
+color_background="f8/f9/fb"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3e4a77"
+  put_template_custom Ph "f8f9fb"
+  put_template_custom Pi "434d79"
+  put_template_custom Pj "d4e8de"
+  put_template_custom Pk "333c61"
+  put_template_custom Pl "386a51"
+  put_template_custom Pm "d7dbea"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Havn Skumring.sh
+++ b/generic/Havn Skumring.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Havn Skumring
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "26/2c/45"
+put_template 1  "d9/60/48"
+put_template 2  "7c/ab/7f"
+put_template 3  "ee/b6/4e"
+put_template 4  "5d/6b/ef"
+put_template 5  "7a/72/9a"
+put_template 6  "ca/8c/be"
+put_template 7  "dd/e0/ed"
+put_template 8  "21/28/40"
+put_template 9  "c4/77/68"
+put_template 10 "8f/9d/90"
+put_template 11 "e4/c6/93"
+put_template 12 "5d/85/c6"
+put_template 13 "96/7d/e7"
+put_template 14 "c5/7e/b3"
+put_template 15 "fd/f6/e3"
+
+color_foreground="d7/db/ea"
+color_background="12/15/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d7dbea"
+  put_template_custom Ph "121521"
+  put_template_custom Pi "d1d4e1"
+  put_template_custom Pj "34504b"
+  put_template_custom Pk "dce0ee"
+  put_template_custom Pl "40786f"
+  put_template_custom Pm "e0e4f2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Highway.sh
+++ b/generic/Highway.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Highway
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d0/0e/18"
+put_template 2  "13/80/34"
+put_template 3  "ff/cb/3e"
+put_template 4  "00/6b/b3"
+put_template 5  "6b/27/75"
+put_template 6  "38/45/64"
+put_template 7  "ed/ed/ed"
+put_template 8  "5d/50/4a"
+put_template 9  "f0/7e/18"
+put_template 10 "b1/d1/30"
+put_template 11 "ff/f1/20"
+put_template 12 "4f/c2/fd"
+put_template 13 "de/00/71"
+put_template 14 "5d/50/4a"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ed/ed/ed"
+color_background="22/22/25"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ededed"
+  put_template_custom Ph "222225"
+  put_template_custom Pi "fff8d8"
+  put_template_custom Pj "384564"
+  put_template_custom Pk "ededed"
+  put_template_custom Pl "e0d9b9"
+  put_template_custom Pm "1f192a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hipster Green.sh
+++ b/generic/Hipster Green.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hipster Green
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b6/21/4a"
+put_template 2  "00/a6/00"
+put_template 3  "bf/bf/00"
+put_template 4  "24/6e/b2"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "86/a9/3e"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="84/c1/38"
+color_background="10/0b/05"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "84c138"
+  put_template_custom Ph "100b05"
+  put_template_custom Pi "00db00"
+  put_template_custom Pj "083905"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "23ff18"
+  put_template_custom Pm "ff0018"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hivacruz.sh
+++ b/generic/Hivacruz.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hivacruz
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "20/27/46"
+put_template 1  "c9/49/22"
+put_template 2  "ac/97/39"
+put_template 3  "c0/8b/30"
+put_template 4  "3d/8f/d1"
+put_template 5  "66/79/cc"
+put_template 6  "22/a2/c9"
+put_template 7  "97/9d/b4"
+put_template 8  "6b/73/94"
+put_template 9  "c7/6b/29"
+put_template 10 "73/ad/43"
+put_template 11 "5e/66/87"
+put_template 12 "89/8e/a4"
+put_template 13 "df/e2/f1"
+put_template 14 "9c/63/7a"
+put_template 15 "f5/f7/ff"
+
+color_foreground="ed/e4/e4"
+color_background="13/26/38"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ede4e4"
+  put_template_custom Ph "132638"
+  put_template_custom Pi "979db4"
+  put_template_custom Pj "5e6687"
+  put_template_custom Pk "979db4"
+  put_template_custom Pl "979db4"
+  put_template_custom Pm "202746"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Homebrew.sh
+++ b/generic/Homebrew.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Homebrew
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "99/00/00"
+put_template 2  "00/a6/00"
+put_template 3  "99/99/00"
+put_template 4  "00/00/b2"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "00/d9/00"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="00/ff/00"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "00ff00"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "00ff00"
+  put_template_custom Pj "083905"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "23ff18"
+  put_template_custom Pm "ff0018"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hopscotch.256.sh
+++ b/generic/Hopscotch.256.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hopscotch.256
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/29/31"
+put_template 1  "dd/46/4c"
+put_template 2  "8f/c1/3e"
+put_template 3  "fd/cc/59"
+put_template 4  "12/90/bf"
+put_template 5  "c8/5e/7c"
+put_template 6  "14/9b/93"
+put_template 7  "b9/b5/b8"
+put_template 8  "79/73/79"
+put_template 9  "dd/46/4c"
+put_template 10 "8f/c1/3e"
+put_template 11 "fd/cc/59"
+put_template 12 "12/90/bf"
+put_template 13 "c8/5e/7c"
+put_template 14 "14/9b/93"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b9/b5/b8"
+color_background="32/29/31"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b9b5b8"
+  put_template_custom Ph "322931"
+  put_template_custom Pi "b9b5b8"
+  put_template_custom Pj "5c545b"
+  put_template_custom Pk "b9b5b8"
+  put_template_custom Pl "b9b5b8"
+  put_template_custom Pm "322931"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hopscotch.sh
+++ b/generic/Hopscotch.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hopscotch
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/29/31"
+put_template 1  "dd/46/4c"
+put_template 2  "8f/c1/3e"
+put_template 3  "fd/cc/59"
+put_template 4  "12/90/bf"
+put_template 5  "c8/5e/7c"
+put_template 6  "14/9b/93"
+put_template 7  "b9/b5/b8"
+put_template 8  "79/73/79"
+put_template 9  "fd/8b/19"
+put_template 10 "43/3b/42"
+put_template 11 "5c/54/5b"
+put_template 12 "98/94/98"
+put_template 13 "d5/d3/d5"
+put_template 14 "b3/35/08"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b9/b5/b8"
+color_background="32/29/31"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b9b5b8"
+  put_template_custom Ph "322931"
+  put_template_custom Pi "b9b5b8"
+  put_template_custom Pj "5c545b"
+  put_template_custom Pk "b9b5b8"
+  put_template_custom Pl "b9b5b8"
+  put_template_custom Pm "322931"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Horizon-Bright.sh
+++ b/generic/Horizon-Bright.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Horizon-Bright
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "16/16/1c"
+put_template 1  "e9/56/78"
+put_template 2  "29/d3/98"
+put_template 3  "fa/b7/95"
+put_template 4  "26/bb/d9"
+put_template 5  "ee/64/ae"
+put_template 6  "59/e3/e3"
+put_template 7  "fd/f0/ed"
+put_template 8  "1a/1c/23"
+put_template 9  "ec/6a/88"
+put_template 10 "3f/da/a4"
+put_template 11 "fb/c3/a7"
+put_template 12 "3f/c6/de"
+put_template 13 "f0/75/b7"
+put_template 14 "6b/e6/e6"
+put_template 15 "ff/f3/f0"
+
+color_foreground="16/16/1c"
+color_background="fb/f0/ee"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "16161c"
+  put_template_custom Ph "fbf0ee"
+  put_template_custom Pi "16161c"
+  put_template_custom Pj "f2d0c5"
+  put_template_custom Pk "16161c"
+  put_template_custom Pl "f2d0c5"
+  put_template_custom Pm "f2d0c5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Horizon.sh
+++ b/generic/Horizon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Horizon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "e9/56/78"
+put_template 2  "29/d3/98"
+put_template 3  "fa/b7/95"
+put_template 4  "26/bb/d9"
+put_template 5  "ee/64/ac"
+put_template 6  "59/e1/e3"
+put_template 7  "e5/e5/e5"
+put_template 8  "66/66/66"
+put_template 9  "ec/6a/88"
+put_template 10 "3f/da/a4"
+put_template 11 "fb/c3/a7"
+put_template 12 "3f/c4/de"
+put_template 13 "f0/75/b5"
+put_template 14 "6b/e4/e6"
+put_template 15 "e5/e5/e5"
+
+color_foreground="d5/d8/da"
+color_background="1c/1e/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d5d8da"
+  put_template_custom Ph "1c1e26"
+  put_template_custom Pi "d5d8da"
+  put_template_custom Pj "6c6f93"
+  put_template_custom Pk "1c1e26"
+  put_template_custom Pl "6c6f93"
+  put_template_custom Pm "6c6f93"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hurtado.sh
+++ b/generic/Hurtado.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hurtado
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "57/57/57"
+put_template 1  "ff/1b/00"
+put_template 2  "a5/e0/55"
+put_template 3  "fb/e7/4a"
+put_template 4  "49/64/87"
+put_template 5  "fd/5f/f1"
+put_template 6  "86/e9/fe"
+put_template 7  "cb/cc/cb"
+put_template 8  "26/26/26"
+put_template 9  "d5/1d/00"
+put_template 10 "a5/df/55"
+put_template 11 "fb/e8/4a"
+put_template 12 "89/be/ff"
+put_template 13 "c0/01/c1"
+put_template 14 "86/ea/fe"
+put_template 15 "db/db/db"
+
+color_foreground="db/db/db"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dbdbdb"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Hybrid.sh
+++ b/generic/Hybrid.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Hybrid
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2a/2e/33"
+put_template 1  "b8/4d/51"
+put_template 2  "b3/bf/5a"
+put_template 3  "e4/b5/5e"
+put_template 4  "6e/90/b0"
+put_template 5  "a1/7e/ac"
+put_template 6  "7f/bf/b4"
+put_template 7  "b5/b9/b6"
+put_template 8  "1d/1f/22"
+put_template 9  "8d/2e/32"
+put_template 10 "79/84/31"
+put_template 11 "e5/8a/50"
+put_template 12 "4b/6b/88"
+put_template 13 "6e/50/79"
+put_template 14 "4d/7b/74"
+put_template 15 "5a/62/6a"
+
+color_foreground="b7/bc/ba"
+color_background="16/17/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b7bcba"
+  put_template_custom Ph "161719"
+  put_template_custom Pi "b7bcba"
+  put_template_custom Pj "1e1f22"
+  put_template_custom Pk "b7bcba"
+  put_template_custom Pl "b7bcba"
+  put_template_custom Pm "1e1f22"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/IC_Green_PPL.sh
+++ b/generic/IC_Green_PPL.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# IC_Green_PPL
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/44/01"
+put_template 1  "ff/27/36"
+put_template 2  "41/a6/38"
+put_template 3  "76/a8/31"
+put_template 4  "2e/c3/b9"
+put_template 5  "50/a0/96"
+put_template 6  "3c/a0/78"
+put_template 7  "e6/fe/f2"
+put_template 8  "03/5c/03"
+put_template 9  "b4/fa/5c"
+put_template 10 "ae/fb/86"
+put_template 11 "da/fa/87"
+put_template 12 "2e/fa/eb"
+put_template 13 "50/fa/fa"
+put_template 14 "3c/fa/c8"
+put_template 15 "e0/f1/dc"
+
+color_foreground="e0/f1/dc"
+color_background="2c/2c/2c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e0f1dc"
+  put_template_custom Ph "2c2c2c"
+  put_template_custom Pi "acfb80"
+  put_template_custom Pj "116b41"
+  put_template_custom Pk "e0f1dc"
+  put_template_custom Pl "47fa6b"
+  put_template_custom Pm "292929"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/IC_Orange_PPL.sh
+++ b/generic/IC_Orange_PPL.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# IC_Orange_PPL
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c1/39/00"
+put_template 2  "a4/a9/00"
+put_template 3  "ca/af/00"
+put_template 4  "bd/6d/00"
+put_template 5  "fc/5e/00"
+put_template 6  "f7/95/00"
+put_template 7  "ff/c8/8a"
+put_template 8  "6a/4f/2a"
+put_template 9  "ff/8c/68"
+put_template 10 "f6/ff/40"
+put_template 11 "ff/e3/6e"
+put_template 12 "ff/be/55"
+put_template 13 "fc/87/4f"
+put_template 14 "c6/97/52"
+put_template 15 "fa/fa/ff"
+
+color_foreground="ff/cb/83"
+color_background="26/26/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffcb83"
+  put_template_custom Ph "262626"
+  put_template_custom Pi "fafaff"
+  put_template_custom Pj "c14020"
+  put_template_custom Pk "ffc88a"
+  put_template_custom Pl "fc531d"
+  put_template_custom Pm "ffc88a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/IRIX Console.sh
+++ b/generic/IRIX Console.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# IRIX Console
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/19/19"
+put_template 1  "d4/24/26"
+put_template 2  "37/a3/27"
+put_template 3  "c2/9d/28"
+put_template 4  "07/39/e2"
+put_template 5  "91/1f/9c"
+put_template 6  "44/97/df"
+put_template 7  "cc/cc/cc"
+put_template 8  "76/76/76"
+put_template 9  "f3/4f/59"
+put_template 10 "45/c7/31"
+put_template 11 "f9/f2/a7"
+put_template 12 "40/79/ff"
+put_template 13 "c3/1b/a2"
+put_template 14 "6e/d7/d7"
+put_template 15 "f2/f2/f2"
+
+color_foreground="f2/f2/f2"
+color_background="0c/0c/0c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f2f2"
+  put_template_custom Ph "0c0c0c"
+  put_template_custom Pi "ffff44"
+  put_template_custom Pj "c2deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/IRIX Terminal.sh
+++ b/generic/IRIX Terminal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# IRIX Terminal
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/19/19"
+put_template 1  "ff/2b/1e"
+put_template 2  "57/ff/3d"
+put_template 3  "ff/ff/44"
+put_template 4  "00/04/ff"
+put_template 5  "ff/2c/ff"
+put_template 6  "56/ff/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "ff/ff/44"
+put_template 9  "ff/ff/44"
+put_template 10 "ff/ff/44"
+put_template 11 "ff/fc/72"
+put_template 12 "ff/ff/44"
+put_template 13 "ff/ff/44"
+put_template 14 "ff/ff/44"
+put_template 15 "ff/ff/44"
+
+color_foreground="f2/f2/f2"
+color_background="00/00/43"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f2f2"
+  put_template_custom Ph "000043"
+  put_template_custom Pi "ffff44"
+  put_template_custom Pj "c2deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/IR_Black.sh
+++ b/generic/IR_Black.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# IR_Black
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4f/4f/4f"
+put_template 1  "fa/6c/60"
+put_template 2  "a8/ff/60"
+put_template 3  "ff/fe/b7"
+put_template 4  "96/ca/fe"
+put_template 5  "fa/73/fd"
+put_template 6  "c6/c5/fe"
+put_template 7  "ef/ed/ef"
+put_template 8  "7b/7b/7b"
+put_template 9  "fc/b6/b0"
+put_template 10 "cf/ff/ab"
+put_template 11 "ff/ff/cc"
+put_template 12 "b5/dc/ff"
+put_template 13 "fb/9c/fe"
+put_template 14 "e0/e0/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f1/f1/f1"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f1f1f1"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "808080"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Jackie Brown.sh
+++ b/generic/Jackie Brown.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Jackie Brown
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2c/1d/16"
+put_template 1  "ef/57/34"
+put_template 2  "2b/af/2b"
+put_template 3  "be/bf/00"
+put_template 4  "24/6e/b2"
+put_template 5  "d0/5e/c1"
+put_template 6  "00/ac/ee"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "86/a9/3e"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="ff/cc/2f"
+color_background="2c/1d/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffcc2f"
+  put_template_custom Ph "2c1d16"
+  put_template_custom Pi "ffcc2f"
+  put_template_custom Pj "af8d21"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "23ff18"
+  put_template_custom Pm "ff0018"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Japanesque.sh
+++ b/generic/Japanesque.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Japanesque
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "34/39/35"
+put_template 1  "cf/3f/61"
+put_template 2  "7b/b7/5b"
+put_template 3  "e9/b3/2a"
+put_template 4  "4c/9a/d4"
+put_template 5  "a5/7f/c4"
+put_template 6  "38/9a/ad"
+put_template 7  "fa/fa/f6"
+put_template 8  "59/5b/59"
+put_template 9  "d1/8f/a6"
+put_template 10 "76/7f/2c"
+put_template 11 "78/59/2f"
+put_template 12 "13/59/79"
+put_template 13 "60/42/91"
+put_template 14 "76/bb/ca"
+put_template 15 "b2/b5/ae"
+
+color_foreground="f7/f6/ec"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f7f6ec"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "fffffa"
+  put_template_custom Pj "175877"
+  put_template_custom Pk "f7f6ec"
+  put_template_custom Pl "edcf4f"
+  put_template_custom Pm "343935"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Jellybeans.sh
+++ b/generic/Jellybeans.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Jellybeans
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "92/92/92"
+put_template 1  "e2/73/73"
+put_template 2  "94/b9/79"
+put_template 3  "ff/ba/7b"
+put_template 4  "97/be/dc"
+put_template 5  "e1/c0/fa"
+put_template 6  "00/98/8e"
+put_template 7  "de/de/de"
+put_template 8  "bd/bd/bd"
+put_template 9  "ff/a1/a1"
+put_template 10 "bd/de/ab"
+put_template 11 "ff/dc/a0"
+put_template 12 "b1/d8/f6"
+put_template 13 "fb/da/ff"
+put_template 14 "1a/b2/a8"
+put_template 15 "ff/ff/ff"
+
+color_foreground="de/de/de"
+color_background="12/12/12"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dedede"
+  put_template_custom Ph "121212"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "474e91"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "ffa560"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/JetBrains Darcula.sh
+++ b/generic/JetBrains Darcula.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# JetBrains Darcula
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fa/53/55"
+put_template 2  "12/6e/00"
+put_template 3  "c2/c3/00"
+put_template 4  "45/81/eb"
+put_template 5  "fa/54/ff"
+put_template 6  "33/c2/c1"
+put_template 7  "ad/ad/ad"
+put_template 8  "55/55/55"
+put_template 9  "fb/71/72"
+put_template 10 "67/ff/4f"
+put_template 11 "ff/ff/00"
+put_template 12 "6d/9d/f1"
+put_template 13 "fb/82/ff"
+put_template 14 "60/d3/d1"
+put_template 15 "ee/ee/ee"
+
+color_foreground="ad/ad/ad"
+color_background="20/20/20"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "adadad"
+  put_template_custom Ph "202020"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "1a3272"
+  put_template_custom Pk "adadad"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Kanagawa Dragon.sh
+++ b/generic/Kanagawa Dragon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Kanagawa Dragon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0d/0c/0c"
+put_template 1  "c4/74/6e"
+put_template 2  "8a/9a/7b"
+put_template 3  "c4/b2/8a"
+put_template 4  "8b/a4/b0"
+put_template 5  "a2/92/a3"
+put_template 6  "8e/a4/a2"
+put_template 7  "c8/c0/93"
+put_template 8  "a6/a6/9c"
+put_template 9  "e4/68/76"
+put_template 10 "87/a9/87"
+put_template 11 "e6/c3/84"
+put_template 12 "7f/b4/ca"
+put_template 13 "93/8a/a9"
+put_template 14 "7a/a8/9f"
+put_template 15 "c5/c9/c5"
+
+color_foreground="c8/c0/93"
+color_background="18/16/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c8c093"
+  put_template_custom Ph "181616"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "223249"
+  put_template_custom Pk "c5c9c5"
+  put_template_custom Pl "c5c9c5"
+  put_template_custom Pm "1d202f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Kanagawa Wave.sh
+++ b/generic/Kanagawa Wave.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Kanagawa Wave
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/06/18"
+put_template 1  "c3/40/43"
+put_template 2  "76/94/6a"
+put_template 3  "c0/a3/6e"
+put_template 4  "7e/9c/d8"
+put_template 5  "95/7f/b8"
+put_template 6  "6a/95/89"
+put_template 7  "c8/c0/93"
+put_template 8  "72/71/69"
+put_template 9  "e8/24/24"
+put_template 10 "98/bb/6c"
+put_template 11 "e6/c3/84"
+put_template 12 "7f/b4/ca"
+put_template 13 "93/8a/a9"
+put_template 14 "7a/a8/9f"
+put_template 15 "dc/d7/ba"
+
+color_foreground="dc/d7/ba"
+color_background="1f/1f/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcd7ba"
+  put_template_custom Ph "1f1f28"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "2d4f67"
+  put_template_custom Pk "c8c093"
+  put_template_custom Pl "c8c093"
+  put_template_custom Pm "1d202f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Kibble.sh
+++ b/generic/Kibble.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Kibble
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4d/4d/4d"
+put_template 1  "c7/00/31"
+put_template 2  "29/cf/13"
+put_template 3  "d8/e3/0e"
+put_template 4  "34/49/d1"
+put_template 5  "84/00/ff"
+put_template 6  "07/98/ab"
+put_template 7  "e2/d1/e3"
+put_template 8  "5a/5a/5a"
+put_template 9  "f0/15/78"
+put_template 10 "6c/e0/5c"
+put_template 11 "f3/f7/9e"
+put_template 12 "97/a4/f7"
+put_template 13 "c4/95/f0"
+put_template 14 "68/f2/e0"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f7/f7/f7"
+color_background="0e/10/0a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f7f7f7"
+  put_template_custom Ph "0e100a"
+  put_template_custom Pi "ca631e"
+  put_template_custom Pj "9ba787"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "9fda9c"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Kolorit.sh
+++ b/generic/Kolorit.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Kolorit
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1a/1e"
+put_template 1  "ff/5b/82"
+put_template 2  "47/d7/a1"
+put_template 3  "e8/e5/62"
+put_template 4  "5d/b4/ee"
+put_template 5  "da/6c/da"
+put_template 6  "57/e9/eb"
+put_template 7  "ed/ed/ed"
+put_template 8  "1d/1a/1e"
+put_template 9  "ff/5b/82"
+put_template 10 "47/d7/a1"
+put_template 11 "e8/e5/62"
+put_template 12 "5d/b4/ee"
+put_template 13 "da/6c/da"
+put_template 14 "57/e9/eb"
+put_template 15 "ed/ed/ed"
+
+color_foreground="ef/ec/ec"
+color_background="1d/1a/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "efecec"
+  put_template_custom Ph "1d1a1e"
+  put_template_custom Pi "ff5b82"
+  put_template_custom Pj "e1925c"
+  put_template_custom Pk "1d1a1e"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Konsolas.sh
+++ b/generic/Konsolas.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Konsolas
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "aa/17/17"
+put_template 2  "18/b2/18"
+put_template 3  "eb/ae/1f"
+put_template 4  "23/23/a5"
+put_template 5  "ad/1e/dc"
+put_template 6  "42/b0/c8"
+put_template 7  "c8/c1/c1"
+put_template 8  "7b/71/6e"
+put_template 9  "ff/41/41"
+put_template 10 "5f/ff/5f"
+put_template 11 "ff/ff/55"
+put_template 12 "4b/4b/ff"
+put_template 13 "ff/54/ff"
+put_template 14 "69/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c8/c1/c1"
+color_background="06/06/06"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c8c1c1"
+  put_template_custom Ph "060606"
+  put_template_custom Pi "c8c1c1"
+  put_template_custom Pj "060606"
+  put_template_custom Pk "c8c1c1"
+  put_template_custom Pl "c8c1c1"
+  put_template_custom Pm "060606"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Lab Fox.sh
+++ b/generic/Lab Fox.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Lab Fox
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2e/2e/2e"
+put_template 1  "fc/6d/26"
+put_template 2  "3e/b3/83"
+put_template 3  "fc/a1/21"
+put_template 4  "db/3b/21"
+put_template 5  "38/0d/75"
+put_template 6  "6e/49/cb"
+put_template 7  "ff/ff/ff"
+put_template 8  "46/46/46"
+put_template 9  "ff/65/17"
+put_template 10 "53/ea/a8"
+put_template 11 "fc/a0/13"
+put_template 12 "db/50/1f"
+put_template 13 "44/10/90"
+put_template 14 "7d/53/e7"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="2e/2e/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "2e2e2e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "cb392e"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "7f7f7f"
+  put_template_custom Pm "7f7f7f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Laser.sh
+++ b/generic/Laser.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Laser
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "62/62/62"
+put_template 1  "ff/83/73"
+put_template 2  "b4/fb/73"
+put_template 3  "09/b4/bd"
+put_template 4  "fe/d3/00"
+put_template 5  "ff/90/fe"
+put_template 6  "d1/d1/fe"
+put_template 7  "f1/f1/f1"
+put_template 8  "8f/8f/8f"
+put_template 9  "ff/c4/be"
+put_template 10 "d6/fc/ba"
+put_template 11 "ff/fe/d5"
+put_template 12 "f9/28/83"
+put_template 13 "ff/b2/fe"
+put_template 14 "e6/e7/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f1/06/e3"
+color_background="03/0d/18"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f106e3"
+  put_template_custom Ph "030d18"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "2e206a"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "00ff9c"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Later This Evening.sh
+++ b/generic/Later This Evening.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Later This Evening
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2b/2b/2b"
+put_template 1  "d4/5a/60"
+put_template 2  "af/ba/67"
+put_template 3  "e5/d2/89"
+put_template 4  "a0/ba/d6"
+put_template 5  "c0/92/d6"
+put_template 6  "91/bf/b7"
+put_template 7  "3c/3d/3d"
+put_template 8  "45/47/47"
+put_template 9  "d3/23/2f"
+put_template 10 "aa/bb/39"
+put_template 11 "e5/be/39"
+put_template 12 "66/99/d6"
+put_template 13 "ab/53/d6"
+put_template 14 "5f/c0/ae"
+put_template 15 "c1/c2/c2"
+
+color_foreground="95/95/95"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "959595"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "424242"
+  put_template_custom Pk "959595"
+  put_template_custom Pl "424242"
+  put_template_custom Pm "959595"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Lavandula.sh
+++ b/generic/Lavandula.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Lavandula
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "23/00/46"
+put_template 1  "7d/16/25"
+put_template 2  "33/7e/6f"
+put_template 3  "7f/6f/49"
+put_template 4  "4f/4a/7f"
+put_template 5  "5a/3f/7f"
+put_template 6  "58/77/7f"
+put_template 7  "73/6e/7d"
+put_template 8  "37/2d/46"
+put_template 9  "e0/51/67"
+put_template 10 "52/e0/c4"
+put_template 11 "e0/c3/86"
+put_template 12 "8e/87/e0"
+put_template 13 "a7/76/e0"
+put_template 14 "9a/d4/e0"
+put_template 15 "8c/91/fa"
+
+color_foreground="73/6e/7d"
+color_background="05/00/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "736e7d"
+  put_template_custom Ph "050014"
+  put_template_custom Pi "8c91fa"
+  put_template_custom Pj "37323c"
+  put_template_custom Pk "8c91fa"
+  put_template_custom Pl "8c91fa"
+  put_template_custom Pm "050014"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/LightOwl.sh
+++ b/generic/LightOwl.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# LightOwl
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "40/3f/53"
+put_template 1  "de/3d/3b"
+put_template 2  "08/91/6a"
+put_template 3  "e0/af/02"
+put_template 4  "28/8e/d7"
+put_template 5  "d6/43/8a"
+put_template 6  "2a/a2/98"
+put_template 7  "f0/f0/f0"
+put_template 8  "98/9f/b1"
+put_template 9  "de/3d/3b"
+put_template 10 "08/91/6a"
+put_template 11 "da/aa/01"
+put_template 12 "28/8e/d7"
+put_template 13 "d6/43/8a"
+put_template 14 "2a/a2/98"
+put_template 15 "f0/f0/f0"
+
+color_foreground="40/3f/53"
+color_background="fb/fb/fb"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "403f53"
+  put_template_custom Ph "fbfbfb"
+  put_template_custom Pi "403f53"
+  put_template_custom Pj "e0e0e0"
+  put_template_custom Pk "403f53"
+  put_template_custom Pl "403f53"
+  put_template_custom Pm "f6f6f6"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/LiquidCarbon.sh
+++ b/generic/LiquidCarbon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# LiquidCarbon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/30/30"
+put_template 2  "55/9a/70"
+put_template 3  "cc/ac/00"
+put_template 4  "00/99/cc"
+put_template 5  "cc/69/c8"
+put_template 6  "7a/c4/cc"
+put_template 7  "bc/cc/cc"
+put_template 8  "00/00/00"
+put_template 9  "ff/30/30"
+put_template 10 "55/9a/70"
+put_template 11 "cc/ac/00"
+put_template 12 "00/99/cc"
+put_template 13 "cc/69/c8"
+put_template 14 "7a/c4/cc"
+put_template 15 "bc/cc/cc"
+
+color_foreground="af/c2/c2"
+color_background="30/30/30"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "afc2c2"
+  put_template_custom Ph "303030"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "7dbeff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/LiquidCarbonTransparent.sh
+++ b/generic/LiquidCarbonTransparent.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# LiquidCarbonTransparent
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/30/30"
+put_template 2  "55/9a/70"
+put_template 3  "cc/ac/00"
+put_template 4  "00/99/cc"
+put_template 5  "cc/69/c8"
+put_template 6  "7a/c4/cc"
+put_template 7  "bc/cc/cc"
+put_template 8  "00/00/00"
+put_template 9  "ff/30/30"
+put_template 10 "55/9a/70"
+put_template 11 "cc/ac/00"
+put_template 12 "00/99/cc"
+put_template 13 "cc/69/c8"
+put_template 14 "7a/c4/cc"
+put_template 15 "bc/cc/cc"
+
+color_foreground="af/c2/c2"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "afc2c2"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "7dbeff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/LiquidCarbonTransparentInverse.sh
+++ b/generic/LiquidCarbonTransparentInverse.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# LiquidCarbonTransparentInverse
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "bc/cc/cd"
+put_template 1  "ff/30/30"
+put_template 2  "55/9a/70"
+put_template 3  "cc/ac/00"
+put_template 4  "00/99/cc"
+put_template 5  "cc/69/c8"
+put_template 6  "7a/c4/cc"
+put_template 7  "00/00/00"
+put_template 8  "ff/ff/ff"
+put_template 9  "ff/30/30"
+put_template 10 "55/9a/70"
+put_template 11 "cc/ac/00"
+put_template 12 "00/99/cc"
+put_template 13 "cc/69/c8"
+put_template 14 "7a/c4/cc"
+put_template 15 "00/00/00"
+
+color_foreground="af/c2/c2"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "afc2c2"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "7dbeff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Man Page.sh
+++ b/generic/Man Page.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Man Page
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/00/00"
+put_template 2  "00/a6/00"
+put_template 3  "99/99/00"
+put_template 4  "00/00/b2"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "cc/cc/cc"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "00/d9/00"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="00/00/00"
+color_background="fe/f4/9c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "fef49c"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "a4c9cd"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "7f7f7f"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Mariana.sh
+++ b/generic/Mariana.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Mariana
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ec/5f/66"
+put_template 2  "99/c7/94"
+put_template 3  "f9/ae/58"
+put_template 4  "66/99/cc"
+put_template 5  "c6/95/c6"
+put_template 6  "5f/b4/b4"
+put_template 7  "f7/f7/f7"
+put_template 8  "33/33/33"
+put_template 9  "f9/7b/58"
+put_template 10 "ac/d1/a8"
+put_template 11 "fa/c7/61"
+put_template 12 "85/ad/d6"
+put_template 13 "d8/b6/d8"
+put_template 14 "82/c4/c4"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d8/de/e9"
+color_background="34/3d/46"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "343d46"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4e5a65"
+  put_template_custom Pk "d8dee9"
+  put_template_custom Pl "fcbb6a"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Material.sh
+++ b/generic/Material.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Material
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/21/21"
+put_template 1  "b7/14/1f"
+put_template 2  "45/7b/24"
+put_template 3  "f6/98/1e"
+put_template 4  "13/4e/b2"
+put_template 5  "56/00/88"
+put_template 6  "0e/71/7c"
+put_template 7  "ef/ef/ef"
+put_template 8  "42/42/42"
+put_template 9  "e8/3b/3f"
+put_template 10 "7a/ba/3a"
+put_template 11 "ff/ea/2e"
+put_template 12 "54/a4/f3"
+put_template 13 "aa/4d/bc"
+put_template 14 "26/bb/d1"
+put_template 15 "d9/d9/d9"
+
+color_foreground="23/23/22"
+color_background="ea/ea/ea"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "232322"
+  put_template_custom Ph "eaeaea"
+  put_template_custom Pi "b7141f"
+  put_template_custom Pj "c2c2c2"
+  put_template_custom Pk "4e4e4e"
+  put_template_custom Pl "16afca"
+  put_template_custom Pm "2e2e2d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/MaterialDark.sh
+++ b/generic/MaterialDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# MaterialDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/21/21"
+put_template 1  "b7/14/1f"
+put_template 2  "45/7b/24"
+put_template 3  "f6/98/1e"
+put_template 4  "13/4e/b2"
+put_template 5  "56/00/88"
+put_template 6  "0e/71/7c"
+put_template 7  "ef/ef/ef"
+put_template 8  "42/42/42"
+put_template 9  "e8/3b/3f"
+put_template 10 "7a/ba/3a"
+put_template 11 "ff/ea/2e"
+put_template 12 "54/a4/f3"
+put_template 13 "aa/4d/bc"
+put_template 14 "26/bb/d1"
+put_template 15 "d9/d9/d9"
+
+color_foreground="e5/e5/e5"
+color_background="23/23/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e5e5e5"
+  put_template_custom Ph "232322"
+  put_template_custom Pi "b7141f"
+  put_template_custom Pj "dfdfdf"
+  put_template_custom Pk "3d3d3d"
+  put_template_custom Pl "16afca"
+  put_template_custom Pm "dfdfdf"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/MaterialDarker.sh
+++ b/generic/MaterialDarker.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# MaterialDarker
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/53/70"
+put_template 2  "c3/e8/8d"
+put_template 3  "ff/cb/6b"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "89/dd/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "54/54/54"
+put_template 9  "ff/53/70"
+put_template 10 "c3/e8/8d"
+put_template 11 "ff/cb/6b"
+put_template 12 "82/aa/ff"
+put_template 13 "c7/92/ea"
+put_template 14 "89/dd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ee/ff/ff"
+color_background="21/21/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eeffff"
+  put_template_custom Ph "212121"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "eeffff"
+  put_template_custom Pk "545454"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/MaterialDesignColors.sh
+++ b/generic/MaterialDesignColors.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# MaterialDesignColors
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "43/5b/67"
+put_template 1  "fc/38/41"
+put_template 2  "5c/f1/9e"
+put_template 3  "fe/d0/32"
+put_template 4  "37/b6/ff"
+put_template 5  "fc/22/6e"
+put_template 6  "59/ff/d1"
+put_template 7  "ff/ff/ff"
+put_template 8  "a1/b0/b8"
+put_template 9  "fc/74/6d"
+put_template 10 "ad/f7/be"
+put_template 11 "fe/e1/6c"
+put_template 12 "70/cf/ff"
+put_template 13 "fc/66/9b"
+put_template 14 "9a/ff/e6"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e7/eb/ed"
+color_background="1d/26/2a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e7ebed"
+  put_template_custom Ph "1d262a"
+  put_template_custom Pi "eaeaea"
+  put_template_custom Pj "4e6a78"
+  put_template_custom Pk "e7ebed"
+  put_template_custom Pl "eaeaea"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/MaterialOcean.sh
+++ b/generic/MaterialOcean.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# MaterialOcean
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "54/6e/7a"
+put_template 1  "ff/53/70"
+put_template 2  "c3/e8/8d"
+put_template 3  "ff/cb/6b"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "89/dd/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "54/6e/7a"
+put_template 9  "ff/53/70"
+put_template 10 "c3/e8/8d"
+put_template 11 "ff/cb/6b"
+put_template 12 "82/aa/ff"
+put_template 13 "c7/92/ea"
+put_template 14 "89/dd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="8f/93/a2"
+color_background="0f/11/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "8f93a2"
+  put_template_custom Ph "0f111a"
+  put_template_custom Pi "8f93a2"
+  put_template_custom Pj "1f2233"
+  put_template_custom Pk "8f93a2"
+  put_template_custom Pl "ffcc00"
+  put_template_custom Pm "0f111a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Mathias.sh
+++ b/generic/Mathias.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Mathias
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "e5/22/22"
+put_template 2  "a6/e3/2d"
+put_template 3  "fc/95/1e"
+put_template 4  "c4/8d/ff"
+put_template 5  "fa/25/73"
+put_template 6  "67/d9/f0"
+put_template 7  "f2/f2/f2"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "555555"
+  put_template_custom Pk "f2f2f2"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Medallion.sh
+++ b/generic/Medallion.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Medallion
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b6/4c/00"
+put_template 2  "7c/8b/16"
+put_template 3  "d3/bd/26"
+put_template 4  "61/6b/b0"
+put_template 5  "8c/5a/90"
+put_template 6  "91/6c/25"
+put_template 7  "ca/c2/9a"
+put_template 8  "5e/52/19"
+put_template 9  "ff/91/49"
+put_template 10 "b2/ca/3b"
+put_template 11 "ff/e5/4a"
+put_template 12 "ac/b8/ff"
+put_template 13 "ff/a0/ff"
+put_template 14 "ff/bc/51"
+put_template 15 "fe/d6/98"
+
+color_foreground="ca/c2/96"
+color_background="1d/19/08"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cac296"
+  put_template_custom Ph "1d1908"
+  put_template_custom Pi "ffd890"
+  put_template_custom Pj "626dac"
+  put_template_custom Pk "cac29a"
+  put_template_custom Pl "d3ba30"
+  put_template_custom Pm "d2bc3d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Melange_dark.sh
+++ b/generic/Melange_dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Melange_dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "34/30/2c"
+put_template 1  "bd/81/83"
+put_template 2  "78/99/7a"
+put_template 3  "e4/9b/5d"
+put_template 4  "7f/91/b2"
+put_template 5  "b3/80/b0"
+put_template 6  "7b/96/95"
+put_template 7  "c1/a7/8e"
+put_template 8  "86/74/62"
+put_template 9  "d4/77/66"
+put_template 10 "85/b6/95"
+put_template 11 "eb/c0/6d"
+put_template 12 "a3/a9/ce"
+put_template 13 "cf/9b/c2"
+put_template 14 "89/b3/b6"
+put_template 15 "ec/e1/d7"
+
+color_foreground="ec/e1/d7"
+color_background="29/25/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ece1d7"
+  put_template_custom Ph "292522"
+  put_template_custom Pi "292522"
+  put_template_custom Pj "ece1d7"
+  put_template_custom Pk "403a36"
+  put_template_custom Pl "ece1d7"
+  put_template_custom Pm "292522"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Melange_light.sh
+++ b/generic/Melange_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Melange_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "e9/e1/db"
+put_template 1  "c7/7b/8b"
+put_template 2  "6e/9b/72"
+put_template 3  "bc/5c/00"
+put_template 4  "78/92/bd"
+put_template 5  "be/79/bb"
+put_template 6  "73/97/97"
+put_template 7  "7d/66/58"
+put_template 8  "a9/8a/78"
+put_template 9  "bf/00/21"
+put_template 10 "3a/68/4a"
+put_template 11 "a0/6d/00"
+put_template 12 "46/5a/a4"
+put_template 13 "90/41/80"
+put_template 14 "3d/65/68"
+put_template 15 "54/43/3a"
+
+color_foreground="54/43/3a"
+color_background="f1/f1/f1"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "54433a"
+  put_template_custom Ph "f1f1f1"
+  put_template_custom Pi "f1f1f1"
+  put_template_custom Pj "54433a"
+  put_template_custom Pk "d9d3ce"
+  put_template_custom Pl "54433a"
+  put_template_custom Pm "f1f1f1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Mellifluous.sh
+++ b/generic/Mellifluous.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Mellifluous
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/1a/1a"
+put_template 1  "d2/93/93"
+put_template 2  "b3/b3/93"
+put_template 3  "cb/aa/89"
+put_template 4  "a8/a1/be"
+put_template 5  "b3/9f/b0"
+put_template 6  "c0/af/8c"
+put_template 7  "da/da/da"
+put_template 8  "5b/5b/5b"
+put_template 9  "c9/59/54"
+put_template 10 "82/80/40"
+put_template 11 "a6/79/4c"
+put_template 12 "5a/65/99"
+put_template 13 "9c/69/95"
+put_template 14 "74/a3/9e"
+put_template 15 "ff/ff/ff"
+
+color_foreground="da/da/da"
+color_background="1a/1a/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dadada"
+  put_template_custom Ph "1a1a1a"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "2d2d2d"
+  put_template_custom Pk "c0af8c"
+  put_template_custom Pl "bfad9e"
+  put_template_custom Pm "1a1a1a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Mirage.sh
+++ b/generic/Mirage.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Mirage
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/16/27"
+put_template 1  "ff/99/99"
+put_template 2  "85/cc/95"
+put_template 3  "ff/d7/00"
+put_template 4  "7f/b5/ff"
+put_template 5  "dd/b3/ff"
+put_template 6  "21/c7/a8"
+put_template 7  "ff/ff/ff"
+put_template 8  "57/56/56"
+put_template 9  "ff/99/99"
+put_template 10 "85/cc/95"
+put_template 11 "ff/d7/00"
+put_template 12 "7f/b5/ff"
+put_template 13 "dd/b3/ff"
+put_template 14 "85/cc/95"
+put_template 15 "ff/ff/ff"
+
+color_foreground="a6/b2/c0"
+color_background="1b/27/38"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a6b2c0"
+  put_template_custom Ph "1b2738"
+  put_template_custom Pi "ffb38c"
+  put_template_custom Pj "273951"
+  put_template_custom Pk "d3dbe5"
+  put_template_custom Pl "ddb3ff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Misterioso.sh
+++ b/generic/Misterioso.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Misterioso
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/42/42"
+put_template 2  "74/af/68"
+put_template 3  "ff/ad/29"
+put_template 4  "33/8f/86"
+put_template 5  "94/14/e6"
+put_template 6  "23/d7/d7"
+put_template 7  "e1/e1/e0"
+put_template 8  "55/55/55"
+put_template 9  "ff/32/42"
+put_template 10 "74/cd/68"
+put_template 11 "ff/b9/29"
+put_template 12 "23/d7/d7"
+put_template 13 "ff/37/ff"
+put_template 14 "00/ed/e1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e1/e1/e0"
+color_background="2d/37/43"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e1e1e0"
+  put_template_custom Ph "2d3743"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "2d37ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Molokai.sh
+++ b/generic/Molokai.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Molokai
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "12/12/12"
+put_template 1  "fa/25/73"
+put_template 2  "98/e1/23"
+put_template 3  "df/d4/60"
+put_template 4  "10/80/d0"
+put_template 5  "87/00/ff"
+put_template 6  "43/a8/d0"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "f6/66/9d"
+put_template 10 "b1/e0/5f"
+put_template 11 "ff/f2/6d"
+put_template 12 "00/af/ff"
+put_template 13 "af/87/ff"
+put_template 14 "51/ce/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="12/12/12"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "121212"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/MonaLisa.sh
+++ b/generic/MonaLisa.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# MonaLisa
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "35/1b/0e"
+put_template 1  "9b/29/1c"
+put_template 2  "63/62/32"
+put_template 3  "c3/6e/28"
+put_template 4  "51/5c/5d"
+put_template 5  "9b/1d/29"
+put_template 6  "58/80/56"
+put_template 7  "f7/d7/5c"
+put_template 8  "87/42/28"
+put_template 9  "ff/43/31"
+put_template 10 "b4/b2/64"
+put_template 11 "ff/95/66"
+put_template 12 "9e/b2/b4"
+put_template 13 "ff/5b/6a"
+put_template 14 "8a/cd/8f"
+put_template 15 "ff/e5/98"
+
+color_foreground="f7/d6/6a"
+color_background="12/0b/0d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f7d66a"
+  put_template_custom Ph "120b0d"
+  put_template_custom Pi "fee4a0"
+  put_template_custom Pj "f7d66a"
+  put_template_custom Pk "120b0d"
+  put_template_custom Pl "c46c32"
+  put_template_custom Pm "120b0d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Classic.sh
+++ b/generic/Monokai Classic.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Classic
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "27/28/22"
+put_template 1  "f9/26/72"
+put_template 2  "a6/e2/2e"
+put_template 3  "e6/db/74"
+put_template 4  "fd/97/1f"
+put_template 5  "ae/81/ff"
+put_template 6  "66/d9/ef"
+put_template 7  "fd/ff/f1"
+put_template 8  "6e/70/66"
+put_template 9  "f9/26/72"
+put_template 10 "a6/e2/2e"
+put_template 11 "e6/db/74"
+put_template 12 "fd/97/1f"
+put_template 13 "ae/81/ff"
+put_template 14 "66/d9/ef"
+put_template 15 "fd/ff/f1"
+
+color_foreground="fd/ff/f1"
+color_background="27/28/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fdfff1"
+  put_template_custom Ph "272822"
+  put_template_custom Pi "66d9ef"
+  put_template_custom Pj "57584f"
+  put_template_custom Pk "fdfff1"
+  put_template_custom Pl "c0c1b5"
+  put_template_custom Pm "c0c1b5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Light Sun.sh
+++ b/generic/Monokai Pro Light Sun.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Light Sun
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f8/ef/e7"
+put_template 1  "ce/47/70"
+put_template 2  "21/88/71"
+put_template 3  "b1/68/03"
+put_template 4  "d4/57/2b"
+put_template 5  "68/51/a2"
+put_template 6  "24/73/b6"
+put_template 7  "2c/23/2e"
+put_template 8  "a5/9c/9c"
+put_template 9  "ce/47/70"
+put_template 10 "21/88/71"
+put_template 11 "b1/68/03"
+put_template 12 "d4/57/2b"
+put_template 13 "68/51/a2"
+put_template 14 "24/73/b6"
+put_template 15 "2c/23/2e"
+
+color_foreground="2c/23/2e"
+color_background="f8/ef/e7"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "2c232e"
+  put_template_custom Ph "f8efe7"
+  put_template_custom Pi "2473b6"
+  put_template_custom Pj "beb5b3"
+  put_template_custom Pk "2c232e"
+  put_template_custom Pl "72696d"
+  put_template_custom Pm "72696d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Light.sh
+++ b/generic/Monokai Pro Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "fa/f4/f2"
+put_template 1  "e1/47/75"
+put_template 2  "26/9d/69"
+put_template 3  "cc/7a/0a"
+put_template 4  "e1/60/32"
+put_template 5  "70/58/be"
+put_template 6  "1c/8c/a8"
+put_template 7  "29/24/2a"
+put_template 8  "a5/9f/a0"
+put_template 9  "e1/47/75"
+put_template 10 "26/9d/69"
+put_template 11 "cc/7a/0a"
+put_template 12 "e1/60/32"
+put_template 13 "70/58/be"
+put_template 14 "1c/8c/a8"
+put_template 15 "29/24/2a"
+
+color_foreground="29/24/2a"
+color_background="fa/f4/f2"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "29242a"
+  put_template_custom Ph "faf4f2"
+  put_template_custom Pi "1c8ca8"
+  put_template_custom Pj "bfb9ba"
+  put_template_custom Pk "29242a"
+  put_template_custom Pl "706b6e"
+  put_template_custom Pm "706b6e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Machine.sh
+++ b/generic/Monokai Pro Machine.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Machine
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "27/31/36"
+put_template 1  "ff/6d/7e"
+put_template 2  "a2/e5/7b"
+put_template 3  "ff/ed/72"
+put_template 4  "ff/b2/70"
+put_template 5  "ba/a0/f8"
+put_template 6  "7c/d5/f1"
+put_template 7  "f2/ff/fc"
+put_template 8  "6b/76/78"
+put_template 9  "ff/6d/7e"
+put_template 10 "a2/e5/7b"
+put_template 11 "ff/ed/72"
+put_template 12 "ff/b2/70"
+put_template 13 "ba/a0/f8"
+put_template 14 "7c/d5/f1"
+put_template 15 "f2/ff/fc"
+
+color_foreground="f2/ff/fc"
+color_background="27/31/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2fffc"
+  put_template_custom Ph "273136"
+  put_template_custom Pi "7cd5f1"
+  put_template_custom Pj "545f62"
+  put_template_custom Pk "f2fffc"
+  put_template_custom Pl "b8c4c3"
+  put_template_custom Pm "b8c4c3"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Octagon.sh
+++ b/generic/Monokai Pro Octagon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Octagon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "28/2a/3a"
+put_template 1  "ff/65/7a"
+put_template 2  "ba/d7/61"
+put_template 3  "ff/d7/6d"
+put_template 4  "ff/9b/5e"
+put_template 5  "c3/9a/c9"
+put_template 6  "9c/d1/bb"
+put_template 7  "ea/f2/f1"
+put_template 8  "69/6d/77"
+put_template 9  "ff/65/7a"
+put_template 10 "ba/d7/61"
+put_template 11 "ff/d7/6d"
+put_template 12 "ff/9b/5e"
+put_template 13 "c3/9a/c9"
+put_template 14 "9c/d1/bb"
+put_template 15 "ea/f2/f1"
+
+color_foreground="ea/f2/f1"
+color_background="28/2a/3a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eaf2f1"
+  put_template_custom Ph "282a3a"
+  put_template_custom Pi "9cd1bb"
+  put_template_custom Pj "535763"
+  put_template_custom Pk "eaf2f1"
+  put_template_custom Pl "b2b9bd"
+  put_template_custom Pm "b2b9bd"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Ristretto.sh
+++ b/generic/Monokai Pro Ristretto.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Ristretto
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2c/25/25"
+put_template 1  "fd/68/83"
+put_template 2  "ad/da/78"
+put_template 3  "f9/cc/6c"
+put_template 4  "f3/8d/70"
+put_template 5  "a8/a9/eb"
+put_template 6  "85/da/cc"
+put_template 7  "ff/f1/f3"
+put_template 8  "72/69/6a"
+put_template 9  "fd/68/83"
+put_template 10 "ad/da/78"
+put_template 11 "f9/cc/6c"
+put_template 12 "f3/8d/70"
+put_template 13 "a8/a9/eb"
+put_template 14 "85/da/cc"
+put_template 15 "ff/f1/f3"
+
+color_foreground="ff/f1/f3"
+color_background="2c/25/25"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fff1f3"
+  put_template_custom Ph "2c2525"
+  put_template_custom Pi "85dacc"
+  put_template_custom Pj "5b5353"
+  put_template_custom Pk "fff1f3"
+  put_template_custom Pl "c3b7b8"
+  put_template_custom Pm "c3b7b8"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro Spectrum.sh
+++ b/generic/Monokai Pro Spectrum.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro Spectrum
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "22/22/22"
+put_template 1  "fc/61/8d"
+put_template 2  "7b/d8/8f"
+put_template 3  "fc/e5/66"
+put_template 4  "fd/93/53"
+put_template 5  "94/8a/e3"
+put_template 6  "5a/d4/e6"
+put_template 7  "f7/f1/ff"
+put_template 8  "69/67/6c"
+put_template 9  "fc/61/8d"
+put_template 10 "7b/d8/8f"
+put_template 11 "fc/e5/66"
+put_template 12 "fd/93/53"
+put_template 13 "94/8a/e3"
+put_template 14 "5a/d4/e6"
+put_template 15 "f7/f1/ff"
+
+color_foreground="f7/f1/ff"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f7f1ff"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "5ad4e6"
+  put_template_custom Pj "525053"
+  put_template_custom Pk "f7f1ff"
+  put_template_custom Pl "bab6c0"
+  put_template_custom Pm "bab6c0"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Pro.sh
+++ b/generic/Monokai Pro.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Pro
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2d/2a/2e"
+put_template 1  "ff/61/88"
+put_template 2  "a9/dc/76"
+put_template 3  "ff/d8/66"
+put_template 4  "fc/98/67"
+put_template 5  "ab/9d/f2"
+put_template 6  "78/dc/e8"
+put_template 7  "fc/fc/fa"
+put_template 8  "72/70/72"
+put_template 9  "ff/61/88"
+put_template 10 "a9/dc/76"
+put_template 11 "ff/d8/66"
+put_template 12 "fc/98/67"
+put_template 13 "ab/9d/f2"
+put_template 14 "78/dc/e8"
+put_template 15 "fc/fc/fa"
+
+color_foreground="fc/fc/fa"
+color_background="2d/2a/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fcfcfa"
+  put_template_custom Ph "2d2a2e"
+  put_template_custom Pi "78dce8"
+  put_template_custom Pj "5b595c"
+  put_template_custom Pk "fcfcfa"
+  put_template_custom Pl "c1c0c0"
+  put_template_custom Pm "c1c0c0"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Remastered.sh
+++ b/generic/Monokai Remastered.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Remastered
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/1a/1a"
+put_template 1  "f4/00/5f"
+put_template 2  "98/e0/24"
+put_template 3  "fd/97/1f"
+put_template 4  "9d/65/ff"
+put_template 5  "f4/00/5f"
+put_template 6  "58/d1/eb"
+put_template 7  "c4/c5/b5"
+put_template 8  "62/5e/4c"
+put_template 9  "f4/00/5f"
+put_template 10 "98/e0/24"
+put_template 11 "e0/d5/61"
+put_template 12 "9d/65/ff"
+put_template 13 "f4/00/5f"
+put_template 14 "58/d1/eb"
+put_template 15 "f6/f6/ef"
+
+color_foreground="d9/d9/d9"
+color_background="0c/0c/0c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d9d9d9"
+  put_template_custom Ph "0c0c0c"
+  put_template_custom Pi "ebebeb"
+  put_template_custom Pj "343434"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fc971f"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Soda.sh
+++ b/generic/Monokai Soda.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Soda
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1a/1a/1a"
+put_template 1  "f4/00/5f"
+put_template 2  "98/e0/24"
+put_template 3  "fa/84/19"
+put_template 4  "9d/65/ff"
+put_template 5  "f4/00/5f"
+put_template 6  "58/d1/eb"
+put_template 7  "c4/c5/b5"
+put_template 8  "62/5e/4c"
+put_template 9  "f4/00/5f"
+put_template 10 "98/e0/24"
+put_template 11 "e0/d5/61"
+put_template 12 "9d/65/ff"
+put_template 13 "f4/00/5f"
+put_template 14 "58/d1/eb"
+put_template 15 "f6/f6/ef"
+
+color_foreground="c4/c5/b5"
+color_background="1a/1a/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c4c5b5"
+  put_template_custom Ph "1a1a1a"
+  put_template_custom Pi "c4c5b5"
+  put_template_custom Pj "343434"
+  put_template_custom Pk "c4c5b5"
+  put_template_custom Pl "f6f7ec"
+  put_template_custom Pm "c4c5b5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Monokai Vivid.sh
+++ b/generic/Monokai Vivid.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Monokai Vivid
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "12/12/12"
+put_template 1  "fa/29/34"
+put_template 2  "98/e1/23"
+put_template 3  "ff/f3/0a"
+put_template 4  "04/43/ff"
+put_template 5  "f8/00/f8"
+put_template 6  "01/b6/ed"
+put_template 7  "ff/ff/ff"
+put_template 8  "83/83/83"
+put_template 9  "f6/66/9d"
+put_template 10 "b1/e0/5f"
+put_template 11 "ff/f2/6d"
+put_template 12 "04/43/ff"
+put_template 13 "f2/00/f6"
+put_template 14 "51/ce/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f9/f9/f9"
+color_background="12/12/12"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f9f9f9"
+  put_template_custom Ph "121212"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "fb0007"
+  put_template_custom Pm "ea0009"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/N0tch2k.sh
+++ b/generic/N0tch2k.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# N0tch2k
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "38/38/38"
+put_template 1  "a9/55/51"
+put_template 2  "66/66/66"
+put_template 3  "a9/80/51"
+put_template 4  "65/7d/3e"
+put_template 5  "76/76/76"
+put_template 6  "c9/c9/c9"
+put_template 7  "d0/b8/a3"
+put_template 8  "47/47/47"
+put_template 9  "a9/77/75"
+put_template 10 "8c/8c/8c"
+put_template 11 "a9/91/75"
+put_template 12 "98/bd/5e"
+put_template 13 "a3/a3/a3"
+put_template 14 "dc/dc/dc"
+put_template 15 "d8/c8/bb"
+
+color_foreground="a0/a0/a0"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a0a0a0"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "e5e5e5"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "aa9175"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Neon.sh
+++ b/generic/Neon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Neon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/30/45"
+put_template 2  "5f/fa/74"
+put_template 3  "ff/fc/7e"
+put_template 4  "02/08/cb"
+put_template 5  "f9/24/e7"
+put_template 6  "00/ff/fc"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/5a/5a"
+put_template 10 "75/ff/88"
+put_template 11 "ff/fd/96"
+put_template 12 "3c/40/cb"
+put_template 13 "f1/5b/e5"
+put_template 14 "88/ff/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/ff/fc"
+color_background="14/16/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "00fffc"
+  put_template_custom Ph "14161a"
+  put_template_custom Pi "ff3099"
+  put_template_custom Pj "0013ff"
+  put_template_custom Pk "08d2cf"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Neopolitan.sh
+++ b/generic/Neopolitan.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Neopolitan
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "80/00/00"
+put_template 2  "61/ce/3c"
+put_template 3  "fb/de/2d"
+put_template 4  "25/3b/76"
+put_template 5  "ff/00/80"
+put_template 6  "8d/a6/ce"
+put_template 7  "f8/f8/f8"
+put_template 8  "00/00/00"
+put_template 9  "80/00/00"
+put_template 10 "61/ce/3c"
+put_template 11 "fb/de/2d"
+put_template 12 "25/3b/76"
+put_template 13 "ff/00/80"
+put_template 14 "8d/a6/ce"
+put_template 15 "f8/f8/f8"
+
+color_foreground="ff/ff/ff"
+color_background="27/1f/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "271f19"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "253b76"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Neutron.sh
+++ b/generic/Neutron.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Neutron
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "23/25/2b"
+put_template 1  "b5/40/36"
+put_template 2  "5a/b9/77"
+put_template 3  "de/b5/66"
+put_template 4  "6a/7c/93"
+put_template 5  "a4/79/9d"
+put_template 6  "3f/94/a8"
+put_template 7  "e6/e8/ef"
+put_template 8  "23/25/2b"
+put_template 9  "b5/40/36"
+put_template 10 "5a/b9/77"
+put_template 11 "de/b5/66"
+put_template 12 "6a/7c/93"
+put_template 13 "a4/79/9d"
+put_template 14 "3f/94/a8"
+put_template 15 "eb/ed/f2"
+
+color_foreground="e6/e8/ef"
+color_background="1c/1e/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6e8ef"
+  put_template_custom Ph "1c1e22"
+  put_template_custom Pi "52606b"
+  put_template_custom Pj "2f363e"
+  put_template_custom Pk "7d8fa4"
+  put_template_custom Pl "f6f7ec"
+  put_template_custom Pm "c4c5b5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Night Owlish Light.sh
+++ b/generic/Night Owlish Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Night Owlish Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/16/27"
+put_template 1  "d3/42/3e"
+put_template 2  "2a/a2/98"
+put_template 3  "da/aa/01"
+put_template 4  "48/76/d6"
+put_template 5  "40/3f/53"
+put_template 6  "08/91/6a"
+put_template 7  "7a/81/81"
+put_template 8  "7a/81/81"
+put_template 9  "f7/6e/6e"
+put_template 10 "49/d0/c5"
+put_template 11 "da/c2/6b"
+put_template 12 "5c/a7/e4"
+put_template 13 "69/70/98"
+put_template 14 "00/c9/90"
+put_template 15 "98/9f/b1"
+
+color_foreground="40/3f/53"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "403f53"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "403f53"
+  put_template_custom Pj "f2f2f2"
+  put_template_custom Pk "403f53"
+  put_template_custom Pl "403f53"
+  put_template_custom Pm "fbfbfb"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/NightLion v1.sh
+++ b/generic/NightLion v1.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# NightLion v1
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4c/4c/4c"
+put_template 1  "bb/00/00"
+put_template 2  "5f/de/8f"
+put_template 3  "f3/f1/67"
+put_template 4  "27/6b/d8"
+put_template 5  "bb/00/bb"
+put_template 6  "00/da/df"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "e3e3e3"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/NightLion v2.sh
+++ b/generic/NightLion v2.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# NightLion v2
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4c/4c/4c"
+put_template 1  "bb/00/00"
+put_template 2  "04/f6/23"
+put_template 3  "f3/f1/67"
+put_template 4  "64/d0/f0"
+put_template 5  "ce/6f/db"
+put_template 6  "00/da/df"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "7d/f7/1d"
+put_template 11 "ff/ff/55"
+put_template 12 "62/cb/e8"
+put_template 13 "ff/9b/f5"
+put_template 14 "00/cc/d8"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bb/bb/bb"
+color_background="17/17/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "171717"
+  put_template_custom Pi "e3e3e3"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/NightOwl.sh
+++ b/generic/NightOwl.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# NightOwl
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/16/27"
+put_template 1  "ef/53/50"
+put_template 2  "22/da/6e"
+put_template 3  "ad/db/67"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "21/c7/a8"
+put_template 7  "ff/ff/ff"
+put_template 8  "57/56/56"
+put_template 9  "ef/53/50"
+put_template 10 "22/da/6e"
+put_template 11 "ff/eb/95"
+put_template 12 "82/aa/ff"
+put_template 13 "c7/92/ea"
+put_template 14 "7f/db/ca"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d6/de/eb"
+color_background="01/16/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d6deeb"
+  put_template_custom Ph "011627"
+  put_template_custom Pi "addb67"
+  put_template_custom Pj "5f7e97"
+  put_template_custom Pk "dfe5ee"
+  put_template_custom Pl "7e57c2"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Nocturnal Winter.sh
+++ b/generic/Nocturnal Winter.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Nocturnal Winter
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4d/4d/4d"
+put_template 1  "f1/2d/52"
+put_template 2  "09/cd/7e"
+put_template 3  "f5/f1/7a"
+put_template 4  "31/82/e0"
+put_template 5  "ff/2b/6d"
+put_template 6  "09/c8/7a"
+put_template 7  "fc/fc/fc"
+put_template 8  "80/80/80"
+put_template 9  "f1/6d/86"
+put_template 10 "0a/e7/8d"
+put_template 11 "ff/fc/67"
+put_template 12 "60/96/ff"
+put_template 13 "ff/78/a2"
+put_template 14 "0a/e7/8d"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e6/e5/e5"
+color_background="0d/0d/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6e5e5"
+  put_template_custom Ph "0d0d17"
+  put_template_custom Pi "e8e8e8"
+  put_template_custom Pj "adbdd0"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "e6e5e5"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Novel.sh
+++ b/generic/Novel.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Novel
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/00/00"
+put_template 2  "00/96/00"
+put_template 3  "d0/6b/00"
+put_template 4  "00/00/cc"
+put_template 5  "cc/00/cc"
+put_template 6  "00/87/cc"
+put_template 7  "cc/cc/cc"
+put_template 8  "80/80/80"
+put_template 9  "cc/00/00"
+put_template 10 "00/96/00"
+put_template 11 "d0/6b/00"
+put_template 12 "00/00/cc"
+put_template 13 "cc/00/cc"
+put_template 14 "00/87/cc"
+put_template 15 "ff/ff/ff"
+
+color_foreground="3b/23/22"
+color_background="df/db/c3"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3b2322"
+  put_template_custom Ph "dfdbc3"
+  put_template_custom Pi "8e2a19"
+  put_template_custom Pj "a4a390"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "73635a"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/NvimDark.sh
+++ b/generic/NvimDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# NvimDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/08/0d"
+put_template 1  "ff/c0/b9"
+put_template 2  "b3/f6/c0"
+put_template 3  "fc/e0/94"
+put_template 4  "a6/db/ff"
+put_template 5  "ff/ca/ff"
+put_template 6  "8c/f8/f7"
+put_template 7  "ee/f1/f8"
+put_template 8  "4f/52/58"
+put_template 9  "ff/c0/b9"
+put_template 10 "b3/f6/c0"
+put_template 11 "fc/e0/94"
+put_template 12 "a6/db/ff"
+put_template 13 "ff/ca/ff"
+put_template 14 "8c/f8/f7"
+put_template 15 "ee/f1/f8"
+
+color_foreground="e0/e2/ea"
+color_background="14/16/1b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e0e2ea"
+  put_template_custom Ph "14161b"
+  put_template_custom Pi "e0e2ea"
+  put_template_custom Pj "4f5258"
+  put_template_custom Pk "e0e2ea"
+  put_template_custom Pl "9b9ea4"
+  put_template_custom Pm "e0e2ea"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/NvimLight.sh
+++ b/generic/NvimLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# NvimLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/08/0d"
+put_template 1  "59/00/08"
+put_template 2  "00/55/23"
+put_template 3  "6b/53/00"
+put_template 4  "00/4c/73"
+put_template 5  "47/00/45"
+put_template 6  "00/73/73"
+put_template 7  "ee/f1/f8"
+put_template 8  "4f/52/58"
+put_template 9  "59/00/08"
+put_template 10 "00/55/23"
+put_template 11 "6b/53/00"
+put_template 12 "00/4c/73"
+put_template 13 "47/00/45"
+put_template 14 "00/73/73"
+put_template 15 "ee/f1/f8"
+
+color_foreground="14/16/1b"
+color_background="e0/e2/ea"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "14161b"
+  put_template_custom Ph "e0e2ea"
+  put_template_custom Pi "14161b"
+  put_template_custom Pj "9b9ea4"
+  put_template_custom Pk "14161b"
+  put_template_custom Pl "9b9ea4"
+  put_template_custom Pm "14161b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Obsidian.sh
+++ b/generic/Obsidian.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Obsidian
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "a6/00/01"
+put_template 2  "00/bb/00"
+put_template 3  "fe/cd/22"
+put_template 4  "3a/9b/db"
+put_template 5  "bb/00/bb"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "ff/00/03"
+put_template 10 "93/c8/63"
+put_template 11 "fe/f8/74"
+put_template 12 "a1/d7/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cd/cd/cd"
+color_background="28/30/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cdcdcd"
+  put_template_custom Ph "283033"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3e4c4f"
+  put_template_custom Pk "dfe1e2"
+  put_template_custom Pl "c0cad0"
+  put_template_custom Pm "cdcdcd"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ocean.sh
+++ b/generic/Ocean.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ocean
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "99/00/00"
+put_template 2  "00/a6/00"
+put_template 3  "99/99/00"
+put_template 4  "00/00/b2"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "00/d9/00"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="ff/ff/ff"
+color_background="22/4f/bc"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "224fbc"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "216dff"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "7f7f7f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Oceanic-Next.sh
+++ b/generic/Oceanic-Next.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Oceanic-Next
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/2b/34"
+put_template 1  "db/68/6b"
+put_template 2  "a2/c6/99"
+put_template 3  "f2/ca/73"
+put_template 4  "71/98/c8"
+put_template 5  "bd/96/c2"
+put_template 6  "74/b1/b2"
+put_template 7  "ff/ff/ff"
+put_template 8  "68/73/7d"
+put_template 9  "db/68/6b"
+put_template 10 "a2/c6/99"
+put_template 11 "f2/ca/73"
+put_template 12 "71/98/c8"
+put_template 13 "bd/96/c2"
+put_template 14 "74/b1/b2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c1/c5/cd"
+color_background="1b/2b/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c5cd"
+  put_template_custom Ph "1b2b34"
+  put_template_custom Pi "c1c5cd"
+  put_template_custom Pj "515b65"
+  put_template_custom Pk "c1c5cd"
+  put_template_custom Pl "c1c5cd"
+  put_template_custom Pm "1e2b33"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/OceanicMaterial.sh
+++ b/generic/OceanicMaterial.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# OceanicMaterial
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ee/2b/2a"
+put_template 2  "40/a3/3f"
+put_template 3  "ff/ea/2e"
+put_template 4  "1e/80/f0"
+put_template 5  "88/00/a0"
+put_template 6  "16/af/ca"
+put_template 7  "a4/a4/a4"
+put_template 8  "77/77/77"
+put_template 9  "dc/5c/60"
+put_template 10 "70/be/71"
+put_template 11 "ff/f1/63"
+put_template 12 "54/a4/f3"
+put_template 13 "aa/4d/bc"
+put_template 14 "42/c7/da"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c2/c8/d7"
+color_background="1c/26/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c2c8d7"
+  put_template_custom Ph "1c262b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "6dc2b8"
+  put_template_custom Pk "c2c8d7"
+  put_template_custom Pl "b3b8c3"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ollie.sh
+++ b/generic/Ollie.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ollie
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ac/2e/31"
+put_template 2  "31/ac/61"
+put_template 3  "ac/43/00"
+put_template 4  "2d/57/ac"
+put_template 5  "b0/85/28"
+put_template 6  "1f/a6/ac"
+put_template 7  "8a/8e/ac"
+put_template 8  "5b/37/25"
+put_template 9  "ff/3d/48"
+put_template 10 "3b/ff/99"
+put_template 11 "ff/5e/1e"
+put_template 12 "44/88/ff"
+put_template 13 "ff/c2/1d"
+put_template 14 "1f/fa/ff"
+put_template 15 "5b/6e/a7"
+
+color_foreground="8a/8d/ae"
+color_background="22/21/25"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "8a8dae"
+  put_template_custom Ph "222125"
+  put_template_custom Pi "5c6dac"
+  put_template_custom Pj "1e3a66"
+  put_template_custom Pk "8a8eac"
+  put_template_custom Pl "5b6ea7"
+  put_template_custom Pm "2a292d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/One Double Dark.sh
+++ b/generic/One Double Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# One Double Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3e/44/51"
+put_template 1  "e0/6c/75"
+put_template 2  "98/c3/79"
+put_template 3  "e5/c0/7b"
+put_template 4  "61/af/ef"
+put_template 5  "c6/78/dd"
+put_template 6  "56/b6/c2"
+put_template 7  "dc/df/e4"
+put_template 8  "54/5d/6d"
+put_template 9  "fd/80/7f"
+put_template 10 "96/d5/8b"
+put_template 11 "ed/c2/73"
+put_template 12 "84/c8/ff"
+put_template 13 "ee/82/ee"
+put_template 14 "3a/e1/f7"
+put_template 15 "f7/f9/fc"
+
+color_foreground="dc/df/e4"
+color_background="29/2c/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcdfe4"
+  put_template_custom Ph "292c33"
+  put_template_custom Pi "f7f9fc"
+  put_template_custom Pj "595b6e"
+  put_template_custom Pk "cfd6f1"
+  put_template_custom Pl "f1e1dd"
+  put_template_custom Pm "cfd6f1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/One Double Light.sh
+++ b/generic/One Double Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# One Double Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "46/4b/57"
+put_template 1  "e4/56/49"
+put_template 2  "50/a1/4f"
+put_template 3  "c1/84/01"
+put_template 4  "01/84/bc"
+put_template 5  "a6/26/a4"
+put_template 6  "09/97/b3"
+put_template 7  "e8/d9/d9"
+put_template 8  "0f/13/1e"
+put_template 9  "f2/4c/2d"
+put_template 10 "3d/b6/37"
+put_template 11 "e0/9d/00"
+put_template 12 "2e/63/d6"
+put_template 13 "d2/1f/d1"
+put_template 14 "06/b1/d8"
+put_template 15 "ff/ff/ff"
+
+color_foreground="38/3a/42"
+color_background="fa/fa/fa"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "383a42"
+  put_template_custom Ph "fafafa"
+  put_template_custom Pi "0f131e"
+  put_template_custom Pj "474e5d"
+  put_template_custom Pk "1a1a1a"
+  put_template_custom Pl "1a1a1a"
+  put_template_custom Pm "dcdfe4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/OneHalfDark.sh
+++ b/generic/OneHalfDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# OneHalfDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "28/2c/34"
+put_template 1  "e0/6c/75"
+put_template 2  "98/c3/79"
+put_template 3  "e5/c0/7b"
+put_template 4  "61/af/ef"
+put_template 5  "c6/78/dd"
+put_template 6  "56/b6/c2"
+put_template 7  "dc/df/e4"
+put_template 8  "28/2c/34"
+put_template 9  "e0/6c/75"
+put_template 10 "98/c3/79"
+put_template 11 "e5/c0/7b"
+put_template 12 "61/af/ef"
+put_template 13 "c6/78/dd"
+put_template 14 "56/b6/c2"
+put_template 15 "dc/df/e4"
+
+color_foreground="dc/df/e4"
+color_background="28/2c/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcdfe4"
+  put_template_custom Ph "282c34"
+  put_template_custom Pi "abb2bf"
+  put_template_custom Pj "474e5d"
+  put_template_custom Pk "dcdfe4"
+  put_template_custom Pl "a3b3cc"
+  put_template_custom Pm "dcdfe4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/OneHalfLight.sh
+++ b/generic/OneHalfLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# OneHalfLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "38/3a/42"
+put_template 1  "e4/56/49"
+put_template 2  "50/a1/4f"
+put_template 3  "c1/84/01"
+put_template 4  "01/84/bc"
+put_template 5  "a6/26/a4"
+put_template 6  "09/97/b3"
+put_template 7  "fa/fa/fa"
+put_template 8  "4f/52/5e"
+put_template 9  "e0/6c/75"
+put_template 10 "98/c3/79"
+put_template 11 "e5/c0/7b"
+put_template 12 "61/af/ef"
+put_template 13 "c6/78/dd"
+put_template 14 "56/b6/c2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="38/3a/42"
+color_background="fa/fa/fa"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "383a42"
+  put_template_custom Ph "fafafa"
+  put_template_custom Pi "abb2bf"
+  put_template_custom Pj "bfceff"
+  put_template_custom Pk "383a42"
+  put_template_custom Pl "bfceff"
+  put_template_custom Pm "383a42"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Operator Mono Dark.sh
+++ b/generic/Operator Mono Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Operator Mono Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "5a/5a/5a"
+put_template 1  "ca/37/2d"
+put_template 2  "4d/7b/3a"
+put_template 3  "d4/d6/97"
+put_template 4  "43/87/cf"
+put_template 5  "b8/6c/b4"
+put_template 6  "72/d5/c6"
+put_template 7  "ce/d4/cd"
+put_template 8  "9a/9b/99"
+put_template 9  "c3/7d/62"
+put_template 10 "83/d0/a2"
+put_template 11 "fd/fd/c5"
+put_template 12 "89/d3/f6"
+put_template 13 "ff/2c/7a"
+put_template 14 "82/ea/da"
+put_template 15 "fd/fd/f6"
+
+color_foreground="c3/ca/c2"
+color_background="19/19/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c3cac2"
+  put_template_custom Ph "191919"
+  put_template_custom Pi "fefdbf"
+  put_template_custom Pj "19273b"
+  put_template_custom Pk "dde5dc"
+  put_template_custom Pl "fcdc08"
+  put_template_custom Pm "161616"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Overnight Slumber.sh
+++ b/generic/Overnight Slumber.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Overnight Slumber
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0a/12/22"
+put_template 1  "ff/a7/c4"
+put_template 2  "85/cc/95"
+put_template 3  "ff/cb/8b"
+put_template 4  "8d/ab/e1"
+put_template 5  "c7/92/eb"
+put_template 6  "78/cc/f0"
+put_template 7  "ff/ff/ff"
+put_template 8  "57/56/56"
+put_template 9  "ff/a7/c4"
+put_template 10 "85/cc/95"
+put_template 11 "ff/cb/8b"
+put_template 12 "8d/ab/e1"
+put_template 13 "c7/92/eb"
+put_template 14 "ff/a7/c4"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ce/d2/d6"
+color_background="0e/17/29"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ced2d6"
+  put_template_custom Ph "0e1729"
+  put_template_custom Pi "ffcb8b"
+  put_template_custom Pj "1f2b41"
+  put_template_custom Pk "ced2d6"
+  put_template_custom Pl "ffa7c4"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Oxocarbon.sh
+++ b/generic/Oxocarbon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Oxocarbon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "16/16/16"
+put_template 1  "3d/db/d9"
+put_template 2  "33/b1/ff"
+put_template 3  "ee/53/96"
+put_template 4  "42/be/65"
+put_template 5  "be/95/ff"
+put_template 6  "ff/7e/b6"
+put_template 7  "f2/f4/f8"
+put_template 8  "58/58/58"
+put_template 9  "3d/db/d9"
+put_template 10 "33/b1/ff"
+put_template 11 "ee/53/96"
+put_template 12 "42/be/65"
+put_template 13 "be/95/ff"
+put_template 14 "ff/7e/b6"
+put_template 15 "f2/f4/f8"
+
+color_foreground="f2/f4/f8"
+color_background="16/16/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f4f8"
+  put_template_custom Ph "161616"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "393939"
+  put_template_custom Pk "161616"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/PaleNightHC.sh
+++ b/generic/PaleNightHC.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# PaleNightHC
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f0/71/78"
+put_template 2  "c3/e8/8d"
+put_template 3  "ff/cb/6b"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "89/dd/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "66/66/66"
+put_template 9  "f6/a9/ae"
+put_template 10 "db/f1/ba"
+put_template 11 "ff/df/a6"
+put_template 12 "b4/cc/ff"
+put_template 13 "dd/bd/f2"
+put_template 14 "b8/ea/ff"
+put_template 15 "99/99/99"
+
+color_foreground="cc/cc/cc"
+color_background="3e/42/51"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cccccc"
+  put_template_custom Ph "3e4251"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "717cb4"
+  put_template_custom Pk "80cbc4"
+  put_template_custom Pl "ffcb6b"
+  put_template_custom Pm "323232"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Pandora.sh
+++ b/generic/Pandora.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Pandora
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/42/42"
+put_template 2  "74/af/68"
+put_template 3  "ff/ad/29"
+put_template 4  "33/8f/86"
+put_template 5  "94/14/e6"
+put_template 6  "23/d7/d7"
+put_template 7  "e2/e2/e2"
+put_template 8  "3f/56/48"
+put_template 9  "ff/32/42"
+put_template 10 "74/cd/68"
+put_template 11 "ff/b9/29"
+put_template 12 "23/d7/d7"
+put_template 13 "ff/37/ff"
+put_template 14 "00/ed/e1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e1/e1/e1"
+color_background="14/1e/43"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e1e1e1"
+  put_template_custom Ph "141e43"
+  put_template_custom Pi "67a672"
+  put_template_custom Pj "2d37ff"
+  put_template_custom Pk "82e0ff"
+  put_template_custom Pl "43d58e"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Paraiso Dark.sh
+++ b/generic/Paraiso Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Paraiso Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2f/1e/2e"
+put_template 1  "ef/61/55"
+put_template 2  "48/b6/85"
+put_template 3  "fe/c4/18"
+put_template 4  "06/b6/ef"
+put_template 5  "81/5b/a4"
+put_template 6  "5b/c4/bf"
+put_template 7  "a3/9e/9b"
+put_template 8  "77/6e/71"
+put_template 9  "ef/61/55"
+put_template 10 "48/b6/85"
+put_template 11 "fe/c4/18"
+put_template 12 "06/b6/ef"
+put_template 13 "81/5b/a4"
+put_template 14 "5b/c4/bf"
+put_template 15 "e7/e9/db"
+
+color_foreground="a3/9e/9b"
+color_background="2f/1e/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a39e9b"
+  put_template_custom Ph "2f1e2e"
+  put_template_custom Pi "a39e9b"
+  put_template_custom Pj "4f424c"
+  put_template_custom Pk "a39e9b"
+  put_template_custom Pl "a39e9b"
+  put_template_custom Pm "2f1e2e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/PaulMillr.sh
+++ b/generic/PaulMillr.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# PaulMillr
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2a/2a/2a"
+put_template 1  "ff/00/00"
+put_template 2  "79/ff/0f"
+put_template 3  "e7/bf/00"
+put_template 4  "39/6b/d7"
+put_template 5  "b4/49/be"
+put_template 6  "66/cc/ff"
+put_template 7  "bb/bb/bb"
+put_template 8  "66/66/66"
+put_template 9  "ff/00/80"
+put_template 10 "66/ff/66"
+put_template 11 "f3/d6/4e"
+put_template 12 "70/9a/ed"
+put_template 13 "db/67/e6"
+put_template 14 "7a/df/f2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="f2/f2/f2"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f2f2"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "414141"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "4d4d4d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/PencilDark.sh
+++ b/generic/PencilDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# PencilDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/21/21"
+put_template 1  "c3/07/71"
+put_template 2  "10/a7/78"
+put_template 3  "a8/9c/14"
+put_template 4  "00/8e/c4"
+put_template 5  "52/3c/79"
+put_template 6  "20/a5/ba"
+put_template 7  "d9/d9/d9"
+put_template 8  "42/42/42"
+put_template 9  "fb/00/7a"
+put_template 10 "5f/d7/af"
+put_template 11 "f3/e4/30"
+put_template 12 "20/bb/fc"
+put_template 13 "68/55/de"
+put_template 14 "4f/b8/cc"
+put_template 15 "f1/f1/f1"
+
+color_foreground="f1/f1/f1"
+color_background="21/21/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f1f1f1"
+  put_template_custom Ph "212121"
+  put_template_custom Pi "fb007a"
+  put_template_custom Pj "b6d6fd"
+  put_template_custom Pk "f1f1f1"
+  put_template_custom Pl "20bbfc"
+  put_template_custom Pm "f1f1f1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/PencilLight.sh
+++ b/generic/PencilLight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# PencilLight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "21/21/21"
+put_template 1  "c3/07/71"
+put_template 2  "10/a7/78"
+put_template 3  "a8/9c/14"
+put_template 4  "00/8e/c4"
+put_template 5  "52/3c/79"
+put_template 6  "20/a5/ba"
+put_template 7  "d9/d9/d9"
+put_template 8  "42/42/42"
+put_template 9  "fb/00/7a"
+put_template 10 "5f/d7/af"
+put_template 11 "f3/e4/30"
+put_template 12 "20/bb/fc"
+put_template 13 "68/55/de"
+put_template 14 "4f/b8/cc"
+put_template 15 "f1/f1/f1"
+
+color_foreground="42/42/42"
+color_background="f1/f1/f1"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "424242"
+  put_template_custom Ph "f1f1f1"
+  put_template_custom Pi "fb007a"
+  put_template_custom Pj "b6d6fd"
+  put_template_custom Pk "424242"
+  put_template_custom Pl "20bbfc"
+  put_template_custom Pm "424242"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Peppermint.sh
+++ b/generic/Peppermint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Peppermint
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "35/35/35"
+put_template 1  "e7/46/69"
+put_template 2  "89/d2/87"
+put_template 3  "da/b8/53"
+put_template 4  "44/9f/d0"
+put_template 5  "da/62/dc"
+put_template 6  "65/aa/af"
+put_template 7  "b4/b4/b4"
+put_template 8  "53/53/53"
+put_template 9  "e4/85/9b"
+put_template 10 "a3/cc/a2"
+put_template 11 "e1/e4/87"
+put_template 12 "6f/bc/e2"
+put_template 13 "e5/86/e7"
+put_template 14 "96/dc/db"
+put_template 15 "df/df/df"
+
+color_foreground="c8/c8/c8"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c8c8c8"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "e0001c"
+  put_template_custom Pj "e6e6e6"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Piatto Light.sh
+++ b/generic/Piatto Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Piatto Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "41/41/41"
+put_template 1  "b2/37/71"
+put_template 2  "66/78/1e"
+put_template 3  "cd/6f/34"
+put_template 4  "3c/5e/a8"
+put_template 5  "a4/54/b2"
+put_template 6  "66/78/1e"
+put_template 7  "ff/ff/ff"
+put_template 8  "3f/3f/3f"
+put_template 9  "db/33/65"
+put_template 10 "82/94/29"
+put_template 11 "cd/6f/34"
+put_template 12 "3c/5e/a8"
+put_template 13 "a4/54/b2"
+put_template 14 "82/94/29"
+put_template 15 "f2/f2/f2"
+
+color_foreground="41/41/41"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "414141"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "323232"
+  put_template_custom Pj "706b4e"
+  put_template_custom Pk "acbcdc"
+  put_template_custom Pl "5e77c8"
+  put_template_custom Pm "abbee5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Pnevma.sh
+++ b/generic/Pnevma.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Pnevma
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2f/2e/2d"
+put_template 1  "a3/66/66"
+put_template 2  "90/a5/7d"
+put_template 3  "d7/af/87"
+put_template 4  "7f/a5/bd"
+put_template 5  "c7/9e/c4"
+put_template 6  "8a/db/b4"
+put_template 7  "d0/d0/d0"
+put_template 8  "4a/48/45"
+put_template 9  "d7/87/87"
+put_template 10 "af/be/a2"
+put_template 11 "e4/c9/af"
+put_template 12 "a1/bd/ce"
+put_template 13 "d7/be/da"
+put_template 14 "b1/e7/dd"
+put_template 15 "ef/ef/ef"
+
+color_foreground="d0/d0/d0"
+color_background="1c/1c/1c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d0d0d0"
+  put_template_custom Ph "1c1c1c"
+  put_template_custom Pi "e5e5e5"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "e4c9af"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Popping and Locking.sh
+++ b/generic/Popping and Locking.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Popping and Locking
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/20/21"
+put_template 1  "cc/24/1d"
+put_template 2  "98/97/1a"
+put_template 3  "d7/99/21"
+put_template 4  "45/85/88"
+put_template 5  "b1/62/86"
+put_template 6  "68/9d/6a"
+put_template 7  "a8/99/84"
+put_template 8  "92/83/74"
+put_template 9  "f4/2c/3e"
+put_template 10 "b8/bb/26"
+put_template 11 "fa/bd/2f"
+put_template 12 "99/c6/ca"
+put_template 13 "d3/86/9b"
+put_template 14 "7e/c1/6e"
+put_template 15 "eb/db/b2"
+
+color_foreground="eb/db/b2"
+color_background="18/19/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebdbb2"
+  put_template_custom Ph "181921"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ebdbb2"
+  put_template_custom Pk "928374"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Pro Light.sh
+++ b/generic/Pro Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Pro Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "e5/49/2b"
+put_template 2  "50/d1/48"
+put_template 3  "c6/c4/40"
+put_template 4  "3b/75/ff"
+put_template 5  "ed/66/e8"
+put_template 6  "4e/d2/de"
+put_template 7  "dc/dc/dc"
+put_template 8  "9f/9f/9f"
+put_template 9  "ff/66/40"
+put_template 10 "61/ef/57"
+put_template 11 "f2/f1/56"
+put_template 12 "00/82/ff"
+put_template 13 "ff/7e/ff"
+put_template 14 "61/f7/f8"
+put_template 15 "f2/f2/f2"
+
+color_foreground="19/19/19"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "191919"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "191919"
+  put_template_custom Pj "c1ddff"
+  put_template_custom Pk "191919"
+  put_template_custom Pl "4d4d4d"
+  put_template_custom Pm "f2f2f2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Pro.sh
+++ b/generic/Pro.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Pro
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "99/00/00"
+put_template 2  "00/a6/00"
+put_template 3  "99/99/00"
+put_template 4  "20/09/db"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "00/d9/00"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="f2/f2/f2"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f2f2"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "414141"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "4d4d4d"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Purple Rain.sh
+++ b/generic/Purple Rain.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Purple Rain
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/26/0e"
+put_template 2  "9b/e2/05"
+put_template 3  "ff/c4/00"
+put_template 4  "00/a2/fa"
+put_template 5  "81/5b/b5"
+put_template 6  "00/de/ef"
+put_template 7  "ff/ff/ff"
+put_template 8  "56/56/56"
+put_template 9  "ff/42/50"
+put_template 10 "b8/e3/6e"
+put_template 11 "ff/d8/52"
+put_template 12 "00/a6/ff"
+put_template 13 "ac/7b/f0"
+put_template 14 "74/fd/f3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/fb/f6"
+color_background="21/08/4a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fffbf6"
+  put_template_custom Ph "21084a"
+  put_template_custom Pi "333333"
+  put_template_custom Pj "287691"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ff271d"
+  put_template_custom Pm "ff271d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Rapture.sh
+++ b/generic/Rapture.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Rapture
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fc/64/4d"
+put_template 2  "7a/fd/e1"
+put_template 3  "ff/f0/9b"
+put_template 4  "6c/9b/f5"
+put_template 5  "ff/4f/a1"
+put_template 6  "64/e0/ff"
+put_template 7  "c0/c9/e5"
+put_template 8  "30/4b/66"
+put_template 9  "fc/64/4d"
+put_template 10 "7a/fd/e1"
+put_template 11 "ff/f0/9b"
+put_template 12 "6c/9b/f5"
+put_template 13 "ff/4f/a1"
+put_template 14 "64/e0/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c0/c9/e5"
+color_background="11/1e/2a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c0c9e5"
+  put_template_custom Ph "111e2a"
+  put_template_custom Pi "d5ced9"
+  put_template_custom Pj "304b66"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "111e2a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Raycast_Dark.sh
+++ b/generic/Raycast_Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Raycast_Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/53/60"
+put_template 2  "59/d4/99"
+put_template 3  "ff/c5/31"
+put_template 4  "56/c2/ff"
+put_template 5  "cf/2f/98"
+put_template 6  "52/ee/e5"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "ff/63/63"
+put_template 10 "59/d4/99"
+put_template 11 "ff/c5/31"
+put_template 12 "56/c2/ff"
+put_template 13 "cf/2f/98"
+put_template 14 "52/ee/e5"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1a/1a/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1a1a1a"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "333333"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "cccccc"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Raycast_Light.sh
+++ b/generic/Raycast_Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Raycast_Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b1/24/24"
+put_template 2  "00/6b/4f"
+put_template 3  "f8/a3/00"
+put_template 4  "13/8a/f2"
+put_template 5  "9a/1b/6e"
+put_template 6  "3e/b8/bf"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "b1/24/24"
+put_template 10 "00/6b/4f"
+put_template 11 "f8/a3/00"
+put_template 12 "13/8a/f2"
+put_template 13 "9a/1b/6e"
+put_template 14 "3e/b8/bf"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "e5e5e5"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Red Alert.sh
+++ b/generic/Red Alert.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Red Alert
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d6/2e/4e"
+put_template 2  "71/be/6b"
+put_template 3  "be/b8/6b"
+put_template 4  "48/9b/ee"
+put_template 5  "e9/79/d7"
+put_template 6  "6b/be/b8"
+put_template 7  "d6/d6/d6"
+put_template 8  "26/26/26"
+put_template 9  "e0/25/53"
+put_template 10 "af/f0/8c"
+put_template 11 "df/dd/b7"
+put_template 12 "65/aa/f1"
+put_template 13 "dd/b7/df"
+put_template 14 "b7/df/dd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="76/24/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "762423"
+  put_template_custom Pi "ff9c44"
+  put_template_custom Pj "073642"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "762423"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Red Planet.sh
+++ b/generic/Red Planet.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Red Planet
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "20/20/20"
+put_template 1  "8c/34/32"
+put_template 2  "72/82/71"
+put_template 3  "e8/bf/6a"
+put_template 4  "69/81/9e"
+put_template 5  "89/64/92"
+put_template 6  "5b/83/90"
+put_template 7  "b9/aa/99"
+put_template 8  "67/67/67"
+put_template 9  "b5/52/42"
+put_template 10 "86/99/85"
+put_template 11 "eb/eb/91"
+put_template 12 "60/82/7e"
+put_template 13 "de/49/74"
+put_template 14 "38/ad/d8"
+put_template 15 "d6/bf/b8"
+
+color_foreground="c2/b7/90"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c2b790"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ebeb91"
+  put_template_custom Pj "1b324a"
+  put_template_custom Pk "bcb291"
+  put_template_custom Pl "c2b790"
+  put_template_custom Pm "202020"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Red Sands.sh
+++ b/generic/Red Sands.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Red Sands
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/3f/00"
+put_template 2  "00/bb/00"
+put_template 3  "e7/b0/00"
+put_template 4  "00/72/ff"
+put_template 5  "bb/00/bb"
+put_template 6  "00/bb/bb"
+put_template 7  "bb/bb/bb"
+put_template 8  "55/55/55"
+put_template 9  "bb/00/00"
+put_template 10 "00/bb/00"
+put_template 11 "e7/b0/00"
+put_template 12 "00/72/ae"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d7/c9/a7"
+color_background="7a/25/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d7c9a7"
+  put_template_custom Ph "7a251e"
+  put_template_custom Pi "dfbd22"
+  put_template_custom Pj "a4a390"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Relaxed.sh
+++ b/generic/Relaxed.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Relaxed
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/15/15"
+put_template 1  "bc/56/53"
+put_template 2  "90/9d/63"
+put_template 3  "eb/c1/7a"
+put_template 4  "6a/87/99"
+put_template 5  "b0/66/98"
+put_template 6  "c9/df/ff"
+put_template 7  "d9/d9/d9"
+put_template 8  "63/63/63"
+put_template 9  "bc/56/53"
+put_template 10 "a0/ac/77"
+put_template 11 "eb/c1/7a"
+put_template 12 "7e/aa/c7"
+put_template 13 "b0/66/98"
+put_template 14 "ac/bb/d0"
+put_template 15 "f7/f7/f7"
+
+color_foreground="d9/d9/d9"
+color_background="35/3a/44"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d9d9d9"
+  put_template_custom Ph "353a44"
+  put_template_custom Pi "d9d9d9"
+  put_template_custom Pj "6a7985"
+  put_template_custom Pk "d9d9d9"
+  put_template_custom Pl "d9d9d9"
+  put_template_custom Pm "1b1b1b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Retro.sh
+++ b/generic/Retro.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Retro
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "13/a1/0e"
+put_template 1  "13/a1/0e"
+put_template 2  "13/a1/0e"
+put_template 3  "13/a1/0e"
+put_template 4  "13/a1/0e"
+put_template 5  "13/a1/0e"
+put_template 6  "13/a1/0e"
+put_template 7  "13/a1/0e"
+put_template 8  "16/ba/10"
+put_template 9  "16/ba/10"
+put_template 10 "16/ba/10"
+put_template 11 "16/ba/10"
+put_template 12 "16/ba/10"
+put_template 13 "16/ba/10"
+put_template 14 "16/ba/10"
+put_template 15 "16/ba/10"
+
+color_foreground="13/a1/0e"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "13a10e"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "16ba10"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "13a10e"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/RetroLegends.sh
+++ b/generic/RetroLegends.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# RetroLegends
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "26/26/26"
+put_template 1  "de/54/54"
+put_template 2  "45/eb/45"
+put_template 3  "f7/bf/2b"
+put_template 4  "40/66/f2"
+put_template 5  "bf/4c/f2"
+put_template 6  "40/d9/e6"
+put_template 7  "bf/e6/bf"
+put_template 8  "4c/59/4c"
+put_template 9  "ff/66/66"
+put_template 10 "59/ff/59"
+put_template 11 "ff/d9/33"
+put_template 12 "4c/80/ff"
+put_template 13 "e6/66/ff"
+put_template 14 "59/e6/ff"
+put_template 15 "f2/ff/f2"
+
+color_foreground="45/eb/45"
+color_background="0d/0d/0d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "45eb45"
+  put_template_custom Ph "0d0d0d"
+  put_template_custom Pi "59ff59"
+  put_template_custom Pj "336633"
+  put_template_custom Pk "f2fff2"
+  put_template_custom Pl "45eb45"
+  put_template_custom Pm "0d0d0d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Rippedcasts.sh
+++ b/generic/Rippedcasts.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Rippedcasts
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cd/af/95"
+put_template 2  "a8/ff/60"
+put_template 3  "bf/bb/1f"
+put_template 4  "75/a5/b0"
+put_template 5  "ff/73/fd"
+put_template 6  "5a/64/7e"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "ee/cb/ad"
+put_template 10 "bc/ee/68"
+put_template 11 "e5/e5/00"
+put_template 12 "86/bd/c9"
+put_template 13 "e5/00/e5"
+put_template 14 "8c/9b/c4"
+put_template 15 "e5/e5/e5"
+
+color_foreground="ff/ff/ff"
+color_background="2b/2b/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "2b2b2b"
+  put_template_custom Pi "d0f367"
+  put_template_custom Pj "5a647e"
+  put_template_custom Pk "f2f2f2"
+  put_template_custom Pl "7f7f7f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Rouge 2.sh
+++ b/generic/Rouge 2.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Rouge 2
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "5d/5d/6b"
+put_template 1  "c6/79/7e"
+put_template 2  "96/9e/92"
+put_template 3  "db/cd/ab"
+put_template 4  "6e/94/b9"
+put_template 5  "4c/4e/78"
+put_template 6  "8a/b6/c1"
+put_template 7  "e8/e8/ea"
+put_template 8  "61/62/74"
+put_template 9  "c6/79/7e"
+put_template 10 "e6/dc/c4"
+put_template 11 "e6/dc/c4"
+put_template 12 "98/b3/cd"
+put_template 13 "82/83/a1"
+put_template 14 "ab/cb/d3"
+put_template 15 "e8/e8/ea"
+
+color_foreground="a2/a3/aa"
+color_background="17/18/2b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a2a3aa"
+  put_template_custom Ph "17182b"
+  put_template_custom Pi "6e94b9"
+  put_template_custom Pj "5d5d6b"
+  put_template_custom Pk "dfe5ee"
+  put_template_custom Pl "969e92"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Royal.sh
+++ b/generic/Royal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Royal
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/1f/2b"
+put_template 1  "91/28/4c"
+put_template 2  "23/80/1c"
+put_template 3  "b4/9d/27"
+put_template 4  "65/80/b0"
+put_template 5  "67/4d/96"
+put_template 6  "8a/aa/be"
+put_template 7  "52/49/66"
+put_template 8  "31/2d/3d"
+put_template 9  "d5/35/6c"
+put_template 10 "2c/d9/46"
+put_template 11 "fd/e8/3b"
+put_template 12 "90/ba/f9"
+put_template 13 "a4/79/e3"
+put_template 14 "ac/d4/eb"
+put_template 15 "9e/8c/bd"
+
+color_foreground="51/49/68"
+color_background="10/08/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "514968"
+  put_template_custom Ph "100815"
+  put_template_custom Pi "c8bd1d"
+  put_template_custom Pj "1f1d2b"
+  put_template_custom Pk "a593cd"
+  put_template_custom Pl "524966"
+  put_template_custom Pm "100613"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ryuuko.sh
+++ b/generic/Ryuuko.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ryuuko
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2c/39/41"
+put_template 1  "86/5f/5b"
+put_template 2  "66/90/7d"
+put_template 3  "b1/a9/90"
+put_template 4  "6a/8e/95"
+put_template 5  "b1/8a/73"
+put_template 6  "88/b2/ac"
+put_template 7  "ec/ec/ec"
+put_template 8  "5d/70/79"
+put_template 9  "86/5f/5b"
+put_template 10 "66/90/7d"
+put_template 11 "b1/a9/90"
+put_template 12 "6a/8e/95"
+put_template 13 "b1/8a/73"
+put_template 14 "88/b2/ac"
+put_template 15 "ec/ec/ec"
+
+color_foreground="ec/ec/ec"
+color_background="2c/39/41"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ececec"
+  put_template_custom Ph "2c3941"
+  put_template_custom Pi "819090"
+  put_template_custom Pj "002831"
+  put_template_custom Pk "819090"
+  put_template_custom Pl "ececec"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Sakura.sh
+++ b/generic/Sakura.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Sakura
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d5/23/70"
+put_template 2  "41/af/1a"
+put_template 3  "bc/70/53"
+put_template 4  "69/64/ab"
+put_template 5  "c7/1f/bf"
+put_template 6  "93/93/93"
+put_template 7  "99/8e/ac"
+put_template 8  "78/6d/69"
+put_template 9  "f4/1d/99"
+put_template 10 "22/e5/29"
+put_template 11 "f5/95/74"
+put_template 12 "98/92/f1"
+put_template 13 "e9/0c/dd"
+put_template 14 "ee/ee/ee"
+put_template 15 "cb/b6/ff"
+
+color_foreground="dd/7b/dc"
+color_background="18/13/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dd7bdc"
+  put_template_custom Ph "18131e"
+  put_template_custom Pi "d445d2"
+  put_template_custom Pj "c05cbf"
+  put_template_custom Pk "24242e"
+  put_template_custom Pl "ff65fd"
+  put_template_custom Pm "24242e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Scarlet Protocol.sh
+++ b/generic/Scarlet Protocol.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Scarlet Protocol
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/11/16"
+put_template 1  "ff/00/51"
+put_template 2  "00/dc/84"
+put_template 3  "fa/f9/45"
+put_template 4  "02/71/b6"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "bd/35/ec"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e4/19/51"
+color_background="1c/15/3d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e41951"
+  put_template_custom Ph "1c153d"
+  put_template_custom Pi "f5f443"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "76ff9f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SeaShells.sh
+++ b/generic/SeaShells.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SeaShells
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "17/38/4c"
+put_template 1  "d1/51/23"
+put_template 2  "02/7c/9b"
+put_template 3  "fc/a0/2f"
+put_template 4  "1e/49/50"
+put_template 5  "68/d4/f1"
+put_template 6  "50/a3/b5"
+put_template 7  "de/b8/8d"
+put_template 8  "43/4b/53"
+put_template 9  "d4/86/78"
+put_template 10 "62/8d/98"
+put_template 11 "fd/d3/9f"
+put_template 12 "1b/bc/dd"
+put_template 13 "bb/e3/ee"
+put_template 14 "87/ac/b4"
+put_template 15 "fe/e4/ce"
+
+color_foreground="de/b8/8d"
+color_background="09/14/1b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "deb88d"
+  put_template_custom Ph "09141b"
+  put_template_custom Pi "ffe4cc"
+  put_template_custom Pj "1e4962"
+  put_template_custom Pk "fee4ce"
+  put_template_custom Pl "fca02f"
+  put_template_custom Pm "08131a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Seafoam Pastel.sh
+++ b/generic/Seafoam Pastel.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Seafoam Pastel
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "75/75/75"
+put_template 1  "82/5d/4d"
+put_template 2  "72/8c/62"
+put_template 3  "ad/a1/6d"
+put_template 4  "4d/7b/82"
+put_template 5  "8a/72/67"
+put_template 6  "72/94/94"
+put_template 7  "e0/e0/e0"
+put_template 8  "8a/8a/8a"
+put_template 9  "cf/93/7a"
+put_template 10 "98/d9/aa"
+put_template 11 "fa/e7/9d"
+put_template 12 "7a/c3/cf"
+put_template 13 "d6/b2/a1"
+put_template 14 "ad/e0/e0"
+put_template 15 "e0/e0/e0"
+
+color_foreground="d4/e7/d4"
+color_background="24/34/35"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d4e7d4"
+  put_template_custom Ph "243435"
+  put_template_custom Pi "648890"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "9e8b13"
+  put_template_custom Pl "57647a"
+  put_template_custom Pm "323232"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Seti.sh
+++ b/generic/Seti.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Seti
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/32/32"
+put_template 1  "c2/28/32"
+put_template 2  "8e/c4/3d"
+put_template 3  "e0/c6/4f"
+put_template 4  "43/a5/d5"
+put_template 5  "8b/57/b5"
+put_template 6  "8e/c4/3d"
+put_template 7  "ee/ee/ee"
+put_template 8  "32/32/32"
+put_template 9  "c2/28/32"
+put_template 10 "8e/c4/3d"
+put_template 11 "e0/c6/4f"
+put_template 12 "43/a5/d5"
+put_template 13 "8b/57/b5"
+put_template 14 "8e/c4/3d"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ca/ce/cd"
+color_background="11/12/13"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cacecd"
+  put_template_custom Ph "111213"
+  put_template_custom Pi "cacecd"
+  put_template_custom Pj "303233"
+  put_template_custom Pk "cacecd"
+  put_template_custom Pl "e3bf21"
+  put_template_custom Pm "e0be2e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Shaman.sh
+++ b/generic/Shaman.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Shaman
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "01/20/26"
+put_template 1  "b2/30/2d"
+put_template 2  "00/a9/41"
+put_template 3  "5e/8b/aa"
+put_template 4  "44/9a/86"
+put_template 5  "00/59/9d"
+put_template 6  "5d/7e/19"
+put_template 7  "40/55/55"
+put_template 8  "38/44/51"
+put_template 9  "ff/42/42"
+put_template 10 "2a/ea/5e"
+put_template 11 "8e/d4/fd"
+put_template 12 "61/d5/ba"
+put_template 13 "12/98/ff"
+put_template 14 "98/d0/28"
+put_template 15 "58/fb/d6"
+
+color_foreground="40/55/55"
+color_background="00/10/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "405555"
+  put_template_custom Ph "001015"
+  put_template_custom Pi "53fbd6"
+  put_template_custom Pj "415555"
+  put_template_custom Pk "5afad6"
+  put_template_custom Pl "4afcd6"
+  put_template_custom Pm "031413"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Slate.sh
+++ b/generic/Slate.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Slate
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "22/22/22"
+put_template 1  "e2/a8/bf"
+put_template 2  "81/d7/78"
+put_template 3  "c4/c9/c0"
+put_template 4  "26/4b/49"
+put_template 5  "a4/81/d3"
+put_template 6  "15/ab/9c"
+put_template 7  "02/c5/e0"
+put_template 8  "ff/ff/ff"
+put_template 9  "ff/cd/d9"
+put_template 10 "be/ff/a8"
+put_template 11 "d0/cc/ca"
+put_template 12 "7a/b0/d2"
+put_template 13 "c5/a7/d9"
+put_template 14 "8c/df/e0"
+put_template 15 "e0/e0/e0"
+
+color_foreground="35/b1/d2"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "35b1d2"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "648890"
+  put_template_custom Pj "0f3754"
+  put_template_custom Pk "2dffc0"
+  put_template_custom Pl "87d3c4"
+  put_template_custom Pm "323232"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SleepyHollow.sh
+++ b/generic/SleepyHollow.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SleepyHollow
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "57/21/00"
+put_template 1  "ba/39/34"
+put_template 2  "91/77/3f"
+put_template 3  "b5/56/00"
+put_template 4  "5f/63/b4"
+put_template 5  "a1/7c/7b"
+put_template 6  "8f/ae/a9"
+put_template 7  "af/9a/91"
+put_template 8  "4e/4b/61"
+put_template 9  "d9/44/3f"
+put_template 10 "d6/b0/4e"
+put_template 11 "f6/68/13"
+put_template 12 "80/86/ef"
+put_template 13 "e2/c2/bb"
+put_template 14 "a4/dc/e7"
+put_template 15 "d2/c7/a9"
+
+color_foreground="af/9a/91"
+color_background="12/12/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "af9a91"
+  put_template_custom Ph "121214"
+  put_template_custom Pi "af9a92"
+  put_template_custom Pj "575256"
+  put_template_custom Pk "d2c7a9"
+  put_template_custom Pl "af9a91"
+  put_template_custom Pm "391a02"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Smyck.sh
+++ b/generic/Smyck.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Smyck
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b8/41/31"
+put_template 2  "7d/a9/00"
+put_template 3  "c4/a5/00"
+put_template 4  "62/a3/c4"
+put_template 5  "ba/8a/cc"
+put_template 6  "20/73/83"
+put_template 7  "a1/a1/a1"
+put_template 8  "7a/7a/7a"
+put_template 9  "d6/83/7c"
+put_template 10 "c4/f1/37"
+put_template 11 "fe/e1/4d"
+put_template 12 "8d/cf/f0"
+put_template 13 "f7/9a/ff"
+put_template 14 "6a/d9/cf"
+put_template 15 "f7/f7/f7"
+
+color_foreground="f7/f7/f7"
+color_background="1b/1b/1b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f7f7f7"
+  put_template_custom Ph "1b1b1b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "207483"
+  put_template_custom Pk "f7f7f7"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Snazzy Soft.sh
+++ b/generic/Snazzy Soft.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Snazzy Soft
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/5c/57"
+put_template 2  "5a/f7/8e"
+put_template 3  "f3/f9/9d"
+put_template 4  "57/c7/ff"
+put_template 5  "ff/6a/c1"
+put_template 6  "9a/ed/fe"
+put_template 7  "f1/f1/f0"
+put_template 8  "68/68/68"
+put_template 9  "ff/5c/57"
+put_template 10 "5a/f7/8e"
+put_template 11 "f3/f9/9d"
+put_template 12 "57/c7/ff"
+put_template 13 "ff/6a/c1"
+put_template 14 "9a/ed/fe"
+put_template 15 "f1/f1/f0"
+
+color_foreground="ef/f0/eb"
+color_background="28/2a/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eff0eb"
+  put_template_custom Ph "282a36"
+  put_template_custom Pi "f8f8f8"
+  put_template_custom Pj "92bcd0"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "eaeaea"
+  put_template_custom Pm "282a36"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Snazzy.sh
+++ b/generic/Snazzy.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Snazzy
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "fc/43/46"
+put_template 2  "50/fb/7c"
+put_template 3  "f0/fb/8c"
+put_template 4  "49/ba/ff"
+put_template 5  "fc/4c/b4"
+put_template 6  "8b/e9/fe"
+put_template 7  "ed/ed/ec"
+put_template 8  "55/55/55"
+put_template 9  "fc/43/46"
+put_template 10 "50/fb/7c"
+put_template 11 "f0/fb/8c"
+put_template 12 "49/ba/ff"
+put_template 13 "fc/4c/b4"
+put_template 14 "8b/e9/fe"
+put_template 15 "ed/ed/ec"
+
+color_foreground="eb/ec/e6"
+color_background="1e/1f/29"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebece6"
+  put_template_custom Ph "1e1f29"
+  put_template_custom Pi "f6f6f6"
+  put_template_custom Pj "81aec6"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "e4e4e4"
+  put_template_custom Pm "f6f6f6"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SoftServer.sh
+++ b/generic/SoftServer.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SoftServer
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "a2/68/6a"
+put_template 2  "9a/a5/6a"
+put_template 3  "a3/90/6a"
+put_template 4  "6b/8f/a3"
+put_template 5  "6a/71/a3"
+put_template 6  "6b/a5/8f"
+put_template 7  "99/a3/a2"
+put_template 8  "66/6c/6c"
+put_template 9  "dd/5c/60"
+put_template 10 "bf/df/55"
+put_template 11 "de/b3/60"
+put_template 12 "62/b1/df"
+put_template 13 "60/6e/df"
+put_template 14 "64/e3/9c"
+put_template 15 "d2/e0/de"
+
+color_foreground="99/a3/a2"
+color_background="24/26/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "99a3a2"
+  put_template_custom Ph "242626"
+  put_template_custom Pi "d2e0de"
+  put_template_custom Pj "7f8786"
+  put_template_custom Pk "effffe"
+  put_template_custom Pl "d2e0de"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Solarized Darcula.sh
+++ b/generic/Solarized Darcula.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Solarized Darcula
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "25/29/2a"
+put_template 1  "f2/48/40"
+put_template 2  "62/96/55"
+put_template 3  "b6/88/00"
+put_template 4  "20/75/c7"
+put_template 5  "79/7f/d4"
+put_template 6  "15/96/8d"
+put_template 7  "d2/d8/d9"
+put_template 8  "25/29/2a"
+put_template 9  "f2/48/40"
+put_template 10 "62/96/55"
+put_template 11 "b6/88/00"
+put_template 12 "20/75/c7"
+put_template 13 "79/7f/d4"
+put_template 14 "15/96/8d"
+put_template 15 "d2/d8/d9"
+
+color_foreground="d2/d8/d9"
+color_background="3d/3f/41"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d2d8d9"
+  put_template_custom Ph "3d3f41"
+  put_template_custom Pi "ececec"
+  put_template_custom Pj "214283"
+  put_template_custom Pk "d2d8d9"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Solarized Dark - Patched.sh
+++ b/generic/Solarized Dark - Patched.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Solarized Dark - Patched
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/28/31"
+put_template 1  "d1/1c/24"
+put_template 2  "73/8a/05"
+put_template 3  "a5/77/06"
+put_template 4  "21/76/c7"
+put_template 5  "c6/1c/6f"
+put_template 6  "25/92/86"
+put_template 7  "ea/e3/cb"
+put_template 8  "47/5b/62"
+put_template 9  "bd/36/13"
+put_template 10 "47/5b/62"
+put_template 11 "53/68/70"
+put_template 12 "70/82/84"
+put_template 13 "59/56/ba"
+put_template 14 "81/90/90"
+put_template 15 "fc/f4/dc"
+
+color_foreground="70/82/84"
+color_background="00/1e/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "708284"
+  put_template_custom Ph "001e27"
+  put_template_custom Pi "819090"
+  put_template_custom Pj "002831"
+  put_template_custom Pk "819090"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Solarized Dark Higher Contrast.sh
+++ b/generic/Solarized Dark Higher Contrast.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Solarized Dark Higher Contrast
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/28/31"
+put_template 1  "d1/1c/24"
+put_template 2  "6c/be/6c"
+put_template 3  "a5/77/06"
+put_template 4  "21/76/c7"
+put_template 5  "c6/1c/6f"
+put_template 6  "25/92/86"
+put_template 7  "ea/e3/cb"
+put_template 8  "00/64/88"
+put_template 9  "f5/16/3b"
+put_template 10 "51/ef/84"
+put_template 11 "b2/7e/28"
+put_template 12 "17/8e/c8"
+put_template 13 "e2/4d/8e"
+put_template 14 "00/b3/9e"
+put_template 15 "fc/f4/dc"
+
+color_foreground="9c/c2/c3"
+color_background="00/1e/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "9cc2c3"
+  put_template_custom Ph "001e27"
+  put_template_custom Pi "b5d5d3"
+  put_template_custom Pj "003748"
+  put_template_custom Pk "7a8f8e"
+  put_template_custom Pl "f34b00"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SpaceGray Bright.sh
+++ b/generic/SpaceGray Bright.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SpaceGray Bright
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "08/08/08"
+put_template 1  "bc/55/53"
+put_template 2  "a0/b5/6c"
+put_template 3  "f6/c9/87"
+put_template 4  "7b/ae/c1"
+put_template 5  "b9/8a/ae"
+put_template 6  "85/c9/b8"
+put_template 7  "d8/d8/d8"
+put_template 8  "62/62/62"
+put_template 9  "bc/55/53"
+put_template 10 "a0/b5/6c"
+put_template 11 "f6/c9/87"
+put_template 12 "7b/ae/c1"
+put_template 13 "b9/8a/ae"
+put_template 14 "85/c9/b8"
+put_template 15 "f7/f7/f7"
+
+color_foreground="f3/f3/f3"
+color_background="2a/2e/3a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f3f3f3"
+  put_template_custom Ph "2a2e3a"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "cacaca"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c6c6c6"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SpaceGray Eighties Dull.sh
+++ b/generic/SpaceGray Eighties Dull.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SpaceGray Eighties Dull
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/17/1c"
+put_template 1  "b2/4a/56"
+put_template 2  "92/b4/77"
+put_template 3  "c6/73/5a"
+put_template 4  "7c/8f/a5"
+put_template 5  "a5/78/9e"
+put_template 6  "80/cd/cb"
+put_template 7  "b3/b8/c3"
+put_template 8  "55/55/55"
+put_template 9  "ec/5f/67"
+put_template 10 "89/e9/86"
+put_template 11 "fe/c2/54"
+put_template 12 "54/86/c0"
+put_template 13 "bf/83/c1"
+put_template 14 "58/c2/c1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c9/c6/bc"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c9c6bc"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "272e36"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SpaceGray Eighties.sh
+++ b/generic/SpaceGray Eighties.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SpaceGray Eighties
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/17/1c"
+put_template 1  "ec/5f/67"
+put_template 2  "81/a7/64"
+put_template 3  "fe/c2/54"
+put_template 4  "54/86/c0"
+put_template 5  "bf/83/c1"
+put_template 6  "57/c2/c1"
+put_template 7  "ef/ec/e7"
+put_template 8  "55/55/55"
+put_template 9  "ff/69/73"
+put_template 10 "93/d4/93"
+put_template 11 "ff/d2/56"
+put_template 12 "4d/84/d1"
+put_template 13 "ff/55/ff"
+put_template 14 "83/e9/e4"
+put_template 15 "ff/ff/ff"
+
+color_foreground="bd/ba/ae"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bdbaae"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "272e35"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SpaceGray.sh
+++ b/generic/SpaceGray.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SpaceGray
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b0/4b/57"
+put_template 2  "87/b3/79"
+put_template 3  "e5/c1/79"
+put_template 4  "7d/8f/a4"
+put_template 5  "a4/79/96"
+put_template 6  "85/a7/a5"
+put_template 7  "b3/b8/c3"
+put_template 8  "00/00/00"
+put_template 9  "b0/4b/57"
+put_template 10 "87/b3/79"
+put_template 11 "e5/c1/79"
+put_template 12 "7d/8f/a4"
+put_template 13 "a4/79/96"
+put_template 14 "85/a7/a5"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b3/b8/c3"
+color_background="20/24/2d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b3b8c3"
+  put_template_custom Ph "20242d"
+  put_template_custom Pi "b3b8c3"
+  put_template_custom Pj "16181e"
+  put_template_custom Pk "b3b8c3"
+  put_template_custom Pl "b3b8c3"
+  put_template_custom Pm "1d1f21"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Spacedust.sh
+++ b/generic/Spacedust.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Spacedust
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "6e/53/46"
+put_template 1  "e3/5b/00"
+put_template 2  "5c/ab/96"
+put_template 3  "e3/cd/7b"
+put_template 4  "0f/54/8b"
+put_template 5  "e3/5b/00"
+put_template 6  "06/af/c7"
+put_template 7  "f0/f1/ce"
+put_template 8  "68/4c/31"
+put_template 9  "ff/8a/3a"
+put_template 10 "ae/ca/b8"
+put_template 11 "ff/c8/78"
+put_template 12 "67/a0/ce"
+put_template 13 "ff/8a/3a"
+put_template 14 "83/a7/b4"
+put_template 15 "fe/ff/f1"
+
+color_foreground="ec/f0/c1"
+color_background="0a/1e/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ecf0c1"
+  put_template_custom Ph "0a1e24"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "0a385c"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "002831"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Spiderman.sh
+++ b/generic/Spiderman.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Spiderman
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/1e"
+put_template 1  "e6/08/13"
+put_template 2  "e2/29/28"
+put_template 3  "e2/47/56"
+put_template 4  "2c/3f/ff"
+put_template 5  "24/35/db"
+put_template 6  "32/56/ff"
+put_template 7  "ff/fe/f6"
+put_template 8  "50/53/54"
+put_template 9  "ff/03/25"
+put_template 10 "ff/33/38"
+put_template 11 "fe/3a/35"
+put_template 12 "1d/50/ff"
+put_template 13 "74/7c/ff"
+put_template 14 "61/84/ff"
+put_template 15 "ff/ff/f9"
+
+color_foreground="e3/e3/e3"
+color_background="1b/1d/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e3e3e3"
+  put_template_custom Ph "1b1d1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "070e50"
+  put_template_custom Pk "f0272d"
+  put_template_custom Pl "2c3fff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Spring.sh
+++ b/generic/Spring.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Spring
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/4d/83"
+put_template 2  "1f/8c/3b"
+put_template 3  "1f/c9/5b"
+put_template 4  "1d/d3/ee"
+put_template 5  "89/59/a8"
+put_template 6  "3e/99/9f"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "ff/00/21"
+put_template 10 "1f/c2/31"
+put_template 11 "d5/b8/07"
+put_template 12 "15/a9/fd"
+put_template 13 "89/59/a8"
+put_template 14 "3e/99/9f"
+put_template 15 "ff/ff/ff"
+
+color_foreground="4d/4d/4c"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "4d4d4c"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "4d4d4c"
+  put_template_custom Pj "d6d6d6"
+  put_template_custom Pk "4d4d4c"
+  put_template_custom Pl "4d4d4c"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Square.sh
+++ b/generic/Square.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Square
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "05/05/05"
+put_template 1  "e9/89/7c"
+put_template 2  "b6/37/7d"
+put_template 3  "ec/eb/be"
+put_template 4  "a9/cd/eb"
+put_template 5  "75/50/7b"
+put_template 6  "c9/ca/ec"
+put_template 7  "f2/f2/f2"
+put_template 8  "14/14/14"
+put_template 9  "f9/92/86"
+put_template 10 "c3/f7/86"
+put_template 11 "fc/fb/cc"
+put_template 12 "b6/de/fb"
+put_template 13 "ad/7f/a8"
+put_template 14 "d7/d9/fc"
+put_template 15 "e2/e2/e2"
+
+color_foreground="ac/ac/ab"
+color_background="1a/1a/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "acacab"
+  put_template_custom Ph "1a1a1a"
+  put_template_custom Pi "e5e5e5"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fcfbcc"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Squirrelsong Dark.sh
+++ b/generic/Squirrelsong Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Squirrelsong Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "35/2a/21"
+put_template 1  "ac/49/3e"
+put_template 2  "55/82/40"
+put_template 3  "ce/b2/50"
+put_template 4  "59/93/c2"
+put_template 5  "7f/61/b3"
+put_template 6  "4f/95/93"
+put_template 7  "cf/ba/a5"
+put_template 8  "6b/50/3c"
+put_template 9  "ce/57/4a"
+put_template 10 "71/99/55"
+put_template 11 "e2/c3/58"
+put_template 12 "63/a2/d6"
+put_template 13 "96/72/d4"
+put_template 14 "72/aa/a8"
+put_template 15 "ed/d5/be"
+
+color_foreground="ad/9c/8b"
+color_background="35/2a/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ad9c8b"
+  put_template_custom Ph "352a21"
+  put_template_custom Pi "edd5be"
+  put_template_custom Pj "574131"
+  put_template_custom Pk "ad9c8b"
+  put_template_custom Pl "ad9c8b"
+  put_template_custom Pm "352a21"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Sublette.sh
+++ b/generic/Sublette.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Sublette
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "25/30/45"
+put_template 1  "ee/55/77"
+put_template 2  "55/ee/77"
+put_template 3  "ff/dd/88"
+put_template 4  "55/88/ff"
+put_template 5  "ff/77/cc"
+put_template 6  "44/ee/ee"
+put_template 7  "f5/f5/da"
+put_template 8  "40/55/70"
+put_template 9  "ee/66/55"
+put_template 10 "99/ee/77"
+put_template 11 "ff/ff/77"
+put_template 12 "77/bb/ff"
+put_template 13 "aa/88/ff"
+put_template 14 "55/ff/bb"
+put_template 15 "ff/ff/ee"
+
+color_foreground="cc/ce/d0"
+color_background="20/25/35"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ccced0"
+  put_template_custom Ph "202535"
+  put_template_custom Pi "ccced0"
+  put_template_custom Pj "ccced0"
+  put_template_custom Pk "202535"
+  put_template_custom Pl "ccced0"
+  put_template_custom Pm "202535"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Subliminal.sh
+++ b/generic/Subliminal.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Subliminal
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "7f/7f/7f"
+put_template 1  "e1/5a/60"
+put_template 2  "a9/cf/a4"
+put_template 3  "ff/e2/a9"
+put_template 4  "66/99/cc"
+put_template 5  "f1/a5/ab"
+put_template 6  "5f/b3/b3"
+put_template 7  "d4/d4/d4"
+put_template 8  "7f/7f/7f"
+put_template 9  "e1/5a/60"
+put_template 10 "a9/cf/a4"
+put_template 11 "ff/e2/a9"
+put_template 12 "66/99/cc"
+put_template 13 "f1/a5/ab"
+put_template 14 "5f/b3/b3"
+put_template 15 "d4/d4/d4"
+
+color_foreground="d4/d4/d4"
+color_background="28/2c/35"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d4d4d4"
+  put_template_custom Ph "282c35"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "484e5b"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Sugarplum.sh
+++ b/generic/Sugarplum.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Sugarplum
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "11/11/47"
+put_template 1  "5c/a8/dc"
+put_template 2  "53/b3/97"
+put_template 3  "24/9a/84"
+put_template 4  "db/7d/dd"
+put_template 5  "d0/be/ee"
+put_template 6  "f9/f3/f9"
+put_template 7  "a1/75/d4"
+put_template 8  "11/11/47"
+put_template 9  "5c/b5/dc"
+put_template 10 "52/de/b5"
+put_template 11 "01/f5/c7"
+put_template 12 "fa/5d/fd"
+put_template 13 "c6/a5/fd"
+put_template 14 "ff/ff/ff"
+put_template 15 "b5/77/fd"
+
+color_foreground="db/7d/dd"
+color_background="11/11/47"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "db7ddd"
+  put_template_custom Ph "111147"
+  put_template_custom Pi "d0beee"
+  put_template_custom Pj "5ca8dc"
+  put_template_custom Pk "d0beee"
+  put_template_custom Pl "53b397"
+  put_template_custom Pm "53b397"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Sundried.sh
+++ b/generic/Sundried.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Sundried
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "30/2b/2a"
+put_template 1  "a7/46/3d"
+put_template 2  "58/77/44"
+put_template 3  "9d/60/2a"
+put_template 4  "48/5b/98"
+put_template 5  "86/46/51"
+put_template 6  "9c/81/4f"
+put_template 7  "c9/c9/c9"
+put_template 8  "4d/4e/48"
+put_template 9  "aa/00/0c"
+put_template 10 "12/8c/21"
+put_template 11 "fc/6a/21"
+put_template 12 "79/99/f7"
+put_template 13 "fd/8a/a1"
+put_template 14 "fa/d4/84"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c9/c9/c9"
+color_background="1a/18/18"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c9c9c9"
+  put_template_custom Ph "1a1818"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "302b2a"
+  put_template_custom Pk "c9c9c9"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "191717"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Symfonic.sh
+++ b/generic/Symfonic.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Symfonic
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "dc/32/2f"
+put_template 2  "56/db/3a"
+put_template 3  "ff/84/00"
+put_template 4  "00/84/d4"
+put_template 5  "b7/29/d9"
+put_template 6  "cc/cc/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "1b/1d/21"
+put_template 9  "dc/32/2f"
+put_template 10 "56/db/3a"
+put_template 11 "ff/84/00"
+put_template 12 "00/84/d4"
+put_template 13 "b7/29/d9"
+put_template 14 "cc/cc/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ff8400"
+  put_template_custom Pj "073642"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "dc322f"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/SynthwaveAlpha.sh
+++ b/generic/SynthwaveAlpha.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# SynthwaveAlpha
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/1b/30"
+put_template 1  "e6/0a/70"
+put_template 2  "00/98/6c"
+put_template 3  "ad/ad/3e"
+put_template 4  "6e/29/ad"
+put_template 5  "b3/00/ad"
+put_template 6  "00/b0/b1"
+put_template 7  "b9/b1/bc"
+put_template 8  "7f/70/94"
+put_template 9  "e6/0a/70"
+put_template 10 "0a/e4/a4"
+put_template 11 "f9/f9/72"
+put_template 12 "aa/54/f9"
+put_template 13 "ff/00/f6"
+put_template 14 "00/fb/fd"
+put_template 15 "f2/f2/e3"
+
+color_foreground="f2/f2/e3"
+color_background="24/1b/30"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f2f2e3"
+  put_template_custom Ph "241b30"
+  put_template_custom Pi "f2f2e3"
+  put_template_custom Pj "6e29ad"
+  put_template_custom Pk "f2f2e3"
+  put_template_custom Pl "f2f2e3"
+  put_template_custom Pm "241b30"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tango Adapted.sh
+++ b/generic/Tango Adapted.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tango Adapted
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/00/00"
+put_template 2  "59/d6/00"
+put_template 3  "f0/cb/00"
+put_template 4  "00/a2/ff"
+put_template 5  "c1/7e/cc"
+put_template 6  "00/d0/d6"
+put_template 7  "e6/eb/e1"
+put_template 8  "8f/92/8b"
+put_template 9  "ff/00/13"
+put_template 10 "93/ff/00"
+put_template 11 "ff/f1/21"
+put_template 12 "88/c9/ff"
+put_template 13 "e9/a7/e1"
+put_template 14 "00/fe/ff"
+put_template 15 "f6/f6/f4"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tango Half Adapted.sh
+++ b/generic/Tango Half Adapted.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tango Half Adapted
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/00/00"
+put_template 2  "4c/c3/00"
+put_template 3  "e2/c0/00"
+put_template 4  "00/8e/f6"
+put_template 5  "a9/6c/b3"
+put_template 6  "00/bd/c3"
+put_template 7  "e0/e5/db"
+put_template 8  "79/7d/76"
+put_template 9  "ff/00/13"
+put_template 10 "8a/f6/00"
+put_template 11 "ff/ec/00"
+put_template 12 "76/bf/ff"
+put_template 13 "d8/98/d1"
+put_template 14 "00/f6/fa"
+put_template 15 "f4/f4/f2"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Teerb.sh
+++ b/generic/Teerb.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Teerb
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1c/1c/1c"
+put_template 1  "d6/86/86"
+put_template 2  "ae/d6/86"
+put_template 3  "d7/af/87"
+put_template 4  "86/ae/d6"
+put_template 5  "d6/ae/d6"
+put_template 6  "8a/db/b4"
+put_template 7  "d0/d0/d0"
+put_template 8  "1c/1c/1c"
+put_template 9  "d6/86/86"
+put_template 10 "ae/d6/86"
+put_template 11 "e4/c9/af"
+put_template 12 "86/ae/d6"
+put_template 13 "d6/ae/d6"
+put_template 14 "b1/e7/dd"
+put_template 15 "ef/ef/ef"
+
+color_foreground="d0/d0/d0"
+color_background="26/26/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d0d0d0"
+  put_template_custom Ph "262626"
+  put_template_custom Pi "e5e5e5"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "e4c9af"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Terminal Basic Dark.sh
+++ b/generic/Terminal Basic Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Terminal Basic Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c6/53/39"
+put_template 2  "6a/c4/4b"
+put_template 3  "b8/b7/4a"
+put_template 4  "64/44/ed"
+put_template 5  "d3/57/db"
+put_template 6  "69/c1/cf"
+put_template 7  "d1/d1/d1"
+put_template 8  "90/90/90"
+put_template 9  "eb/5a/3a"
+put_template 10 "77/ea/51"
+put_template 11 "ef/ef/53"
+put_template 12 "d0/9a/f9"
+put_template 13 "eb/5a/f7"
+put_template 14 "78/f1/f2"
+put_template 15 "ed/ed/ed"
+
+color_foreground="ff/ff/ff"
+color_background="1d/1e/1d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1d1e1d"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3f638a"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "9d9d9d"
+  put_template_custom Pm "1d1e1d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Terminal Basic.sh
+++ b/generic/Terminal Basic.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Terminal Basic
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "99/00/00"
+put_template 2  "00/a6/00"
+put_template 3  "99/99/00"
+put_template 4  "00/00/b2"
+put_template 5  "b2/00/b2"
+put_template 6  "00/a6/b2"
+put_template 7  "bf/bf/bf"
+put_template 8  "66/66/66"
+put_template 9  "e5/00/00"
+put_template 10 "00/d9/00"
+put_template 11 "e5/e5/00"
+put_template 12 "00/00/ff"
+put_template 13 "e5/00/e5"
+put_template 14 "00/e5/e5"
+put_template 15 "e5/e5/e5"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "a4c9ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "7f7f7f"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Thayer Bright.sh
+++ b/generic/Thayer Bright.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Thayer Bright
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/1e"
+put_template 1  "f9/26/72"
+put_template 2  "4d/f8/40"
+put_template 3  "f4/fd/22"
+put_template 4  "27/57/d6"
+put_template 5  "8c/54/fe"
+put_template 6  "38/c8/b5"
+put_template 7  "cc/cc/c6"
+put_template 8  "50/53/54"
+put_template 9  "ff/59/95"
+put_template 10 "b6/e3/54"
+put_template 11 "fe/ed/6c"
+put_template 12 "3f/78/ff"
+put_template 13 "9e/6f/fe"
+put_template 14 "23/cf/d5"
+put_template 15 "f8/f8/f2"
+
+color_foreground="f8/f8/f8"
+color_background="1b/1d/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f8f8f8"
+  put_template_custom Ph "1b1d1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "fc971f"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/The Hulk.sh
+++ b/generic/The Hulk.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# The Hulk
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/1e"
+put_template 1  "26/9d/1b"
+put_template 2  "13/ce/30"
+put_template 3  "63/e4/57"
+put_template 4  "25/25/f5"
+put_template 5  "64/1f/74"
+put_template 6  "37/8c/a9"
+put_template 7  "d9/d8/d1"
+put_template 8  "50/53/54"
+put_template 9  "8d/ff/2a"
+put_template 10 "48/ff/77"
+put_template 11 "3a/fe/16"
+put_template 12 "50/6b/95"
+put_template 13 "72/58/9d"
+put_template 14 "40/85/a6"
+put_template 15 "e5/e6/e1"
+
+color_foreground="b5/b5/b5"
+color_background="1b/1d/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b5b5b5"
+  put_template_custom Ph "1b1d1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d504c"
+  put_template_custom Pk "0b6309"
+  put_template_custom Pl "16b61b"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tinacious Design (Dark).sh
+++ b/generic/Tinacious Design (Dark).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tinacious Design (Dark)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1d/26"
+put_template 1  "ff/33/99"
+put_template 2  "00/d3/64"
+put_template 3  "ff/cc/66"
+put_template 4  "00/cb/ff"
+put_template 5  "cc/66/ff"
+put_template 6  "00/ce/ca"
+put_template 7  "cb/cb/f0"
+put_template 8  "63/66/67"
+put_template 9  "ff/2f/92"
+put_template 10 "00/d3/64"
+put_template 11 "ff/d4/79"
+put_template 12 "00/cb/ff"
+put_template 13 "d7/83/ff"
+put_template 14 "00/d5/d4"
+put_template 15 "d5/d6/f3"
+
+color_foreground="cb/cb/f0"
+color_background="1d/1d/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cbcbf0"
+  put_template_custom Ph "1d1d26"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ff3399"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "cbcbf0"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tinacious Design (Light).sh
+++ b/generic/Tinacious Design (Light).sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tinacious Design (Light)
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/1d/26"
+put_template 1  "ff/33/99"
+put_template 2  "00/d3/64"
+put_template 3  "ff/cc/66"
+put_template 4  "00/cb/ff"
+put_template 5  "cc/66/ff"
+put_template 6  "00/ce/ca"
+put_template 7  "cb/cb/f0"
+put_template 8  "63/66/67"
+put_template 9  "ff/2f/92"
+put_template 10 "00/d3/64"
+put_template 11 "ff/d4/79"
+put_template 12 "00/cb/ff"
+put_template 13 "d7/83/ff"
+put_template 14 "00/d5/d4"
+put_template 15 "d5/d6/f3"
+
+color_foreground="1d/1d/26"
+color_background="f8/f8/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "1d1d26"
+  put_template_custom Ph "f8f8ff"
+  put_template_custom Pi "1d1d26"
+  put_template_custom Pj "ff3399"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "cbcbf0"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow Night Blue.sh
+++ b/generic/Tomorrow Night Blue.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow Night Blue
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/9d/a4"
+put_template 2  "d1/f1/a9"
+put_template 3  "ff/ee/ad"
+put_template 4  "bb/da/ff"
+put_template 5  "eb/bb/ff"
+put_template 6  "99/ff/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "ff/9d/a4"
+put_template 10 "d1/f1/a9"
+put_template 11 "ff/ee/ad"
+put_template 12 "bb/da/ff"
+put_template 13 "eb/bb/ff"
+put_template 14 "99/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="00/24/51"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "002451"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "003f8e"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "003f8e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow Night Bright.sh
+++ b/generic/Tomorrow Night Bright.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow Night Bright
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d5/4e/53"
+put_template 2  "b9/ca/4a"
+put_template 3  "e7/c5/47"
+put_template 4  "7a/a6/da"
+put_template 5  "c3/97/d8"
+put_template 6  "70/c0/b1"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "d5/4e/53"
+put_template 10 "b9/ca/4a"
+put_template 11 "e7/c5/47"
+put_template 12 "7a/a6/da"
+put_template 13 "c3/97/d8"
+put_template 14 "70/c0/b1"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ea/ea/ea"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eaeaea"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "eaeaea"
+  put_template_custom Pj "424242"
+  put_template_custom Pk "eaeaea"
+  put_template_custom Pl "eaeaea"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow Night Burns.sh
+++ b/generic/Tomorrow Night Burns.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow Night Burns
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "25/25/25"
+put_template 1  "83/2e/31"
+put_template 2  "a6/3c/40"
+put_template 3  "d3/49/4e"
+put_template 4  "fc/59/5f"
+put_template 5  "df/93/95"
+put_template 6  "ba/85/86"
+put_template 7  "f5/f5/f5"
+put_template 8  "5d/6f/71"
+put_template 9  "83/2e/31"
+put_template 10 "a6/3c/40"
+put_template 11 "d2/49/4e"
+put_template 12 "fc/59/5f"
+put_template 13 "df/93/95"
+put_template 14 "ba/85/86"
+put_template 15 "f5/f5/f5"
+
+color_foreground="a1/b0/b8"
+color_background="15/15/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a1b0b8"
+  put_template_custom Ph "151515"
+  put_template_custom Pi "819090"
+  put_template_custom Pj "b0bec5"
+  put_template_custom Pk "2a2d32"
+  put_template_custom Pl "ff443e"
+  put_template_custom Pm "708284"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow Night Eighties.sh
+++ b/generic/Tomorrow Night Eighties.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow Night Eighties
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f2/77/7a"
+put_template 2  "99/cc/99"
+put_template 3  "ff/cc/66"
+put_template 4  "66/99/cc"
+put_template 5  "cc/99/cc"
+put_template 6  "66/cc/cc"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "f2/77/7a"
+put_template 10 "99/cc/99"
+put_template 11 "ff/cc/66"
+put_template 12 "66/99/cc"
+put_template 13 "cc/99/cc"
+put_template 14 "66/cc/cc"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cc/cc/cc"
+color_background="2d/2d/2d"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cccccc"
+  put_template_custom Ph "2d2d2d"
+  put_template_custom Pi "cccccc"
+  put_template_custom Pj "515151"
+  put_template_custom Pk "cccccc"
+  put_template_custom Pl "cccccc"
+  put_template_custom Pm "2d2d2d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow Night.sh
+++ b/generic/Tomorrow Night.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow Night
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/66/66"
+put_template 2  "b5/bd/68"
+put_template 3  "f0/c6/74"
+put_template 4  "81/a2/be"
+put_template 5  "b2/94/bb"
+put_template 6  "8a/be/b7"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "cc/66/66"
+put_template 10 "b5/bd/68"
+put_template 11 "f0/c6/74"
+put_template 12 "81/a2/be"
+put_template 13 "b2/94/bb"
+put_template 14 "8a/be/b7"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c5/c8/c6"
+color_background="1d/1f/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c5c8c6"
+  put_template_custom Ph "1d1f21"
+  put_template_custom Pi "c5c8c6"
+  put_template_custom Pj "373b41"
+  put_template_custom Pk "c5c8c6"
+  put_template_custom Pl "c5c8c6"
+  put_template_custom Pm "1d1f21"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Tomorrow.sh
+++ b/generic/Tomorrow.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tomorrow
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c8/28/29"
+put_template 2  "71/8c/00"
+put_template 3  "ea/b7/00"
+put_template 4  "42/71/ae"
+put_template 5  "89/59/a8"
+put_template 6  "3e/99/9f"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "c8/28/29"
+put_template 10 "71/8c/00"
+put_template 11 "ea/b7/00"
+put_template 12 "42/71/ae"
+put_template 13 "89/59/a8"
+put_template 14 "3e/99/9f"
+put_template 15 "ff/ff/ff"
+
+color_foreground="4d/4d/4c"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "4d4d4c"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "4d4d4c"
+  put_template_custom Pj "d6d6d6"
+  put_template_custom Pk "4d4d4c"
+  put_template_custom Pl "4d4d4c"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ToyChest.sh
+++ b/generic/ToyChest.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ToyChest
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2c/3f/58"
+put_template 1  "be/2d/26"
+put_template 2  "1a/91/72"
+put_template 3  "db/8e/27"
+put_template 4  "32/5d/96"
+put_template 5  "8a/5e/dc"
+put_template 6  "35/a0/8f"
+put_template 7  "23/d1/83"
+put_template 8  "33/68/89"
+put_template 9  "dd/59/44"
+put_template 10 "31/d0/7b"
+put_template 11 "e7/d8/4b"
+put_template 12 "34/a6/da"
+put_template 13 "ae/6b/dc"
+put_template 14 "42/c3/ae"
+put_template 15 "d5/d5/d5"
+
+color_foreground="31/d0/7b"
+color_background="24/36/4b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "31d07b"
+  put_template_custom Ph "24364b"
+  put_template_custom Pi "2bff9f"
+  put_template_custom Pj "5f217a"
+  put_template_custom Pk "d5d5d5"
+  put_template_custom Pl "d5d5d5"
+  put_template_custom Pm "141c25"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Treehouse.sh
+++ b/generic/Treehouse.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Treehouse
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/13/00"
+put_template 1  "b2/27/0e"
+put_template 2  "44/a9/00"
+put_template 3  "aa/82/0c"
+put_template 4  "58/85/9a"
+put_template 5  "97/36/3d"
+put_template 6  "b2/5a/1e"
+put_template 7  "78/6b/53"
+put_template 8  "43/36/26"
+put_template 9  "ed/5d/20"
+put_template 10 "55/f2/38"
+put_template 11 "f2/b7/32"
+put_template 12 "85/cf/ed"
+put_template 13 "e1/4c/5a"
+put_template 14 "f0/7d/14"
+put_template 15 "ff/c8/00"
+
+color_foreground="78/6b/53"
+color_background="19/19/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "786b53"
+  put_template_custom Ph "191919"
+  put_template_custom Pi "fac800"
+  put_template_custom Pj "786b53"
+  put_template_custom Pk "fac800"
+  put_template_custom Pl "fac814"
+  put_template_custom Pm "191919"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Twilight.sh
+++ b/generic/Twilight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Twilight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/14/14"
+put_template 1  "c0/6d/44"
+put_template 2  "af/b9/7a"
+put_template 3  "c2/a8/6c"
+put_template 4  "44/47/4a"
+put_template 5  "b4/be/7c"
+put_template 6  "77/83/85"
+put_template 7  "ff/ff/d4"
+put_template 8  "26/26/26"
+put_template 9  "de/7c/4c"
+put_template 10 "cc/d8/8c"
+put_template 11 "e2/c4/7e"
+put_template 12 "5a/5e/62"
+put_template 13 "d0/dc/8e"
+put_template 14 "8a/98/9b"
+put_template 15 "ff/ff/d4"
+
+color_foreground="ff/ff/d4"
+color_background="14/14/14"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffd4"
+  put_template_custom Ph "141414"
+  put_template_custom Pi "ffffd4"
+  put_template_custom Pj "313131"
+  put_template_custom Pk "ffffd4"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Ubuntu.sh
+++ b/generic/Ubuntu.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Ubuntu
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2e/34/36"
+put_template 1  "cc/00/00"
+put_template 2  "4e/9a/06"
+put_template 3  "c4/a0/00"
+put_template 4  "34/65/a4"
+put_template 5  "75/50/7b"
+put_template 6  "06/98/9a"
+put_template 7  "d3/d7/cf"
+put_template 8  "55/57/53"
+put_template 9  "ef/29/29"
+put_template 10 "8a/e2/34"
+put_template 11 "fc/e9/4f"
+put_template 12 "72/9f/cf"
+put_template 13 "ad/7f/a8"
+put_template 14 "34/e2/e2"
+put_template 15 "ee/ee/ec"
+
+color_foreground="ee/ee/ec"
+color_background="30/0a/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eeeeec"
+  put_template_custom Ph "300a24"
+  put_template_custom Pi "eeeeec"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/UltraDark.sh
+++ b/generic/UltraDark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# UltraDark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f0/71/78"
+put_template 2  "c3/e8/8d"
+put_template 3  "ff/cb/6b"
+put_template 4  "82/aa/ff"
+put_template 5  "c7/92/ea"
+put_template 6  "89/dd/ff"
+put_template 7  "cc/cc/cc"
+put_template 8  "33/33/33"
+put_template 9  "f6/a9/ae"
+put_template 10 "db/f1/ba"
+put_template 11 "ff/df/a6"
+put_template 12 "b4/cc/ff"
+put_template 13 "dd/bd/f2"
+put_template 14 "b8/ea/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "222222"
+  put_template_custom Pk "cccccc"
+  put_template_custom Pl "fefefe"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/UltraViolent.sh
+++ b/generic/UltraViolent.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# UltraViolent
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/27/28"
+put_template 1  "ff/00/90"
+put_template 2  "b6/ff/00"
+put_template 3  "ff/f7/27"
+put_template 4  "47/e0/fb"
+put_template 5  "d7/31/ff"
+put_template 6  "0e/ff/bb"
+put_template 7  "e1/e1/e1"
+put_template 8  "63/66/67"
+put_template 9  "fb/58/b4"
+put_template 10 "de/ff/8c"
+put_template 11 "eb/e0/87"
+put_template 12 "7f/ec/ff"
+put_template 13 "e6/81/ff"
+put_template 14 "69/fc/d3"
+put_template 15 "f9/f9/f5"
+
+color_foreground="c1/c1/c1"
+color_background="24/27/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c1c1c1"
+  put_template_custom Ph "242728"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "574c49"
+  put_template_custom Pk "c3c7cb"
+  put_template_custom Pl "c1c1c1"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/UnderTheSea.sh
+++ b/generic/UnderTheSea.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# UnderTheSea
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "02/20/26"
+put_template 1  "b2/30/2d"
+put_template 2  "00/a9/41"
+put_template 3  "59/81/9c"
+put_template 4  "45/9a/86"
+put_template 5  "00/59/9d"
+put_template 6  "5d/7e/19"
+put_template 7  "40/55/55"
+put_template 8  "38/44/51"
+put_template 9  "ff/42/42"
+put_template 10 "2a/ea/5e"
+put_template 11 "8e/d4/fd"
+put_template 12 "61/d5/ba"
+put_template 13 "12/98/ff"
+put_template 14 "98/d0/28"
+put_template 15 "58/fb/d6"
+
+color_foreground="ff/ff/ff"
+color_background="01/11/16"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "011116"
+  put_template_custom Pi "2bffd2"
+  put_template_custom Pj "415555"
+  put_template_custom Pk "4dffda"
+  put_template_custom Pl "4afcd6"
+  put_template_custom Pm "031413"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Unikitty.sh
+++ b/generic/Unikitty.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Unikitty
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0c/0c/0c"
+put_template 1  "a8/0f/20"
+put_template 2  "ba/fc/8b"
+put_template 3  "ee/df/4b"
+put_template 4  "14/5f/cd"
+put_template 5  "ff/36/a2"
+put_template 6  "6b/d1/bc"
+put_template 7  "e2/d7/e1"
+put_template 8  "43/43/43"
+put_template 9  "d9/13/29"
+put_template 10 "d3/ff/af"
+put_template 11 "ff/ef/50"
+put_template 12 "00/75/ea"
+put_template 13 "fd/d5/e5"
+put_template 14 "79/ec/d5"
+put_template 15 "ff/f3/fe"
+
+color_foreground="0b/0b/0b"
+color_background="ff/8c/d9"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "0b0b0b"
+  put_template_custom Ph "ff8cd9"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "3ea9fe"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "bafc8b"
+  put_template_custom Pm "202020"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Urple.sh
+++ b/generic/Urple.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Urple
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "b0/42/5b"
+put_template 2  "37/a4/15"
+put_template 3  "ad/5c/42"
+put_template 4  "56/4d/9b"
+put_template 5  "6c/3c/a1"
+put_template 6  "80/80/80"
+put_template 7  "87/79/9c"
+put_template 8  "5d/32/25"
+put_template 9  "ff/63/88"
+put_template 10 "29/e6/20"
+put_template 11 "f0/81/61"
+put_template 12 "86/7a/ed"
+put_template 13 "a0/5e/ee"
+put_template 14 "ea/ea/ea"
+put_template 15 "bf/a3/ff"
+
+color_foreground="87/7a/9b"
+color_background="1b/1b/23"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "877a9b"
+  put_template_custom Ph "1b1b23"
+  put_template_custom Pi "a063eb"
+  put_template_custom Pj "a063eb"
+  put_template_custom Pk "1b1b22"
+  put_template_custom Pl "a063eb"
+  put_template_custom Pm "1b1b22"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Vague.sh
+++ b/generic/Vague.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Vague
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/14/15"
+put_template 1  "df/68/82"
+put_template 2  "8c/b6/6d"
+put_template 3  "f3/be/7c"
+put_template 4  "7e/98/e8"
+put_template 5  "c3/c3/d5"
+put_template 6  "9b/b4/bc"
+put_template 7  "cd/cd/cd"
+put_template 8  "87/87/87"
+put_template 9  "df/68/82"
+put_template 10 "8c/b6/6d"
+put_template 11 "f3/be/7c"
+put_template 12 "7e/98/e8"
+put_template 13 "c3/c3/d5"
+put_template 14 "9b/b4/bc"
+put_template 15 "cd/cd/cd"
+
+color_foreground="cd/cd/cd"
+color_background="14/14/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cdcdcd"
+  put_template_custom Ph "141415"
+  put_template_custom Pi "cdcdcd"
+  put_template_custom Pj "878787"
+  put_template_custom Pk "cdcdcd"
+  put_template_custom Pl "cdcdcd"
+  put_template_custom Pm "141415"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Vaughn.sh
+++ b/generic/Vaughn.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Vaughn
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "25/23/4f"
+put_template 1  "70/50/50"
+put_template 2  "60/b4/8a"
+put_template 3  "df/af/8f"
+put_template 4  "55/55/ff"
+put_template 5  "f0/8c/c3"
+put_template 6  "8c/d0/d3"
+put_template 7  "70/90/80"
+put_template 8  "70/90/80"
+put_template 9  "dc/a3/a3"
+put_template 10 "60/b4/8a"
+put_template 11 "f0/df/af"
+put_template 12 "55/55/ff"
+put_template 13 "ec/93/d3"
+put_template 14 "93/e0/e3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="dc/dc/cc"
+color_background="25/23/4f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcdccc"
+  put_template_custom Ph "25234f"
+  put_template_custom Pi "ff5e7d"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ff5555"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Vesper.sh
+++ b/generic/Vesper.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Vesper
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/10/10"
+put_template 1  "f5/a1/91"
+put_template 2  "90/b9/9f"
+put_template 3  "e6/b9/9d"
+put_template 4  "ac/a1/cf"
+put_template 5  "e2/9e/ca"
+put_template 6  "ea/83/a5"
+put_template 7  "a0/a0/a0"
+put_template 8  "7e/7e/7e"
+put_template 9  "ff/80/80"
+put_template 10 "99/ff/e4"
+put_template 11 "ff/c7/99"
+put_template 12 "b9/ae/da"
+put_template 13 "ec/aa/d6"
+put_template 14 "f5/91/b2"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="10/10/10"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "101010"
+  put_template_custom Pi "acb1ab"
+  put_template_custom Pj "988049"
+  put_template_custom Pk "acb1ab"
+  put_template_custom Pl "acb1ab"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/VibrantInk.sh
+++ b/generic/VibrantInk.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# VibrantInk
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "87/87/87"
+put_template 1  "ff/66/00"
+put_template 2  "cc/ff/04"
+put_template 3  "ff/cc/00"
+put_template 4  "44/b4/cc"
+put_template 5  "99/33/cc"
+put_template 6  "44/b4/cc"
+put_template 7  "f5/f5/f5"
+put_template 8  "55/55/55"
+put_template 9  "ff/00/00"
+put_template 10 "00/ff/00"
+put_template 11 "ff/ff/00"
+put_template 12 "00/00/ff"
+put_template 13 "ff/00/ff"
+put_template 14 "00/ff/ff"
+put_template 15 "e5/e5/e5"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b5d5ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Violet Dark.sh
+++ b/generic/Violet Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Violet Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "56/59/5c"
+put_template 1  "c9/4c/22"
+put_template 2  "85/98/1c"
+put_template 3  "b4/88/1d"
+put_template 4  "2e/8b/ce"
+put_template 5  "d1/3a/82"
+put_template 6  "32/a1/98"
+put_template 7  "c9/c6/bd"
+put_template 8  "45/48/4b"
+put_template 9  "bd/36/13"
+put_template 10 "73/8a/04"
+put_template 11 "a5/77/05"
+put_template 12 "21/76/c7"
+put_template 13 "c6/1c/6f"
+put_template 14 "25/92/86"
+put_template 15 "c9/c6/bd"
+
+color_foreground="70/82/84"
+color_background="1c/1d/1f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "708284"
+  put_template_custom Ph "1c1d1f"
+  put_template_custom Pi "475b62"
+  put_template_custom Pj "595ab7"
+  put_template_custom Pk "1c1d1f"
+  put_template_custom Pl "708284"
+  put_template_custom Pm "1c1d1f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Violet Light.sh
+++ b/generic/Violet Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Violet Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "56/59/5c"
+put_template 1  "c9/4c/22"
+put_template 2  "85/98/1c"
+put_template 3  "b4/88/1d"
+put_template 4  "2e/8b/ce"
+put_template 5  "d1/3a/82"
+put_template 6  "32/a1/98"
+put_template 7  "d3/d0/c9"
+put_template 8  "45/48/4b"
+put_template 9  "bd/36/13"
+put_template 10 "73/8a/04"
+put_template 11 "a5/77/05"
+put_template 12 "21/76/c7"
+put_template 13 "c6/1c/6f"
+put_template 14 "25/92/86"
+put_template 15 "c9/c6/bd"
+
+color_foreground="53/68/70"
+color_background="fc/f4/dc"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "536870"
+  put_template_custom Ph "fcf4dc"
+  put_template_custom Pi "475b62"
+  put_template_custom Pj "595ab7"
+  put_template_custom Pk "fcf4dc"
+  put_template_custom Pl "536870"
+  put_template_custom Pm "fcf4dc"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/WarmNeon.sh
+++ b/generic/WarmNeon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# WarmNeon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "e2/43/46"
+put_template 2  "39/b1/3a"
+put_template 3  "da/e1/45"
+put_template 4  "42/61/c5"
+put_template 5  "f9/20/fb"
+put_template 6  "2a/bb/d4"
+put_template 7  "d0/b8/a3"
+put_template 8  "fe/fc/fc"
+put_template 9  "e9/70/71"
+put_template 10 "9c/c0/90"
+put_template 11 "dd/da/7a"
+put_template 12 "7b/91/d6"
+put_template 13 "f6/74/ba"
+put_template 14 "5e/d1/e5"
+put_template 15 "d8/c8/bb"
+
+color_foreground="af/da/b6"
+color_background="40/40/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "afdab6"
+  put_template_custom Ph "404040"
+  put_template_custom Pi "22ff0c"
+  put_template_custom Pj "b0ad21"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "30ff24"
+  put_template_custom Pm "3eef37"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Wez.sh
+++ b/generic/Wez.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Wez
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "cc/55/55"
+put_template 2  "55/cc/55"
+put_template 3  "cd/cd/55"
+put_template 4  "55/55/cc"
+put_template 5  "cc/55/cc"
+put_template 6  "7a/ca/ca"
+put_template 7  "cc/cc/cc"
+put_template 8  "55/55/55"
+put_template 9  "ff/55/55"
+put_template 10 "55/ff/55"
+put_template 11 "ff/ff/55"
+put_template 12 "55/55/ff"
+put_template 13 "ff/55/ff"
+put_template 14 "55/ff/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b3/b3/b3"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b3b3b3"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ff6347"
+  put_template_custom Pj "4d52f8"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "53ae71"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Whimsy.sh
+++ b/generic/Whimsy.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Whimsy
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "53/51/78"
+put_template 1  "ef/64/87"
+put_template 2  "5e/ca/89"
+put_template 3  "fd/d8/77"
+put_template 4  "65/ae/f7"
+put_template 5  "aa/7f/f0"
+put_template 6  "43/c1/be"
+put_template 7  "ff/ff/ff"
+put_template 8  "53/51/78"
+put_template 9  "ef/64/87"
+put_template 10 "5e/ca/89"
+put_template 11 "fd/d8/77"
+put_template 12 "65/ae/f7"
+put_template 13 "aa/7f/f0"
+put_template 14 "43/c1/be"
+put_template 15 "ff/ff/ff"
+
+color_foreground="b3/b0/d6"
+color_background="29/28/3b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b3b0d6"
+  put_template_custom Ph "29283b"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "3d3c58"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "b3b0d6"
+  put_template_custom Pm "535178"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/WildCherry.sh
+++ b/generic/WildCherry.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# WildCherry
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/05/07"
+put_template 1  "d9/40/85"
+put_template 2  "2a/b2/50"
+put_template 3  "ff/d1/6f"
+put_template 4  "88/3c/dc"
+put_template 5  "ec/ec/ec"
+put_template 6  "c1/b8/b7"
+put_template 7  "ff/f8/de"
+put_template 8  "00/9c/c9"
+put_template 9  "da/6b/ac"
+put_template 10 "f4/dc/a5"
+put_template 11 "ea/c0/66"
+put_template 12 "30/8c/ba"
+put_template 13 "ae/63/6b"
+put_template 14 "ff/91/9d"
+put_template 15 "e4/83/8d"
+
+color_foreground="da/fa/ff"
+color_background="1f/17/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dafaff"
+  put_template_custom Ph "1f1726"
+  put_template_custom Pi "819090"
+  put_template_custom Pj "002831"
+  put_template_custom Pk "e4ffff"
+  put_template_custom Pl "dd00ff"
+  put_template_custom Pm "ff00fe"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Wombat.sh
+++ b/generic/Wombat.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Wombat
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/61/5a"
+put_template 2  "b1/e9/69"
+put_template 3  "eb/d9/9c"
+put_template 4  "5d/a9/f6"
+put_template 5  "e8/6a/ff"
+put_template 6  "82/ff/f7"
+put_template 7  "de/da/cf"
+put_template 8  "31/31/31"
+put_template 9  "f5/8c/80"
+put_template 10 "dd/f8/8f"
+put_template 11 "ee/e5/b2"
+put_template 12 "a5/c7/ff"
+put_template 13 "dd/aa/ff"
+put_template 14 "b7/ff/f9"
+put_template 15 "ff/ff/ff"
+
+color_foreground="de/da/cf"
+color_background="17/17/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dedacf"
+  put_template_custom Ph "171717"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "453b39"
+  put_template_custom Pk "b6bbc0"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Wryan.sh
+++ b/generic/Wryan.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Wryan
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "33/33/33"
+put_template 1  "8c/46/65"
+put_template 2  "28/73/73"
+put_template 3  "7c/7c/99"
+put_template 4  "39/55/73"
+put_template 5  "5e/46/8c"
+put_template 6  "31/65/8c"
+put_template 7  "89/9c/a1"
+put_template 8  "3d/3d/3d"
+put_template 9  "bf/4d/80"
+put_template 10 "53/a6/a6"
+put_template 11 "9e/9e/cb"
+put_template 12 "47/7a/b3"
+put_template 13 "7e/62/b3"
+put_template 14 "60/96/bf"
+put_template 15 "c0/c0/c0"
+
+color_foreground="99/99/93"
+color_background="10/10/10"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "999993"
+  put_template_custom Ph "101010"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4d4d4d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "9e9ecb"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/Zenburn.sh
+++ b/generic/Zenburn.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Zenburn
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4d/4d/4d"
+put_template 1  "70/50/50"
+put_template 2  "60/b4/8a"
+put_template 3  "f0/df/af"
+put_template 4  "50/60/70"
+put_template 5  "dc/8c/c3"
+put_template 6  "8c/d0/d3"
+put_template 7  "dc/dc/cc"
+put_template 8  "70/90/80"
+put_template 9  "dc/a3/a3"
+put_template 10 "c3/bf/9f"
+put_template 11 "e0/cf/9f"
+put_template 12 "94/bf/f3"
+put_template 13 "ec/93/d3"
+put_template 14 "93/e0/e3"
+put_template 15 "ff/ff/ff"
+
+color_foreground="dc/dc/cc"
+color_background="3f/3f/3f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcdccc"
+  put_template_custom Ph "3f3f3f"
+  put_template_custom Pi "dcdccc"
+  put_template_custom Pj "21322f"
+  put_template_custom Pk "c2d87a"
+  put_template_custom Pl "73635a"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/arcoiris.sh
+++ b/generic/arcoiris.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# arcoiris
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "33/33/33"
+put_template 1  "da/27/00"
+put_template 2  "12/c2/58"
+put_template 3  "ff/c6/56"
+put_template 4  "51/8b/fc"
+put_template 5  "e3/7b/d9"
+put_template 6  "63/fa/d5"
+put_template 7  "ba/b2/b2"
+put_template 8  "77/77/77"
+put_template 9  "ff/b9/b9"
+put_template 10 "e3/f6/aa"
+put_template 11 "ff/dd/aa"
+put_template 12 "b3/e8/f3"
+put_template 13 "cb/ba/f9"
+put_template 14 "bc/ff/c7"
+put_template 15 "ef/ef/ef"
+
+color_foreground="ee/e4/d9"
+color_background="20/1f/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "eee4d9"
+  put_template_custom Ph "201f1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "25524a"
+  put_template_custom Pk "f3fffd"
+  put_template_custom Pl "7a1c1c"
+  put_template_custom Pm "fffbf2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ayu.sh
+++ b/generic/ayu.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ayu
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/33/33"
+put_template 2  "b8/cc/52"
+put_template 3  "e7/c5/47"
+put_template 4  "36/a3/d9"
+put_template 5  "f0/71/78"
+put_template 6  "95/e6/cb"
+put_template 7  "ff/ff/ff"
+put_template 8  "32/32/32"
+put_template 9  "ff/65/65"
+put_template 10 "ea/fe/84"
+put_template 11 "ff/f7/79"
+put_template 12 "68/d5/ff"
+put_template 13 "ff/a3/aa"
+put_template 14 "c7/ff/fd"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e6/e1/cf"
+color_background="0f/14/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6e1cf"
+  put_template_custom Ph "0f1419"
+  put_template_custom Pi "e6e1cf"
+  put_template_custom Pj "253340"
+  put_template_custom Pk "e6e1cf"
+  put_template_custom Pl "f29718"
+  put_template_custom Pm "e6e1cf"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/ayu_light.sh
+++ b/generic/ayu_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# ayu_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/33/33"
+put_template 2  "86/b3/00"
+put_template 3  "f2/97/18"
+put_template 4  "41/a6/d9"
+put_template 5  "f0/71/78"
+put_template 6  "4d/bf/99"
+put_template 7  "ff/ff/ff"
+put_template 8  "32/32/32"
+put_template 9  "ff/65/65"
+put_template 10 "b8/e5/32"
+put_template 11 "ff/c9/4a"
+put_template 12 "73/d8/ff"
+put_template 13 "ff/a3/aa"
+put_template 14 "7f/f1/cb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="5c/67/73"
+color_background="fa/fa/fa"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "5c6773"
+  put_template_custom Ph "fafafa"
+  put_template_custom Pi "5c6773"
+  put_template_custom Pj "f0eee4"
+  put_template_custom Pk "5c6773"
+  put_template_custom Pl "ff6a00"
+  put_template_custom Pm "5c6773"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/catppuccin-frappe.sh
+++ b/generic/catppuccin-frappe.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# catppuccin-frappe
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "51/57/6d"
+put_template 1  "e7/82/84"
+put_template 2  "a6/d1/89"
+put_template 3  "e5/c8/90"
+put_template 4  "8c/aa/ee"
+put_template 5  "f4/b8/e4"
+put_template 6  "81/c8/be"
+put_template 7  "a5/ad/ce"
+put_template 8  "62/68/80"
+put_template 9  "e6/71/72"
+put_template 10 "8e/c7/72"
+put_template 11 "d9/ba/73"
+put_template 12 "7b/9e/f0"
+put_template 13 "f2/a4/db"
+put_template 14 "5a/bf/b5"
+put_template 15 "b5/bf/e2"
+
+color_foreground="c6/d0/f5"
+color_background="30/34/46"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c6d0f5"
+  put_template_custom Ph "303446"
+  put_template_custom Pi "c6d0f5"
+  put_template_custom Pj "626880"
+  put_template_custom Pk "c6d0f5"
+  put_template_custom Pl "f2d5cf"
+  put_template_custom Pm "c6d0f5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/catppuccin-latte.sh
+++ b/generic/catppuccin-latte.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# catppuccin-latte
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "5c/5f/77"
+put_template 1  "d2/0f/39"
+put_template 2  "40/a0/2b"
+put_template 3  "df/8e/1d"
+put_template 4  "1e/66/f5"
+put_template 5  "ea/76/cb"
+put_template 6  "17/92/99"
+put_template 7  "ac/b0/be"
+put_template 8  "6c/6f/85"
+put_template 9  "de/29/3e"
+put_template 10 "49/af/3d"
+put_template 11 "ee/a0/2d"
+put_template 12 "45/6e/ff"
+put_template 13 "fe/85/d8"
+put_template 14 "2d/9f/a8"
+put_template 15 "bc/c0/cc"
+
+color_foreground="4c/4f/69"
+color_background="ef/f1/f5"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "4c4f69"
+  put_template_custom Ph "eff1f5"
+  put_template_custom Pi "4c4f69"
+  put_template_custom Pj "acb0be"
+  put_template_custom Pk "4c4f69"
+  put_template_custom Pl "dc8a78"
+  put_template_custom Pm "4c4f69"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/catppuccin-macchiato.sh
+++ b/generic/catppuccin-macchiato.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# catppuccin-macchiato
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "49/4d/64"
+put_template 1  "ed/87/96"
+put_template 2  "a6/da/95"
+put_template 3  "ee/d4/9f"
+put_template 4  "8a/ad/f4"
+put_template 5  "f5/bd/e6"
+put_template 6  "8b/d5/ca"
+put_template 7  "a5/ad/cb"
+put_template 8  "5b/60/78"
+put_template 9  "ec/74/86"
+put_template 10 "8c/cf/7f"
+put_template 11 "e1/c6/82"
+put_template 12 "78/a1/f6"
+put_template 13 "f2/a9/dd"
+put_template 14 "63/cb/c0"
+put_template 15 "b8/c0/e0"
+
+color_foreground="ca/d3/f5"
+color_background="24/27/3a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cad3f5"
+  put_template_custom Ph "24273a"
+  put_template_custom Pi "cad3f5"
+  put_template_custom Pj "5b6078"
+  put_template_custom Pk "cad3f5"
+  put_template_custom Pl "f4dbd6"
+  put_template_custom Pm "cad3f5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/catppuccin-mocha.sh
+++ b/generic/catppuccin-mocha.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# catppuccin-mocha
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "45/47/5a"
+put_template 1  "f3/8b/a8"
+put_template 2  "a6/e3/a1"
+put_template 3  "f9/e2/af"
+put_template 4  "89/b4/fa"
+put_template 5  "f5/c2/e7"
+put_template 6  "94/e2/d5"
+put_template 7  "a6/ad/c8"
+put_template 8  "58/5b/70"
+put_template 9  "f3/77/99"
+put_template 10 "89/d8/8b"
+put_template 11 "eb/d3/91"
+put_template 12 "74/a8/fc"
+put_template 13 "f2/ae/de"
+put_template 14 "6b/d7/ca"
+put_template 15 "ba/c2/de"
+
+color_foreground="cd/d6/f4"
+color_background="1e/1e/2e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cdd6f4"
+  put_template_custom Ph "1e1e2e"
+  put_template_custom Pi "cdd6f4"
+  put_template_custom Pj "585b70"
+  put_template_custom Pk "cdd6f4"
+  put_template_custom Pl "f5e0dc"
+  put_template_custom Pm "cdd6f4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/citruszest.sh
+++ b/generic/citruszest.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# citruszest
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "40/40/40"
+put_template 1  "ff/54/54"
+put_template 2  "00/cc/7a"
+put_template 3  "ff/d4/00"
+put_template 4  "00/bf/ff"
+put_template 5  "ff/90/fe"
+put_template 6  "48/d1/cc"
+put_template 7  "bf/bf/bf"
+put_template 8  "80/80/80"
+put_template 9  "ff/1a/75"
+put_template 10 "1a/ff/a3"
+put_template 11 "ff/ff/00"
+put_template 12 "33/cf/ff"
+put_template 13 "ff/b2/fe"
+put_template 14 "00/ff/f2"
+put_template 15 "f9/f9/f9"
+
+color_foreground="bf/bf/bf"
+color_background="12/12/12"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bfbfbf"
+  put_template_custom Ph "121212"
+  put_template_custom Pi "f9f9f9"
+  put_template_custom Pj "ff8c00"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "666666"
+  put_template_custom Pm "f9f9f9"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/coffee_theme.sh
+++ b/generic/coffee_theme.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# coffee_theme
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c9/1b/00"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "02/25/c7"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="f5/de/b3"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "f5deb3"
+  put_template_custom Pi "00c200"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "fffc67"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/cyberpunk.sh
+++ b/generic/cyberpunk.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# cyberpunk
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "ff/70/92"
+put_template 2  "00/fb/ac"
+put_template 3  "ff/fa/6a"
+put_template 4  "00/bf/ff"
+put_template 5  "df/95/ff"
+put_template 6  "86/cb/fe"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "ff/8a/a4"
+put_template 10 "21/f6/bc"
+put_template 11 "ff/f7/87"
+put_template 12 "1b/cc/fd"
+put_template 13 "e6/ae/fe"
+put_template 14 "99/d6/fc"
+put_template 15 "ff/ff/ff"
+
+color_foreground="e5/e5/e5"
+color_background="33/2a/57"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e5e5e5"
+  put_template_custom Ph "332a57"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "21f6bc"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/darkermatrix.sh
+++ b/generic/darkermatrix.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# darkermatrix
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/10/13"
+put_template 1  "00/2e/18"
+put_template 2  "6f/a6/4c"
+put_template 3  "59/59/00"
+put_template 4  "00/cb/6b"
+put_template 5  "41/2a/4d"
+put_template 6  "12/54/59"
+put_template 7  "00/2e/19"
+put_template 8  "33/33/33"
+put_template 9  "00/38/1d"
+put_template 10 "90/d7/62"
+put_template 11 "e2/e5/00"
+put_template 12 "00/ff/87"
+put_template 13 "41/2a/4d"
+put_template 14 "17/6c/73"
+put_template 15 "00/38/1e"
+
+color_foreground="28/38/0d"
+color_background="07/0c/0e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "28380d"
+  put_template_custom Ph "070c0e"
+  put_template_custom Pi "00cd6d"
+  put_template_custom Pj "0f191c"
+  put_template_custom Pk "00ff87"
+  put_template_custom Pl "373a26"
+  put_template_custom Pm "00ff87"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/darkmatrix.sh
+++ b/generic/darkmatrix.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# darkmatrix
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "09/10/13"
+put_template 1  "00/65/36"
+put_template 2  "6f/a6/4c"
+put_template 3  "7e/80/00"
+put_template 4  "2c/9a/84"
+put_template 5  "45/2d/53"
+put_template 6  "11/4d/53"
+put_template 7  "00/65/36"
+put_template 8  "33/33/33"
+put_template 9  "00/73/3d"
+put_template 10 "90/d7/62"
+put_template 11 "e2/e5/00"
+put_template 12 "46/d8/b8"
+put_template 13 "4a/30/59"
+put_template 14 "12/54/5a"
+put_template 15 "00/65/36"
+
+color_foreground="3e/57/15"
+color_background="07/0c/0e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3e5715"
+  put_template_custom Ph "070c0e"
+  put_template_custom Pi "00cd6d"
+  put_template_custom Pj "0f191c"
+  put_template_custom Pk "00ff87"
+  put_template_custom Pl "9fa86e"
+  put_template_custom Pm "00ff87"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/dayfox.sh
+++ b/generic/dayfox.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# dayfox
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "35/2c/24"
+put_template 1  "a5/22/2f"
+put_template 2  "39/68/47"
+put_template 3  "ac/54/02"
+put_template 4  "28/48/a9"
+put_template 5  "6e/33/ce"
+put_template 6  "28/79/80"
+put_template 7  "f2/e9/e1"
+put_template 8  "53/4c/45"
+put_template 9  "b3/43/4e"
+put_template 10 "57/7f/63"
+put_template 11 "b8/6e/28"
+put_template 12 "48/63/b6"
+put_template 13 "84/52/d5"
+put_template 14 "48/8d/93"
+put_template 15 "f4/ec/e6"
+
+color_foreground="3d/2b/5a"
+color_background="f6/f2/ee"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3d2b5a"
+  put_template_custom Ph "f6f2ee"
+  put_template_custom Pi "3d2b5a"
+  put_template_custom Pj "e7d2be"
+  put_template_custom Pk "3d2b5a"
+  put_template_custom Pl "3d2b5a"
+  put_template_custom Pm "f6f2ee"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/deep.sh
+++ b/generic/deep.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# deep
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d7/00/05"
+put_template 2  "1c/d9/15"
+put_template 3  "d9/bd/26"
+put_template 4  "56/65/ff"
+put_template 5  "b0/52/da"
+put_template 6  "50/d2/da"
+put_template 7  "e0/e0/e0"
+put_template 8  "53/53/53"
+put_template 9  "fb/00/07"
+put_template 10 "22/ff/18"
+put_template 11 "fe/dc/2b"
+put_template 12 "9f/a9/ff"
+put_template 13 "e0/9a/ff"
+put_template 14 "8d/f9/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="cd/cd/cd"
+color_background="09/09/09"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cdcdcd"
+  put_template_custom Ph "090909"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "780002"
+  put_template_custom Pk "ececec"
+  put_template_custom Pl "d0d0d0"
+  put_template_custom Pm "151515"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/detuned.sh
+++ b/generic/detuned.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# detuned
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "17/17/17"
+put_template 1  "ea/53/86"
+put_template 2  "b3/e1/53"
+put_template 3  "e4/da/81"
+put_template 4  "41/92/d3"
+put_template 5  "8f/3e/f6"
+put_template 6  "6c/b4/d5"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ea/86/ac"
+put_template 10 "c5/e2/80"
+put_template 11 "fd/f3/8f"
+put_template 12 "55/bb/f9"
+put_template 13 "b9/a0/f9"
+put_template 14 "7f/d4/fb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c7/c7/c7"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c7c7c7"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c7ddfc"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/duckbones.sh
+++ b/generic/duckbones.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# duckbones
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0e/10/1a"
+put_template 1  "e0/36/00"
+put_template 2  "5d/cd/97"
+put_template 3  "e3/95/00"
+put_template 4  "00/a3/cb"
+put_template 5  "79/5c/cc"
+put_template 6  "00/a3/cb"
+put_template 7  "eb/ef/c0"
+put_template 8  "2b/2f/46"
+put_template 9  "ff/48/21"
+put_template 10 "58/db/9e"
+put_template 11 "f6/a1/00"
+put_template 12 "00/b4/e0"
+put_template 13 "b3/a1/e6"
+put_template 14 "00/b4/e0"
+put_template 15 "b3/b6/92"
+
+color_foreground="eb/ef/c0"
+color_background="0e/10/1a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ebefc0"
+  put_template_custom Ph "0e101a"
+  put_template_custom Pi "2b2f46"
+  put_template_custom Pj "37382d"
+  put_template_custom Pk "ebefc0"
+  put_template_custom Pl "edf2c2"
+  put_template_custom Pm "0e101a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/electron-highlighter.sh
+++ b/generic/electron-highlighter.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# electron-highlighter
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/16/1e"
+put_template 1  "f7/76/8e"
+put_template 2  "58/ff/c7"
+put_template 3  "ff/d9/af"
+put_template 4  "82/aa/ff"
+put_template 5  "d2/a6/ef"
+put_template 6  "57/f9/ff"
+put_template 7  "7c/8e/ac"
+put_template 8  "50/66/86"
+put_template 9  "f7/76/8e"
+put_template 10 "58/ff/c7"
+put_template 11 "ff/d9/af"
+put_template 12 "82/aa/ff"
+put_template 13 "d2/a6/ef"
+put_template 14 "57/f9/ff"
+put_template 15 "c5/ce/e0"
+
+color_foreground="a8/b5/d1"
+color_background="24/28/3b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a8b5d1"
+  put_template_custom Ph "24283b"
+  put_template_custom Pi "aab5cf"
+  put_template_custom Pj "283457"
+  put_template_custom Pk "a8b5d1"
+  put_template_custom Pl "a8b5d1"
+  put_template_custom Pm "1a1b26"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/embers-dark.sh
+++ b/generic/embers-dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# embers-dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "16/13/0f"
+put_template 1  "82/6d/57"
+put_template 2  "57/82/6d"
+put_template 3  "6d/82/57"
+put_template 4  "6d/57/82"
+put_template 5  "82/57/6d"
+put_template 6  "57/6d/82"
+put_template 7  "a3/9a/90"
+put_template 8  "5a/50/47"
+put_template 9  "82/82/57"
+put_template 10 "2c/26/20"
+put_template 11 "43/3b/32"
+put_template 12 "8a/80/75"
+put_template 13 "be/b6/ae"
+put_template 14 "82/57/57"
+put_template 15 "db/d6/d1"
+
+color_foreground="a3/9a/90"
+color_background="16/13/0f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "a39a90"
+  put_template_custom Ph "16130f"
+  put_template_custom Pi "a39a90"
+  put_template_custom Pj "433b32"
+  put_template_custom Pk "a39a90"
+  put_template_custom Pl "a39a90"
+  put_template_custom Pm "16130f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/farmhouse-dark.sh
+++ b/generic/farmhouse-dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# farmhouse-dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/20/27"
+put_template 1  "ba/00/04"
+put_template 2  "54/9d/00"
+put_template 3  "c8/73/00"
+put_template 4  "00/49/e6"
+put_template 5  "9f/1b/61"
+put_template 6  "1f/b6/5c"
+put_template 7  "e8/e4/e1"
+put_template 8  "39/40/47"
+put_template 9  "eb/00/09"
+put_template 10 "7a/c1/00"
+put_template 11 "ea/9a/00"
+put_template 12 "00/6e/fe"
+put_template 13 "bf/3b/7f"
+put_template 14 "19/e0/62"
+put_template 15 "f4/ee/f0"
+
+color_foreground="e8/e4/e1"
+color_background="1d/20/27"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e8e4e1"
+  put_template_custom Ph "1d2027"
+  put_template_custom Pi "eb0009"
+  put_template_custom Pj "4d5658"
+  put_template_custom Pk "b3b1aa"
+  put_template_custom Pl "006efe"
+  put_template_custom Pm "e8e4e1"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/farmhouse-light.sh
+++ b/generic/farmhouse-light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# farmhouse-light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/20/27"
+put_template 1  "8d/00/03"
+put_template 2  "3a/7d/00"
+put_template 3  "a9/56/00"
+put_template 4  "09/2c/cd"
+put_template 5  "82/00/46"
+put_template 6  "22/92/56"
+put_template 7  "e8/e4/e1"
+put_template 8  "39/40/47"
+put_template 9  "eb/00/09"
+put_template 10 "7a/c1/00"
+put_template 11 "ea/9a/00"
+put_template 12 "00/6e/fe"
+put_template 13 "bf/3b/7f"
+put_template 14 "19/e0/62"
+put_template 15 "f4/ee/f0"
+
+color_foreground="1d/20/27"
+color_background="e8/e4/e1"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "1d2027"
+  put_template_custom Ph "e8e4e1"
+  put_template_custom Pi "eb0009"
+  put_template_custom Pj "b3b1aa"
+  put_template_custom Pk "4d5658"
+  put_template_custom Pl "006efe"
+  put_template_custom Pm "1d2027"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/flexoki-dark.sh
+++ b/generic/flexoki-dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# flexoki-dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/0f/0f"
+put_template 1  "d1/4d/41"
+put_template 2  "87/9a/39"
+put_template 3  "d0/a2/15"
+put_template 4  "43/85/be"
+put_template 5  "ce/5d/97"
+put_template 6  "3a/a9/9f"
+put_template 7  "87/85/80"
+put_template 8  "57/56/53"
+put_template 9  "af/30/29"
+put_template 10 "66/80/0b"
+put_template 11 "ad/83/01"
+put_template 12 "20/5e/a6"
+put_template 13 "a0/2f/6f"
+put_template 14 "24/83/7b"
+put_template 15 "ce/cd/c3"
+
+color_foreground="ce/cd/c3"
+color_background="10/0f/0f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cecdc3"
+  put_template_custom Ph "100f0f"
+  put_template_custom Pi "fffcf0"
+  put_template_custom Pj "cecdc3"
+  put_template_custom Pk "100f0f"
+  put_template_custom Pl "cecdc3"
+  put_template_custom Pm "100f0f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/flexoki-light.sh
+++ b/generic/flexoki-light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# flexoki-light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "10/0f/0f"
+put_template 1  "af/30/29"
+put_template 2  "66/80/0b"
+put_template 3  "ad/83/01"
+put_template 4  "20/5e/a6"
+put_template 5  "a0/2f/6f"
+put_template 6  "24/83/7b"
+put_template 7  "6f/6e/69"
+put_template 8  "b7/b5/ac"
+put_template 9  "d1/4d/41"
+put_template 10 "87/9a/39"
+put_template 11 "d0/a2/15"
+put_template 12 "43/85/be"
+put_template 13 "ce/5d/97"
+put_template 14 "3a/a9/9f"
+put_template 15 "ce/cd/c3"
+
+color_foreground="10/0f/0f"
+color_background="ff/fc/f0"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "100f0f"
+  put_template_custom Ph "fffcf0"
+  put_template_custom Pi "6f6e69"
+  put_template_custom Pj "6f6e69"
+  put_template_custom Pk "fffcf0"
+  put_template_custom Pl "100f0f"
+  put_template_custom Pm "fffcf0"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/gruber-darker.sh
+++ b/generic/gruber-darker.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# gruber-darker
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "18/18/18"
+put_template 1  "f4/38/41"
+put_template 2  "73/d9/36"
+put_template 3  "ff/dd/33"
+put_template 4  "96/a6/c8"
+put_template 5  "9e/95/c7"
+put_template 6  "95/a9/9f"
+put_template 7  "e4/e4/e4"
+put_template 8  "52/49/4e"
+put_template 9  "ff/4f/58"
+put_template 10 "73/d9/36"
+put_template 11 "ff/dd/33"
+put_template 12 "96/a6/c8"
+put_template 13 "af/af/d7"
+put_template 14 "95/a9/9f"
+put_template 15 "f5/f5/f5"
+
+color_foreground="e4/e4/e4"
+color_background="18/18/18"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e4e4e4"
+  put_template_custom Ph "181818"
+  put_template_custom Pi "f5f5f5"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "52494e"
+  put_template_custom Pl "ffdd33"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/gruvbox-material.sh
+++ b/generic/gruvbox-material.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# gruvbox-material
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/16/17"
+put_template 1  "ea/69/26"
+put_template 2  "c1/d0/41"
+put_template 3  "ee/cf/75"
+put_template 4  "6d/a3/ec"
+put_template 5  "fd/9b/c1"
+put_template 6  "fe/9d/6e"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "d3/57/3b"
+put_template 10 "c1/d0/41"
+put_template 11 "ee/cf/75"
+put_template 12 "2c/86/ff"
+put_template 13 "fd/9b/c1"
+put_template 14 "92/a5/df"
+put_template 15 "ff/ff/ff"
+
+color_foreground="d4/be/98"
+color_background="1d/20/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d4be98"
+  put_template_custom Ph "1d2021"
+  put_template_custom Pi "d4be98"
+  put_template_custom Pj "2b2c3f"
+  put_template_custom Pk "7cfb70"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/heeler.sh
+++ b/generic/heeler.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# heeler
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d3/57/3b"
+put_template 2  "c1/d0/41"
+put_template 3  "ee/cf/75"
+put_template 4  "6d/a3/ec"
+put_template 5  "fd/9b/c1"
+put_template 6  "fe/9d/6e"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "d3/57/3b"
+put_template 10 "c1/d0/41"
+put_template 11 "ee/cf/75"
+put_template 12 "2c/86/ff"
+put_template 13 "fd/9b/c1"
+put_template 14 "92/a5/df"
+put_template 15 "ff/ff/ff"
+
+color_foreground="fd/fd/fd"
+color_background="21/1f/44"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fdfdfd"
+  put_template_custom Ph "211f44"
+  put_template_custom Pi "414694"
+  put_template_custom Pj "2b2c3f"
+  put_template_custom Pk "7cfb70"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Dark Background.sh
+++ b/generic/iTerm2 Dark Background.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Dark Background
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c9/1b/00"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "02/25/c7"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c7/c7/c7"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c7c7c7"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Default.sh
+++ b/generic/iTerm2 Default.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Default
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c9/1b/00"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "22/25/c4"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "ff/ff/ff"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "e5e5e5"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Light Background.sh
+++ b/generic/iTerm2 Light Background.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Light Background
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "c9/1b/00"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "02/25/c7"
+put_template 5  "ca/30/c7"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "ff/6e/67"
+put_template 10 "5f/fa/68"
+put_template 11 "ff/fc/67"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Pastel Dark Background.sh
+++ b/generic/iTerm2 Pastel Dark Background.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Pastel Dark Background
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "62/62/62"
+put_template 1  "ff/83/73"
+put_template 2  "b4/fb/73"
+put_template 3  "ff/fd/c3"
+put_template 4  "a5/d5/fe"
+put_template 5  "ff/90/fe"
+put_template 6  "d1/d1/fe"
+put_template 7  "f1/f1/f1"
+put_template 8  "8f/8f/8f"
+put_template 9  "ff/c4/be"
+put_template 10 "d6/fc/ba"
+put_template 11 "ff/fe/d5"
+put_template 12 "c2/e3/ff"
+put_template 13 "ff/b2/fe"
+put_template 14 "e6/e6/fe"
+put_template 15 "ff/ff/ff"
+
+color_foreground="c7/c7/c7"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c7c7c7"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "454d96"
+  put_template_custom Pk "f4f4f4"
+  put_template_custom Pl "ffb473"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Smoooooth.sh
+++ b/generic/iTerm2 Smoooooth.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Smoooooth
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "14/19/1e"
+put_template 1  "b4/3c/2a"
+put_template 2  "00/c2/00"
+put_template 3  "c7/c4/00"
+put_template 4  "27/44/c7"
+put_template 5  "c0/40/be"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "dd/79/75"
+put_template 10 "58/e7/90"
+put_template 11 "ec/e1/00"
+put_template 12 "a7/ab/f2"
+put_template 13 "e1/7e/e1"
+put_template 14 "60/fd/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="dc/dc/dc"
+color_background="15/19/1f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dcdcdc"
+  put_template_custom Ph "15191f"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "b3d7ff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Solarized Dark.sh
+++ b/generic/iTerm2 Solarized Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Solarized Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/36/42"
+put_template 1  "dc/32/2f"
+put_template 2  "85/99/00"
+put_template 3  "b5/89/00"
+put_template 4  "26/8b/d2"
+put_template 5  "d3/36/82"
+put_template 6  "2a/a1/98"
+put_template 7  "ee/e8/d5"
+put_template 8  "00/2b/36"
+put_template 9  "cb/4b/16"
+put_template 10 "58/6e/75"
+put_template 11 "65/7b/83"
+put_template 12 "83/94/96"
+put_template 13 "6c/71/c4"
+put_template 14 "93/a1/a1"
+put_template 15 "fd/f6/e3"
+
+color_foreground="83/94/96"
+color_background="00/2b/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "839496"
+  put_template_custom Ph "002b36"
+  put_template_custom Pi "93a1a1"
+  put_template_custom Pj "073642"
+  put_template_custom Pk "93a1a1"
+  put_template_custom Pl "839496"
+  put_template_custom Pm "073642"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Solarized Light.sh
+++ b/generic/iTerm2 Solarized Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Solarized Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "07/36/42"
+put_template 1  "dc/32/2f"
+put_template 2  "85/99/00"
+put_template 3  "b5/89/00"
+put_template 4  "26/8b/d2"
+put_template 5  "d3/36/82"
+put_template 6  "2a/a1/98"
+put_template 7  "ee/e8/d5"
+put_template 8  "00/2b/36"
+put_template 9  "cb/4b/16"
+put_template 10 "58/6e/75"
+put_template 11 "65/7b/83"
+put_template 12 "83/94/96"
+put_template 13 "6c/71/c4"
+put_template 14 "93/a1/a1"
+put_template 15 "fd/f6/e3"
+
+color_foreground="65/7b/83"
+color_background="fd/f6/e3"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "657b83"
+  put_template_custom Ph "fdf6e3"
+  put_template_custom Pi "586e75"
+  put_template_custom Pj "eee8d5"
+  put_template_custom Pk "586e75"
+  put_template_custom Pl "657b83"
+  put_template_custom Pm "eee8d5"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Tango Dark.sh
+++ b/generic/iTerm2 Tango Dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Tango Dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d8/1e/00"
+put_template 2  "5e/a7/02"
+put_template 3  "cf/ae/00"
+put_template 4  "42/7a/b3"
+put_template 5  "89/65/8e"
+put_template 6  "00/a7/aa"
+put_template 7  "db/de/d8"
+put_template 8  "68/6a/66"
+put_template 9  "f5/42/35"
+put_template 10 "99/e3/43"
+put_template 11 "fd/eb/61"
+put_template 12 "84/b0/d8"
+put_template 13 "bc/94/b7"
+put_template 14 "37/e6/e8"
+put_template 15 "f1/f1/f0"
+
+color_foreground="ff/ff/ff"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iTerm2 Tango Light.sh
+++ b/generic/iTerm2 Tango Light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iTerm2 Tango Light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d8/1e/00"
+put_template 2  "5e/a7/02"
+put_template 3  "cf/ae/00"
+put_template 4  "42/7a/b3"
+put_template 5  "89/65/8e"
+put_template 6  "00/a7/aa"
+put_template 7  "db/de/d8"
+put_template 8  "68/6a/66"
+put_template 9  "f5/42/35"
+put_template 10 "99/e3/43"
+put_template 11 "fd/eb/61"
+put_template 12 "84/b0/d8"
+put_template 13 "bc/94/b7"
+put_template 14 "37/e6/e8"
+put_template 15 "f1/f1/f0"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iceberg-dark.sh
+++ b/generic/iceberg-dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iceberg-dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1e/21/32"
+put_template 1  "e2/78/78"
+put_template 2  "b4/be/82"
+put_template 3  "e2/a4/78"
+put_template 4  "84/a0/c6"
+put_template 5  "a0/93/c7"
+put_template 6  "89/b8/c2"
+put_template 7  "c6/c8/d1"
+put_template 8  "6b/70/89"
+put_template 9  "e9/89/89"
+put_template 10 "c0/ca/8e"
+put_template 11 "e9/b1/89"
+put_template 12 "91/ac/d1"
+put_template 13 "ad/a0/d3"
+put_template 14 "95/c4/ce"
+put_template 15 "d2/d4/de"
+
+color_foreground="c6/c8/d1"
+color_background="16/18/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c6c8d1"
+  put_template_custom Ph "161821"
+  put_template_custom Pi "c6c8d1"
+  put_template_custom Pj "c6c8d1"
+  put_template_custom Pk "161821"
+  put_template_custom Pl "c6c8d1"
+  put_template_custom Pm "161821"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/iceberg-light.sh
+++ b/generic/iceberg-light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# iceberg-light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "dc/df/e7"
+put_template 1  "cc/51/7a"
+put_template 2  "66/8e/3d"
+put_template 3  "c5/73/39"
+put_template 4  "2d/53/9e"
+put_template 5  "77/59/b4"
+put_template 6  "3f/83/a6"
+put_template 7  "33/37/4c"
+put_template 8  "83/89/a3"
+put_template 9  "cc/37/68"
+put_template 10 "59/80/30"
+put_template 11 "b6/66/2d"
+put_template 12 "22/47/8e"
+put_template 13 "68/45/ad"
+put_template 14 "32/76/98"
+put_template 15 "26/2a/3f"
+
+color_foreground="33/37/4c"
+color_background="e8/e9/ec"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "33374c"
+  put_template_custom Ph "e8e9ec"
+  put_template_custom Pi "33374c"
+  put_template_custom Pj "33374c"
+  put_template_custom Pk "e8e9ec"
+  put_template_custom Pl "33374c"
+  put_template_custom Pm "e8e9ec"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/idea.sh
+++ b/generic/idea.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# idea
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "ad/ad/ad"
+put_template 1  "fc/52/56"
+put_template 2  "98/b6/1c"
+put_template 3  "cc/b4/44"
+put_template 4  "43/7e/e7"
+put_template 5  "9d/74/b0"
+put_template 6  "24/88/87"
+put_template 7  "18/18/18"
+put_template 8  "ff/ff/ff"
+put_template 9  "fc/70/72"
+put_template 10 "98/b6/1c"
+put_template 11 "ff/ff/0b"
+put_template 12 "6c/9c/ed"
+put_template 13 "fc/7e/ff"
+put_template 14 "24/88/87"
+put_template 15 "18/18/18"
+
+color_foreground="ad/ad/ad"
+color_background="20/20/20"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "adadad"
+  put_template_custom Ph "202020"
+  put_template_custom Pi "e6e6e6"
+  put_template_custom Pj "44475a"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "bbbbbb"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/idleToes.sh
+++ b/generic/idleToes.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# idleToes
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/32/32"
+put_template 1  "d2/52/52"
+put_template 2  "7f/e1/73"
+put_template 3  "ff/c6/6d"
+put_template 4  "40/99/ff"
+put_template 5  "f6/80/ff"
+put_template 6  "be/d6/ff"
+put_template 7  "ee/ee/ec"
+put_template 8  "53/53/53"
+put_template 9  "f0/70/70"
+put_template 10 "9d/ff/91"
+put_template 11 "ff/e4/8b"
+put_template 12 "5e/b7/f7"
+put_template 13 "ff/9d/ff"
+put_template 14 "dc/f4/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="32/32/32"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "323232"
+  put_template_custom Pi "ffffa9"
+  put_template_custom Pj "5b5b5b"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "d6d6d6"
+  put_template_custom Pm "000000"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/jubi.sh
+++ b/generic/jubi.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# jubi
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3b/37/50"
+put_template 1  "cf/7b/98"
+put_template 2  "90/a9/4b"
+put_template 3  "6e/bf/c0"
+put_template 4  "57/6e/a6"
+put_template 5  "bc/4f/68"
+put_template 6  "75/a7/d2"
+put_template 7  "c3/d3/de"
+put_template 8  "a8/74/ce"
+put_template 9  "de/90/ab"
+put_template 10 "bc/dd/61"
+put_template 11 "87/e9/ea"
+put_template 12 "8c/9f/cd"
+put_template 13 "e1/6c/87"
+put_template 14 "b7/c9/ef"
+put_template 15 "d5/e5/f1"
+
+color_foreground="c3/d3/de"
+color_background="26/2b/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c3d3de"
+  put_template_custom Ph "262b33"
+  put_template_custom Pi "a874ce"
+  put_template_custom Pj "5b5184"
+  put_template_custom Pk "1e1b2e"
+  put_template_custom Pl "c3d3de"
+  put_template_custom Pm "1e1b2e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/kanagawabones.sh
+++ b/generic/kanagawabones.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# kanagawabones
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1f/1f/28"
+put_template 1  "e4/6a/78"
+put_template 2  "98/bc/6d"
+put_template 3  "e5/c2/83"
+put_template 4  "7e/b3/c9"
+put_template 5  "95/7f/b8"
+put_template 6  "7e/b3/c9"
+put_template 7  "dd/d8/bb"
+put_template 8  "3c/3c/51"
+put_template 9  "ec/81/8c"
+put_template 10 "9e/c9/67"
+put_template 11 "f1/c9/82"
+put_template 12 "7b/c2/df"
+put_template 13 "a9/8f/d2"
+put_template 14 "7b/c2/df"
+put_template 15 "a8/a4/8d"
+
+color_foreground="dd/d8/bb"
+color_background="1f/1f/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ddd8bb"
+  put_template_custom Ph "1f1f28"
+  put_template_custom Pi "3c3c51"
+  put_template_custom Pj "49473e"
+  put_template_custom Pk "ddd8bb"
+  put_template_custom Pl "e6e0c2"
+  put_template_custom Pm "1f1f28"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/kurokula.sh
+++ b/generic/kurokula.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# kurokula
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "33/33/33"
+put_template 1  "b6/60/56"
+put_template 2  "85/b1/a9"
+put_template 3  "db/bb/43"
+put_template 4  "68/90/d7"
+put_template 5  "88/7a/a3"
+put_template 6  "83/73/69"
+put_template 7  "dd/d0/c4"
+put_template 8  "51/51/51"
+put_template 9  "ff/c6/63"
+put_template 10 "c1/ff/ae"
+put_template 11 "ff/f7/00"
+put_template 12 "a1/d9/ff"
+put_template 13 "a9/94/ff"
+put_template 14 "f9/cf/b9"
+put_template 15 "ff/ff/ff"
+
+color_foreground="dd/d0/c4"
+color_background="14/15/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ddd0c4"
+  put_template_custom Ph "141515"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "515151"
+  put_template_custom Pk "ffc663"
+  put_template_custom Pl "702420"
+  put_template_custom Pm "fefbf3"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/lovelace.sh
+++ b/generic/lovelace.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# lovelace
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "28/2a/36"
+put_template 1  "f3/7f/97"
+put_template 2  "5a/de/cd"
+put_template 3  "f2/a2/72"
+put_template 4  "88/97/f4"
+put_template 5  "c5/74/dd"
+put_template 6  "79/e6/f3"
+put_template 7  "fd/fd/fd"
+put_template 8  "41/44/58"
+put_template 9  "ff/49/71"
+put_template 10 "18/e3/c8"
+put_template 11 "ff/80/37"
+put_template 12 "55/6f/ff"
+put_template 13 "b0/43/d1"
+put_template 14 "3f/dc/ee"
+put_template 15 "be/be/c1"
+
+color_foreground="fd/fd/fd"
+color_background="1d/1f/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fdfdfd"
+  put_template_custom Ph "1d1f28"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "c1deff"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c574dd"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/matrix.sh
+++ b/generic/matrix.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# matrix
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0f/19/1c"
+put_template 1  "23/75/5a"
+put_template 2  "82/d9/67"
+put_template 3  "ff/d7/00"
+put_template 4  "3f/52/42"
+put_template 5  "40/99/31"
+put_template 6  "50/b4/5a"
+put_template 7  "50/73/50"
+put_template 8  "68/80/60"
+put_template 9  "2f/c0/79"
+put_template 10 "90/d7/62"
+put_template 11 "fa/ff/00"
+put_template 12 "4f/7e/7e"
+put_template 13 "11/ff/25"
+put_template 14 "c1/ff/8a"
+put_template 15 "67/8c/61"
+
+color_foreground="42/66/44"
+color_background="0f/19/1c"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "426644"
+  put_template_custom Ph "0f191c"
+  put_template_custom Pi "81b32c"
+  put_template_custom Pj "18282e"
+  put_template_custom Pk "00ff87"
+  put_template_custom Pl "384545"
+  put_template_custom Pm "00ff00"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/mellow.sh
+++ b/generic/mellow.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# mellow
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "27/27/2a"
+put_template 1  "f5/a1/91"
+put_template 2  "90/b9/9f"
+put_template 3  "e6/b9/9d"
+put_template 4  "ac/a1/cf"
+put_template 5  "e2/9e/ca"
+put_template 6  "ea/83/a5"
+put_template 7  "c1/c0/d4"
+put_template 8  "35/35/39"
+put_template 9  "ff/ae/9f"
+put_template 10 "9d/c6/ac"
+put_template 11 "f0/c5/a9"
+put_template 12 "b9/ae/da"
+put_template 13 "ec/aa/d6"
+put_template 14 "f5/91/b2"
+put_template 15 "ca/c9/dd"
+
+color_foreground="c9/c7/cd"
+color_background="16/16/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c9c7cd"
+  put_template_custom Ph "161617"
+  put_template_custom Pi "eaeaea"
+  put_template_custom Pj "2a2a2d"
+  put_template_custom Pk "c1c0d4"
+  put_template_custom Pl "cac9dd"
+  put_template_custom Pm "161617"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/miasma.sh
+++ b/generic/miasma.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# miasma
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "68/57/42"
+put_template 2  "5f/87/5f"
+put_template 3  "b3/6d/43"
+put_template 4  "78/82/4b"
+put_template 5  "bb/77/44"
+put_template 6  "c9/a5/54"
+put_template 7  "d7/c4/83"
+put_template 8  "66/66/66"
+put_template 9  "68/57/42"
+put_template 10 "5f/87/5f"
+put_template 11 "b3/6d/43"
+put_template 12 "78/82/4b"
+put_template 13 "bb/77/44"
+put_template 14 "c9/a5/54"
+put_template 15 "d7/c4/83"
+
+color_foreground="c2/c2/b0"
+color_background="22/22/22"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c2c2b0"
+  put_template_custom Ph "222222"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "e5c47b"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "eeeeee"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/midnight-in-mojave.sh
+++ b/generic/midnight-in-mojave.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# midnight-in-mojave
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1e/1e/1e"
+put_template 1  "ff/45/3a"
+put_template 2  "32/d7/4b"
+put_template 3  "ff/d6/0a"
+put_template 4  "0a/84/ff"
+put_template 5  "bf/5a/f2"
+put_template 6  "5a/c8/fa"
+put_template 7  "ff/ff/ff"
+put_template 8  "1e/1e/1e"
+put_template 9  "ff/45/3a"
+put_template 10 "32/d7/4b"
+put_template 11 "ff/d6/0a"
+put_template 12 "0a/84/ff"
+put_template 13 "bf/5a/f2"
+put_template 14 "5a/c8/fa"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1e/1e/1e"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1e1e1e"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "4a504d"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "32d74b"
+  put_template_custom Pm "1c1c1c"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/moonfly.sh
+++ b/generic/moonfly.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# moonfly
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "32/34/37"
+put_template 1  "ff/54/54"
+put_template 2  "8c/c8/5f"
+put_template 3  "e3/c7/8a"
+put_template 4  "80/a0/ff"
+put_template 5  "cf/87/e8"
+put_template 6  "79/da/c8"
+put_template 7  "c6/c6/c6"
+put_template 8  "94/94/94"
+put_template 9  "ff/51/89"
+put_template 10 "36/c6/92"
+put_template 11 "c6/c6/84"
+put_template 12 "74/b2/ff"
+put_template 13 "ae/81/ff"
+put_template 14 "85/dc/85"
+put_template 15 "e4/e4/e4"
+
+color_foreground="bd/bd/bd"
+color_background="08/08/08"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bdbdbd"
+  put_template_custom Ph "080808"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "b2ceee"
+  put_template_custom Pk "080808"
+  put_template_custom Pl "9e9e9e"
+  put_template_custom Pm "080808"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/neobones_dark.sh
+++ b/generic/neobones_dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# neobones_dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0f/19/1f"
+put_template 1  "de/6e/7c"
+put_template 2  "90/ff/6b"
+put_template 3  "b7/7e/64"
+put_template 4  "81/90/d4"
+put_template 5  "b2/79/a7"
+put_template 6  "66/a5/ad"
+put_template 7  "c6/d5/cf"
+put_template 8  "26/39/45"
+put_template 9  "e8/83/8f"
+put_template 10 "a0/ff/85"
+put_template 11 "d6/8c/67"
+put_template 12 "92/a0/e2"
+put_template 13 "cf/86/c1"
+put_template 14 "65/b8/c1"
+put_template 15 "98/a3/9e"
+
+color_foreground="c6/d5/cf"
+color_background="0f/19/1f"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c6d5cf"
+  put_template_custom Ph "0f191f"
+  put_template_custom Pi "263945"
+  put_template_custom Pj "3a3e3d"
+  put_template_custom Pk "c6d5cf"
+  put_template_custom Pl "ceddd7"
+  put_template_custom Pm "0f191f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/neobones_light.sh
+++ b/generic/neobones_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# neobones_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "e5/ed/e6"
+put_template 1  "a8/33/4c"
+put_template 2  "56/7a/30"
+put_template 3  "94/49/27"
+put_template 4  "28/64/86"
+put_template 5  "88/50/7d"
+put_template 6  "3b/89/92"
+put_template 7  "20/2e/18"
+put_template 8  "b3/c6/b6"
+put_template 9  "94/25/3e"
+put_template 10 "3f/5a/22"
+put_template 11 "80/3d/1c"
+put_template 12 "1d/55/73"
+put_template 13 "7b/3b/70"
+put_template 14 "2b/74/7c"
+put_template 15 "41/59/34"
+
+color_foreground="20/2e/18"
+color_background="e5/ed/e6"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "202e18"
+  put_template_custom Ph "e5ede6"
+  put_template_custom Pi "b3c6b6"
+  put_template_custom Pj "ade48c"
+  put_template_custom Pk "202e18"
+  put_template_custom Pl "202e18"
+  put_template_custom Pm "e5ede6"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/nightfox.sh
+++ b/generic/nightfox.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# nightfox
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "39/3b/44"
+put_template 1  "c9/4f/6d"
+put_template 2  "81/b2/9a"
+put_template 3  "db/c0/74"
+put_template 4  "71/9c/d6"
+put_template 5  "9d/79/d6"
+put_template 6  "63/cd/cf"
+put_template 7  "df/df/e0"
+put_template 8  "57/58/60"
+put_template 9  "d1/69/83"
+put_template 10 "8e/ba/a4"
+put_template 11 "e0/c9/89"
+put_template 12 "86/ab/dc"
+put_template 13 "ba/a1/e2"
+put_template 14 "7a/d5/d6"
+put_template 15 "e4/e4/e5"
+
+color_foreground="cd/ce/cf"
+color_background="19/23/30"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "cdcecf"
+  put_template_custom Ph "192330"
+  put_template_custom Pi "cdcecf"
+  put_template_custom Pj "2b3b51"
+  put_template_custom Pk "cdcecf"
+  put_template_custom Pl "cdcecf"
+  put_template_custom Pm "192330"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/niji.sh
+++ b/generic/niji.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# niji
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "33/33/33"
+put_template 1  "d2/3e/08"
+put_template 2  "54/ca/74"
+put_template 3  "ff/f7/00"
+put_template 4  "2a/b9/ff"
+put_template 5  "ff/50/da"
+put_template 6  "1e/f9/f5"
+put_template 7  "dd/d0/c4"
+put_template 8  "51/51/51"
+put_template 9  "ff/b7/b7"
+put_template 10 "c1/ff/ae"
+put_template 11 "fc/ff/b8"
+put_template 12 "8e/ff/f3"
+put_template 13 "ff/a2/ed"
+put_template 14 "bc/ff/c7"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="14/15/15"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "141515"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "515151"
+  put_template_custom Pk "ffc663"
+  put_template_custom Pl "ffc663"
+  put_template_custom Pm "141515"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/nord-light.sh
+++ b/generic/nord-light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# nord-light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3b/42/52"
+put_template 1  "bf/61/6a"
+put_template 2  "a3/be/8c"
+put_template 3  "eb/cb/8b"
+put_template 4  "81/a1/c1"
+put_template 5  "b4/8e/ad"
+put_template 6  "88/c0/d0"
+put_template 7  "d8/de/e9"
+put_template 8  "4c/56/6a"
+put_template 9  "bf/61/6a"
+put_template 10 "a3/be/8c"
+put_template 11 "eb/cb/8b"
+put_template 12 "81/a1/c1"
+put_template 13 "b4/8e/ad"
+put_template 14 "8f/bc/bb"
+put_template 15 "ec/ef/f4"
+
+color_foreground="41/48/58"
+color_background="e5/e9/f0"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "414858"
+  put_template_custom Ph "e5e9f0"
+  put_template_custom Pi "414858"
+  put_template_custom Pj "d8dee9"
+  put_template_custom Pk "4c556a"
+  put_template_custom Pl "88c0d0"
+  put_template_custom Pm "3b4252"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/nord-wave.sh
+++ b/generic/nord-wave.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# nord-wave
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3b/42/52"
+put_template 1  "bf/61/6a"
+put_template 2  "a3/be/8c"
+put_template 3  "eb/cb/8b"
+put_template 4  "81/a1/c1"
+put_template 5  "b4/8e/ad"
+put_template 6  "88/c0/d0"
+put_template 7  "e5/e9/f0"
+put_template 8  "4c/56/6a"
+put_template 9  "bf/61/6a"
+put_template 10 "a3/be/8c"
+put_template 11 "eb/cb/8b"
+put_template 12 "81/a1/c1"
+put_template 13 "b4/8e/ad"
+put_template 14 "8f/bc/bb"
+put_template 15 "ec/ef/f4"
+
+color_foreground="d8/de/e9"
+color_background="21/21/21"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "212121"
+  put_template_custom Pi "d8dee9"
+  put_template_custom Pj "d8dee9"
+  put_template_custom Pk "212121"
+  put_template_custom Pl "ebcb8b"
+  put_template_custom Pm "ebcb8b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/nord.sh
+++ b/generic/nord.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# nord
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "3b/42/52"
+put_template 1  "bf/61/6a"
+put_template 2  "a3/be/8c"
+put_template 3  "eb/cb/8b"
+put_template 4  "81/a1/c1"
+put_template 5  "b4/8e/ad"
+put_template 6  "88/c0/d0"
+put_template 7  "e5/e9/f0"
+put_template 8  "4c/56/6a"
+put_template 9  "bf/61/6a"
+put_template 10 "a3/be/8c"
+put_template 11 "eb/cb/8b"
+put_template 12 "81/a1/c1"
+put_template 13 "b4/8e/ad"
+put_template 14 "8f/bc/bb"
+put_template 15 "ec/ef/f4"
+
+color_foreground="d8/de/e9"
+color_background="2e/34/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "d8dee9"
+  put_template_custom Ph "2e3440"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "eceff4"
+  put_template_custom Pk "4c566a"
+  put_template_custom Pl "eceff4"
+  put_template_custom Pm "282828"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/primary.sh
+++ b/generic/primary.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# primary
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "db/44/37"
+put_template 2  "0f/9d/58"
+put_template 3  "f4/b4/00"
+put_template 4  "42/85/f4"
+put_template 5  "db/44/37"
+put_template 6  "42/85/f4"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "db/44/37"
+put_template 10 "0f/9d/58"
+put_template 11 "f4/b4/00"
+put_template 12 "42/85/f4"
+put_template 13 "42/85/f4"
+put_template 14 "0f/9d/58"
+put_template 15 "ff/ff/ff"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "656565"
+  put_template_custom Pk "eeeeee"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/purplepeter.sh
+++ b/generic/purplepeter.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# purplepeter
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "0a/05/20"
+put_template 1  "ff/79/6d"
+put_template 2  "99/b4/81"
+put_template 3  "ef/df/ac"
+put_template 4  "66/d9/ef"
+put_template 5  "e7/8f/cd"
+put_template 6  "ba/8c/ff"
+put_template 7  "ff/ba/81"
+put_template 8  "10/0b/23"
+put_template 9  "f9/9f/92"
+put_template 10 "b4/be/8f"
+put_template 11 "f2/e9/bf"
+put_template 12 "79/da/ed"
+put_template 13 "ba/91/d4"
+put_template 14 "a0/a0/d6"
+put_template 15 "b9/ae/d3"
+
+color_foreground="ec/e7/fa"
+color_background="2a/1a/4a"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ece7fa"
+  put_template_custom Ph "2a1a4a"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "8689c2"
+  put_template_custom Pk "271c50"
+  put_template_custom Pl "c7c7c7"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/rebecca.sh
+++ b/generic/rebecca.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# rebecca
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "12/13/1e"
+put_template 1  "dd/77/55"
+put_template 2  "04/db/b5"
+put_template 3  "f2/e7/b7"
+put_template 4  "7a/a5/ff"
+put_template 5  "bf/9c/f9"
+put_template 6  "56/d3/c2"
+put_template 7  "e4/e3/e9"
+put_template 8  "66/66/99"
+put_template 9  "ff/92/cd"
+put_template 10 "01/ea/c0"
+put_template 11 "ff/fc/a8"
+put_template 12 "69/c0/fa"
+put_template 13 "c1/7f/f8"
+put_template 14 "8b/fd/e1"
+put_template 15 "f4/f2/f9"
+
+color_foreground="e8/e6/ed"
+color_background="29/2a/44"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e8e6ed"
+  put_template_custom Ph "292a44"
+  put_template_custom Pi "ccccff"
+  put_template_custom Pj "663399"
+  put_template_custom Pk "f4f2f9"
+  put_template_custom Pl "b89bf9"
+  put_template_custom Pm "292a44"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/rose-pine-dawn.sh
+++ b/generic/rose-pine-dawn.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# rose-pine-dawn
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f2/e9/e1"
+put_template 1  "b4/63/7a"
+put_template 2  "28/69/83"
+put_template 3  "ea/9d/34"
+put_template 4  "56/94/9f"
+put_template 5  "90/7a/a9"
+put_template 6  "d7/82/7e"
+put_template 7  "57/52/79"
+put_template 8  "98/93/a5"
+put_template 9  "b4/63/7a"
+put_template 10 "28/69/83"
+put_template 11 "ea/9d/34"
+put_template 12 "56/94/9f"
+put_template 13 "90/7a/a9"
+put_template 14 "d7/82/7e"
+put_template 15 "57/52/79"
+
+color_foreground="57/52/79"
+color_background="fa/f4/ed"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "575279"
+  put_template_custom Ph "faf4ed"
+  put_template_custom Pi "575279"
+  put_template_custom Pj "dfdad9"
+  put_template_custom Pk "575279"
+  put_template_custom Pl "575279"
+  put_template_custom Pm "faf4ed"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/rose-pine-moon.sh
+++ b/generic/rose-pine-moon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# rose-pine-moon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "39/35/52"
+put_template 1  "eb/6f/92"
+put_template 2  "3e/8f/b0"
+put_template 3  "f6/c1/77"
+put_template 4  "9c/cf/d8"
+put_template 5  "c4/a7/e7"
+put_template 6  "ea/9a/97"
+put_template 7  "e0/de/f4"
+put_template 8  "6e/6a/86"
+put_template 9  "eb/6f/92"
+put_template 10 "3e/8f/b0"
+put_template 11 "f6/c1/77"
+put_template 12 "9c/cf/d8"
+put_template 13 "c4/a7/e7"
+put_template 14 "ea/9a/97"
+put_template 15 "e0/de/f4"
+
+color_foreground="e0/de/f4"
+color_background="23/21/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e0def4"
+  put_template_custom Ph "232136"
+  put_template_custom Pi "e0def4"
+  put_template_custom Pj "44415a"
+  put_template_custom Pk "e0def4"
+  put_template_custom Pl "e0def4"
+  put_template_custom Pm "232136"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/rose-pine.sh
+++ b/generic/rose-pine.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# rose-pine
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "26/23/3a"
+put_template 1  "eb/6f/92"
+put_template 2  "31/74/8f"
+put_template 3  "f6/c1/77"
+put_template 4  "9c/cf/d8"
+put_template 5  "c4/a7/e7"
+put_template 6  "eb/bc/ba"
+put_template 7  "e0/de/f4"
+put_template 8  "6e/6a/86"
+put_template 9  "eb/6f/92"
+put_template 10 "31/74/8f"
+put_template 11 "f6/c1/77"
+put_template 12 "9c/cf/d8"
+put_template 13 "c4/a7/e7"
+put_template 14 "eb/bc/ba"
+put_template 15 "e0/de/f4"
+
+color_foreground="e0/de/f4"
+color_background="19/17/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e0def4"
+  put_template_custom Ph "191724"
+  put_template_custom Pi "e0def4"
+  put_template_custom Pj "403d52"
+  put_template_custom Pk "e0def4"
+  put_template_custom Pl "e0def4"
+  put_template_custom Pm "191724"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/selenized-dark.sh
+++ b/generic/selenized-dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# selenized-dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "18/49/56"
+put_template 1  "fa/57/50"
+put_template 2  "75/b9/38"
+put_template 3  "db/b3/2d"
+put_template 4  "46/95/f7"
+put_template 5  "f2/75/be"
+put_template 6  "41/c7/b9"
+put_template 7  "72/89/8f"
+put_template 8  "2d/5b/69"
+put_template 9  "ff/66/5c"
+put_template 10 "84/c7/47"
+put_template 11 "eb/c1/3d"
+put_template 12 "58/a3/ff"
+put_template 13 "ff/84/cd"
+put_template 14 "53/d6/c7"
+put_template 15 "ca/d8/d9"
+
+color_foreground="ad/bc/bc"
+color_background="10/3c/48"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "adbcbc"
+  put_template_custom Ph "103c48"
+  put_template_custom Pi "adbcbc"
+  put_template_custom Pj "184956"
+  put_template_custom Pk "53d6c7"
+  put_template_custom Pl "adbcbc"
+  put_template_custom Pm "adbcbc"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/selenized-light.sh
+++ b/generic/selenized-light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# selenized-light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "ec/e3/cc"
+put_template 1  "d2/21/2d"
+put_template 2  "48/91/00"
+put_template 3  "ad/89/00"
+put_template 4  "00/72/d4"
+put_template 5  "ca/48/98"
+put_template 6  "00/9c/8f"
+put_template 7  "90/99/95"
+put_template 8  "d5/cd/b6"
+put_template 9  "cc/17/29"
+put_template 10 "42/8b/00"
+put_template 11 "a7/83/00"
+put_template 12 "00/6d/ce"
+put_template 13 "c4/43/92"
+put_template 14 "00/97/8a"
+put_template 15 "3a/4d/53"
+
+color_foreground="53/67/6d"
+color_background="fb/f3/db"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "53676d"
+  put_template_custom Ph "fbf3db"
+  put_template_custom Pi "53676d"
+  put_template_custom Pj "ece3cc"
+  put_template_custom Pk "00978a"
+  put_template_custom Pl "53676d"
+  put_template_custom Pm "53676d"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/seoulbones_dark.sh
+++ b/generic/seoulbones_dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# seoulbones_dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "4b/4b/4b"
+put_template 1  "e3/88/a3"
+put_template 2  "98/bd/99"
+put_template 3  "ff/df/9b"
+put_template 4  "97/bd/de"
+put_template 5  "a5/a6/c5"
+put_template 6  "6f/bd/be"
+put_template 7  "dd/dd/dd"
+put_template 8  "6c/64/65"
+put_template 9  "eb/99/b1"
+put_template 10 "8f/cd/92"
+put_template 11 "ff/e5/b3"
+put_template 12 "a2/c8/e9"
+put_template 13 "b2/b3/da"
+put_template 14 "6b/ca/cb"
+put_template 15 "a8/a8/a8"
+
+color_foreground="dd/dd/dd"
+color_background="4b/4b/4b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dddddd"
+  put_template_custom Ph "4b4b4b"
+  put_template_custom Pi "6c6465"
+  put_template_custom Pj "777777"
+  put_template_custom Pk "dddddd"
+  put_template_custom Pl "e2e2e2"
+  put_template_custom Pm "4b4b4b"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/seoulbones_light.sh
+++ b/generic/seoulbones_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# seoulbones_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "e2/e2/e2"
+put_template 1  "dc/52/84"
+put_template 2  "62/85/62"
+put_template 3  "c4/85/62"
+put_template 4  "00/84/a3"
+put_template 5  "89/67/88"
+put_template 6  "00/85/86"
+put_template 7  "55/55/55"
+put_template 8  "bf/ba/bb"
+put_template 9  "be/3c/6d"
+put_template 10 "48/72/49"
+put_template 11 "a7/6b/48"
+put_template 12 "00/6f/89"
+put_template 13 "7f/4c/7e"
+put_template 14 "00/6f/70"
+put_template 15 "77/77/77"
+
+color_foreground="55/55/55"
+color_background="e2/e2/e2"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "555555"
+  put_template_custom Ph "e2e2e2"
+  put_template_custom Pi "bfbabb"
+  put_template_custom Pj "cccccc"
+  put_template_custom Pk "555555"
+  put_template_custom Pl "555555"
+  put_template_custom Pm "e2e2e2"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/shades-of-purple.sh
+++ b/generic/shades-of-purple.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# shades-of-purple
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "d9/04/29"
+put_template 2  "3a/d9/00"
+put_template 3  "ff/e7/00"
+put_template 4  "69/43/ff"
+put_template 5  "ff/2c/70"
+put_template 6  "00/c5/c7"
+put_template 7  "c7/c7/c7"
+put_template 8  "68/68/68"
+put_template 9  "f9/2a/1c"
+put_template 10 "43/d4/26"
+put_template 11 "f1/d0/00"
+put_template 12 "68/71/ff"
+put_template 13 "ff/77/ff"
+put_template 14 "79/e8/fb"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1e/1d/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1e1d40"
+  put_template_custom Pi "f9fdff"
+  put_template_custom Pj "b362ff"
+  put_template_custom Pk "c2c2c2"
+  put_template_custom Pl "fad000"
+  put_template_custom Pm "fefff4"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/solarized-osaka-night.sh
+++ b/generic/solarized-osaka-night.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# solarized-osaka-night
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/16/1d"
+put_template 1  "e7/7d/8f"
+put_template 2  "a8/cd/76"
+put_template 3  "d8/b1/72"
+put_template 4  "82/a1/f1"
+put_template 5  "b6/9b/f1"
+put_template 6  "90/cd/fa"
+put_template 7  "aa/b1/d3"
+put_template 8  "42/48/66"
+put_template 9  "e7/7d/8f"
+put_template 10 "a8/cd/76"
+put_template 11 "d8/b1/72"
+put_template 12 "82/a1/f1"
+put_template 13 "b6/9b/f1"
+put_template 14 "90/cd/fa"
+put_template 15 "c2/ca/f1"
+
+color_foreground="c2/ca/f1"
+color_background="1a/1b/25"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c2caf1"
+  put_template_custom Ph "1a1b25"
+  put_template_custom Pi "58b99d"
+  put_template_custom Pj "2a3454"
+  put_template_custom Pk "c2caf1"
+  put_template_custom Pl "c2caf1"
+  put_template_custom Pm "1a1b25"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/sonokai.sh
+++ b/generic/sonokai.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# sonokai
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "18/18/19"
+put_template 1  "fc/5d/7c"
+put_template 2  "9e/d0/72"
+put_template 3  "e7/c6/64"
+put_template 4  "76/cc/e0"
+put_template 5  "b3/9d/f3"
+put_template 6  "f3/96/60"
+put_template 7  "e2/e2/e3"
+put_template 8  "7f/84/90"
+put_template 9  "fc/5d/7c"
+put_template 10 "9e/d0/72"
+put_template 11 "e7/c6/64"
+put_template 12 "76/cc/e0"
+put_template 13 "b3/9d/f3"
+put_template 14 "f3/96/60"
+put_template 15 "e2/e2/e3"
+
+color_foreground="e2/e2/e3"
+color_background="2c/2e/34"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e2e2e3"
+  put_template_custom Ph "2c2e34"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "414550"
+  put_template_custom Pk "e2e2e3"
+  put_template_custom Pl "e2e2e3"
+  put_template_custom Pm "2c2e34"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/srcery.sh
+++ b/generic/srcery.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# srcery
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1c/1b/19"
+put_template 1  "ef/2f/27"
+put_template 2  "51/9f/50"
+put_template 3  "fb/b8/29"
+put_template 4  "2c/78/bf"
+put_template 5  "e0/2c/6d"
+put_template 6  "0a/ae/b3"
+put_template 7  "ba/a6/7f"
+put_template 8  "91/81/75"
+put_template 9  "f7/53/41"
+put_template 10 "98/bc/37"
+put_template 11 "fe/d0/6e"
+put_template 12 "68/a8/e4"
+put_template 13 "ff/5c/8f"
+put_template 14 "2b/e4/d0"
+put_template 15 "fc/e8/c3"
+
+color_foreground="fc/e8/c3"
+color_background="1c/1b/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "fce8c3"
+  put_template_custom Ph "1c1b19"
+  put_template_custom Pi "fce8c3"
+  put_template_custom Pj "fce8c3"
+  put_template_custom Pk "1c1b19"
+  put_template_custom Pl "fbb829"
+  put_template_custom Pm "1c1b19"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/starlight.sh
+++ b/generic/starlight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# starlight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "24/24/24"
+put_template 1  "e2/42/5d"
+put_template 2  "66/b2/38"
+put_template 3  "de/c5/41"
+put_template 4  "54/aa/d0"
+put_template 5  "e8/b2/f8"
+put_template 6  "5a/bf/9b"
+put_template 7  "e6/e6/e6"
+put_template 8  "61/61/61"
+put_template 9  "ec/5b/58"
+put_template 10 "6b/d1/62"
+put_template 11 "e9/e8/5c"
+put_template 12 "78/c3/f3"
+put_template 13 "f2/af/ee"
+put_template 14 "6a/dc/c5"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="24/24/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "242424"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "ffffff"
+  put_template_custom Pk "242424"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "242424"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/synthwave-everything.sh
+++ b/generic/synthwave-everything.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# synthwave-everything
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "fe/fe/fe"
+put_template 1  "f9/7e/72"
+put_template 2  "72/f1/b8"
+put_template 3  "fe/de/5d"
+put_template 4  "6d/77/b3"
+put_template 5  "c7/92/ea"
+put_template 6  "f7/72/e0"
+put_template 7  "fe/fe/fe"
+put_template 8  "fe/fe/fe"
+put_template 9  "f8/84/14"
+put_template 10 "72/f1/b8"
+put_template 11 "ff/f9/51"
+put_template 12 "36/f9/f6"
+put_template 13 "e1/ac/ff"
+put_template 14 "f9/2a/ad"
+put_template 15 "fe/fe/fe"
+
+color_foreground="f0/ef/f1"
+color_background="2a/21/39"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f0eff1"
+  put_template_custom Ph "2a2139"
+  put_template_custom Pi "f0eff1"
+  put_template_custom Pj "181521"
+  put_template_custom Pk "f0eff1"
+  put_template_custom Pl "72f1b8"
+  put_template_custom Pm "1a1a1a"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/synthwave.sh
+++ b/generic/synthwave.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# synthwave
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "00/00/00"
+put_template 1  "f6/18/8f"
+put_template 2  "1e/bb/2b"
+put_template 3  "fd/f8/34"
+put_template 4  "21/86/ec"
+put_template 5  "f8/5a/21"
+put_template 6  "12/c3/e2"
+put_template 7  "ff/ff/ff"
+put_template 8  "00/00/00"
+put_template 9  "f8/41/a0"
+put_template 10 "25/c1/41"
+put_template 11 "fd/f4/54"
+put_template 12 "2f/9d/ed"
+put_template 13 "f9/71/37"
+put_template 14 "19/cd/e6"
+put_template 15 "ff/ff/ff"
+
+color_foreground="da/d9/c7"
+color_background="00/00/00"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dad9c7"
+  put_template_custom Ph "000000"
+  put_template_custom Pi "dad9c7"
+  put_template_custom Pj "19cde6"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "19cde6"
+  put_template_custom Pm "dad9c7"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/terafox.sh
+++ b/generic/terafox.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# terafox
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "2f/32/39"
+put_template 1  "e8/5c/51"
+put_template 2  "7a/a4/a1"
+put_template 3  "fd/a4/7f"
+put_template 4  "5a/93/aa"
+put_template 5  "ad/5c/7c"
+put_template 6  "a1/cd/d8"
+put_template 7  "eb/eb/eb"
+put_template 8  "4e/51/57"
+put_template 9  "eb/74/6b"
+put_template 10 "8e/b2/af"
+put_template 11 "fd/b2/92"
+put_template 12 "73/a3/b7"
+put_template 13 "b9/74/90"
+put_template 14 "af/d4/de"
+put_template 15 "ee/ee/ee"
+
+color_foreground="e6/ea/ea"
+color_background="15/25/28"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e6eaea"
+  put_template_custom Ph "152528"
+  put_template_custom Pi "e6eaea"
+  put_template_custom Pj "293e40"
+  put_template_custom Pk "e6eaea"
+  put_template_custom Pl "e6eaea"
+  put_template_custom Pm "152528"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/tokyonight-day.sh
+++ b/generic/tokyonight-day.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# tokyonight-day
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "e9/e9/ed"
+put_template 1  "f5/2a/65"
+put_template 2  "58/75/39"
+put_template 3  "8c/6c/3e"
+put_template 4  "2e/7d/e9"
+put_template 5  "98/54/f1"
+put_template 6  "00/71/97"
+put_template 7  "61/72/b0"
+put_template 8  "a1/a6/c5"
+put_template 9  "f5/2a/65"
+put_template 10 "58/75/39"
+put_template 11 "8c/6c/3e"
+put_template 12 "2e/7d/e9"
+put_template 13 "98/54/f1"
+put_template 14 "00/71/97"
+put_template 15 "37/60/bf"
+
+color_foreground="37/60/bf"
+color_background="e1/e2/e7"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "3760bf"
+  put_template_custom Ph "e1e2e7"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "99a7df"
+  put_template_custom Pk "3760bf"
+  put_template_custom Pl "3760bf"
+  put_template_custom Pm "e1e2e7"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/tokyonight-storm.sh
+++ b/generic/tokyonight-storm.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# tokyonight-storm
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1d/20/2f"
+put_template 1  "f7/76/8e"
+put_template 2  "9e/ce/6a"
+put_template 3  "e0/af/68"
+put_template 4  "7a/a2/f7"
+put_template 5  "bb/9a/f7"
+put_template 6  "7d/cf/ff"
+put_template 7  "a9/b1/d6"
+put_template 8  "41/48/68"
+put_template 9  "f7/76/8e"
+put_template 10 "9e/ce/6a"
+put_template 11 "e0/af/68"
+put_template 12 "7a/a2/f7"
+put_template 13 "bb/9a/f7"
+put_template 14 "7d/cf/ff"
+put_template 15 "c0/ca/f5"
+
+color_foreground="c0/ca/f5"
+color_background="24/28/3b"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c0caf5"
+  put_template_custom Ph "24283b"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "364a82"
+  put_template_custom Pk "c0caf5"
+  put_template_custom Pl "c0caf5"
+  put_template_custom Pm "1d202f"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/tokyonight.sh
+++ b/generic/tokyonight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# tokyonight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/16/1e"
+put_template 1  "f7/76/8e"
+put_template 2  "9e/ce/6a"
+put_template 3  "e0/af/68"
+put_template 4  "7a/a2/f7"
+put_template 5  "bb/9a/f7"
+put_template 6  "7d/cf/ff"
+put_template 7  "a9/b1/d6"
+put_template 8  "41/48/68"
+put_template 9  "f7/76/8e"
+put_template 10 "9e/ce/6a"
+put_template 11 "e0/af/68"
+put_template 12 "7a/a2/f7"
+put_template 13 "bb/9a/f7"
+put_template 14 "7d/cf/ff"
+put_template 15 "c0/ca/f5"
+
+color_foreground="c0/ca/f5"
+color_background="1a/1b/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c0caf5"
+  put_template_custom Ph "1a1b26"
+  put_template_custom Pi "eeeeee"
+  put_template_custom Pj "33467c"
+  put_template_custom Pk "c0caf5"
+  put_template_custom Pl "c0caf5"
+  put_template_custom Pm "15161e"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/tokyonight_moon.sh
+++ b/generic/tokyonight_moon.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# tokyonight_moon
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1b/1d/2b"
+put_template 1  "ff/75/7f"
+put_template 2  "c3/e8/8d"
+put_template 3  "ff/c7/77"
+put_template 4  "82/aa/ff"
+put_template 5  "c0/99/ff"
+put_template 6  "86/e1/fc"
+put_template 7  "82/8b/b8"
+put_template 8  "44/4a/73"
+put_template 9  "ff/75/7f"
+put_template 10 "c3/e8/8d"
+put_template 11 "ff/c7/77"
+put_template 12 "82/aa/ff"
+put_template 13 "c0/99/ff"
+put_template 14 "86/e1/fc"
+put_template 15 "c8/d3/f5"
+
+color_foreground="c8/d3/f5"
+color_background="22/24/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c8d3f5"
+  put_template_custom Ph "222436"
+  put_template_custom Pi "4fd6be"
+  put_template_custom Pj "2d3f76"
+  put_template_custom Pk "c8d3f5"
+  put_template_custom Pl "c8d3f5"
+  put_template_custom Pm "222436"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/tokyonight_night.sh
+++ b/generic/tokyonight_night.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# tokyonight_night
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "15/16/1e"
+put_template 1  "f7/76/8e"
+put_template 2  "9e/ce/6a"
+put_template 3  "e0/af/68"
+put_template 4  "7a/a2/f7"
+put_template 5  "bb/9a/f7"
+put_template 6  "7d/cf/ff"
+put_template 7  "a9/b1/d6"
+put_template 8  "41/48/68"
+put_template 9  "f7/76/8e"
+put_template 10 "9e/ce/6a"
+put_template 11 "e0/af/68"
+put_template 12 "7a/a2/f7"
+put_template 13 "bb/9a/f7"
+put_template 14 "7d/cf/ff"
+put_template 15 "c0/ca/f5"
+
+color_foreground="c0/ca/f5"
+color_background="1a/1b/26"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c0caf5"
+  put_template_custom Ph "1a1b26"
+  put_template_custom Pi "1abc9c"
+  put_template_custom Pj "283457"
+  put_template_custom Pk "c0caf5"
+  put_template_custom Pl "c0caf5"
+  put_template_custom Pm "1a1b26"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/vimbones.sh
+++ b/generic/vimbones.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# vimbones
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f0/f0/ca"
+put_template 1  "a8/33/4c"
+put_template 2  "4f/6c/31"
+put_template 3  "94/49/27"
+put_template 4  "28/64/86"
+put_template 5  "88/50/7d"
+put_template 6  "3b/89/92"
+put_template 7  "35/35/35"
+put_template 8  "c6/c6/a3"
+put_template 9  "94/25/3e"
+put_template 10 "3f/5a/22"
+put_template 11 "80/3d/1c"
+put_template 12 "1d/55/73"
+put_template 13 "7b/3b/70"
+put_template 14 "2b/74/7c"
+put_template 15 "5c/5c/5c"
+
+color_foreground="35/35/35"
+color_background="f0/f0/ca"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "353535"
+  put_template_custom Ph "f0f0ca"
+  put_template_custom Pi "c6c6a3"
+  put_template_custom Pj "d7d7d7"
+  put_template_custom Pk "353535"
+  put_template_custom Pl "353535"
+  put_template_custom Pm "f0f0ca"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/wilmersdorf.sh
+++ b/generic/wilmersdorf.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# wilmersdorf
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "34/37/3e"
+put_template 1  "e0/63/83"
+put_template 2  "7e/be/bd"
+put_template 3  "cc/cc/cc"
+put_template 4  "a6/c1/e0"
+put_template 5  "e1/c1/ee"
+put_template 6  "5b/94/ab"
+put_template 7  "ab/ab/ab"
+put_template 8  "43/47/50"
+put_template 9  "fa/71/93"
+put_template 10 "8f/d7/d6"
+put_template 11 "d1/df/ff"
+put_template 12 "b2/cf/f0"
+put_template 13 "ef/cc/fd"
+put_template 14 "69/ab/c5"
+put_template 15 "d3/d3/d3"
+
+color_foreground="c6/c6/c6"
+color_background="28/2b/33"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "c6c6c6"
+  put_template_custom Ph "282b33"
+  put_template_custom Pi "c9d9ff"
+  put_template_custom Pj "1f2024"
+  put_template_custom Pk "c6c6c6"
+  put_template_custom Pl "7ebebd"
+  put_template_custom Pm "1f2024"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/xcodedark.sh
+++ b/generic/xcodedark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# xcodedark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "41/44/53"
+put_template 1  "ff/81/70"
+put_template 2  "78/c2/b3"
+put_template 3  "d9/c9/7c"
+put_template 4  "4e/b0/cc"
+put_template 5  "ff/7a/b2"
+put_template 6  "b2/81/eb"
+put_template 7  "df/df/e0"
+put_template 8  "7f/8c/98"
+put_template 9  "ff/81/70"
+put_template 10 "ac/f2/e4"
+put_template 11 "ff/a1/4f"
+put_template 12 "6b/df/ff"
+put_template 13 "ff/7a/b2"
+put_template 14 "da/ba/ff"
+put_template 15 "df/df/e0"
+
+color_foreground="df/df/e0"
+color_background="29/2a/30"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "dfdfe0"
+  put_template_custom Ph "292a30"
+  put_template_custom Pi "dfdfe0"
+  put_template_custom Pj "414453"
+  put_template_custom Pk "dfdfe0"
+  put_template_custom Pl "dfdfe0"
+  put_template_custom Pm "292a30"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/xcodedarkhc.sh
+++ b/generic/xcodedarkhc.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# xcodedarkhc
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "43/45/4b"
+put_template 1  "ff/8a/7a"
+put_template 2  "83/c9/bc"
+put_template 3  "d9/c6/68"
+put_template 4  "4e/c4/e6"
+put_template 5  "ff/85/b8"
+put_template 6  "cd/a1/ff"
+put_template 7  "ff/ff/ff"
+put_template 8  "83/89/91"
+put_template 9  "ff/8a/7a"
+put_template 10 "b1/fa/eb"
+put_template 11 "ff/a1/4f"
+put_template 12 "6b/df/ff"
+put_template 13 "ff/85/b8"
+put_template 14 "e5/cf/ff"
+put_template 15 "ff/ff/ff"
+
+color_foreground="ff/ff/ff"
+color_background="1f/1f/24"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "ffffff"
+  put_template_custom Ph "1f1f24"
+  put_template_custom Pi "ffffff"
+  put_template_custom Pj "43454b"
+  put_template_custom Pk "ffffff"
+  put_template_custom Pl "ffffff"
+  put_template_custom Pm "1f1f24"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/xcodelight.sh
+++ b/generic/xcodelight.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# xcodelight
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "b4/d8/fd"
+put_template 1  "d1/2f/1b"
+put_template 2  "3e/80/87"
+put_template 3  "78/49/2a"
+put_template 4  "0f/68/a0"
+put_template 5  "ad/3d/a4"
+put_template 6  "80/4f/b8"
+put_template 7  "26/26/26"
+put_template 8  "8a/99/a6"
+put_template 9  "d1/2f/1b"
+put_template 10 "23/57/5c"
+put_template 11 "78/49/2a"
+put_template 12 "0b/4f/79"
+put_template 13 "ad/3d/a4"
+put_template 14 "4b/21/b0"
+put_template 15 "26/26/26"
+
+color_foreground="26/26/26"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "262626"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "262626"
+  put_template_custom Pj "b4d8fd"
+  put_template_custom Pk "262626"
+  put_template_custom Pl "262626"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/xcodelighthc.sh
+++ b/generic/xcodelighthc.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# xcodelighthc
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "b4/d8/fd"
+put_template 1  "ad/18/05"
+put_template 2  "35/5d/61"
+put_template 3  "78/49/2a"
+put_template 4  "00/58/a1"
+put_template 5  "9c/21/91"
+put_template 6  "70/3d/aa"
+put_template 7  "00/00/00"
+put_template 8  "8a/99/a6"
+put_template 9  "ad/18/05"
+put_template 10 "17/41/45"
+put_template 11 "78/49/2a"
+put_template 12 "00/3f/73"
+put_template 13 "9c/21/91"
+put_template 14 "44/1e/a1"
+put_template 15 "00/00/00"
+
+color_foreground="00/00/00"
+color_background="ff/ff/ff"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "000000"
+  put_template_custom Ph "ffffff"
+  put_template_custom Pi "000000"
+  put_template_custom Pj "b4d8fd"
+  put_template_custom Pk "000000"
+  put_template_custom Pl "000000"
+  put_template_custom Pm "ffffff"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/xcodewwdc.sh
+++ b/generic/xcodewwdc.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# xcodewwdc
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "49/4d/5c"
+put_template 1  "bb/38/3a"
+put_template 2  "94/c6/6e"
+put_template 3  "d2/8e/5d"
+put_template 4  "88/84/c5"
+put_template 5  "b7/39/99"
+put_template 6  "00/ab/a4"
+put_template 7  "e7/e8/eb"
+put_template 8  "7f/86/9e"
+put_template 9  "bb/38/3a"
+put_template 10 "94/c6/6e"
+put_template 11 "d2/8e/5d"
+put_template 12 "88/84/c5"
+put_template 13 "b7/39/99"
+put_template 14 "00/ab/a4"
+put_template 15 "e7/e8/eb"
+
+color_foreground="e7/e8/eb"
+color_background="29/2c/36"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "e7e8eb"
+  put_template_custom Ph "292c36"
+  put_template_custom Pi "e7e8eb"
+  put_template_custom Pj "494d5c"
+  put_template_custom Pk "e7e8eb"
+  put_template_custom Pl "e7e8eb"
+  put_template_custom Pm "292c36"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenbones.sh
+++ b/generic/zenbones.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenbones
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f0/ed/ec"
+put_template 1  "a8/33/4c"
+put_template 2  "4f/6c/31"
+put_template 3  "94/49/27"
+put_template 4  "28/64/86"
+put_template 5  "88/50/7d"
+put_template 6  "3b/89/92"
+put_template 7  "2c/36/3c"
+put_template 8  "cf/c1/ba"
+put_template 9  "94/25/3e"
+put_template 10 "3f/5a/22"
+put_template 11 "80/3d/1c"
+put_template 12 "1d/55/73"
+put_template 13 "7b/3b/70"
+put_template 14 "2b/74/7c"
+put_template 15 "4f/5e/68"
+
+color_foreground="2c/36/3c"
+color_background="f0/ed/ec"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "2c363c"
+  put_template_custom Ph "f0edec"
+  put_template_custom Pi "cfc1ba"
+  put_template_custom Pj "cbd9e3"
+  put_template_custom Pk "2c363c"
+  put_template_custom Pl "2c363c"
+  put_template_custom Pm "f0edec"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenbones_dark.sh
+++ b/generic/zenbones_dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenbones_dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "1c/19/17"
+put_template 1  "de/6e/7c"
+put_template 2  "81/9b/69"
+put_template 3  "b7/7e/64"
+put_template 4  "60/99/c0"
+put_template 5  "b2/79/a7"
+put_template 6  "66/a5/ad"
+put_template 7  "b4/bd/c3"
+put_template 8  "40/38/33"
+put_template 9  "e8/83/8f"
+put_template 10 "8b/ae/68"
+put_template 11 "d6/8c/67"
+put_template 12 "61/ab/da"
+put_template 13 "cf/86/c1"
+put_template 14 "65/b8/c1"
+put_template 15 "88/8f/94"
+
+color_foreground="b4/bd/c3"
+color_background="1c/19/17"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "b4bdc3"
+  put_template_custom Ph "1c1917"
+  put_template_custom Pi "403833"
+  put_template_custom Pj "3d4042"
+  put_template_custom Pk "b4bdc3"
+  put_template_custom Pl "c4cacf"
+  put_template_custom Pm "1c1917"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenbones_light.sh
+++ b/generic/zenbones_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenbones_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "f0/ed/ec"
+put_template 1  "a8/33/4c"
+put_template 2  "4f/6c/31"
+put_template 3  "94/49/27"
+put_template 4  "28/64/86"
+put_template 5  "88/50/7d"
+put_template 6  "3b/89/92"
+put_template 7  "2c/36/3c"
+put_template 8  "cf/c1/ba"
+put_template 9  "94/25/3e"
+put_template 10 "3f/5a/22"
+put_template 11 "80/3d/1c"
+put_template 12 "1d/55/73"
+put_template 13 "7b/3b/70"
+put_template 14 "2b/74/7c"
+put_template 15 "4f/5e/68"
+
+color_foreground="2c/36/3c"
+color_background="f0/ed/ec"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "2c363c"
+  put_template_custom Ph "f0edec"
+  put_template_custom Pi "cfc1ba"
+  put_template_custom Pj "cbd9e3"
+  put_template_custom Pk "2c363c"
+  put_template_custom Pl "2c363c"
+  put_template_custom Pm "f0edec"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenburned.sh
+++ b/generic/zenburned.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenburned
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "40/40/40"
+put_template 1  "e3/71/6e"
+put_template 2  "81/9b/69"
+put_template 3  "b7/7e/64"
+put_template 4  "60/99/c0"
+put_template 5  "b2/79/a7"
+put_template 6  "66/a5/ad"
+put_template 7  "f0/e4/cf"
+put_template 8  "62/5a/5b"
+put_template 9  "ec/86/85"
+put_template 10 "8b/ae/68"
+put_template 11 "d6/8c/67"
+put_template 12 "61/ab/da"
+put_template 13 "cf/86/c1"
+put_template 14 "65/b8/c1"
+put_template 15 "c0/ab/86"
+
+color_foreground="f0/e4/cf"
+color_background="40/40/40"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "f0e4cf"
+  put_template_custom Ph "404040"
+  put_template_custom Pi "625a5b"
+  put_template_custom Pj "746956"
+  put_template_custom Pk "f0e4cf"
+  put_template_custom Pl "f3eadb"
+  put_template_custom Pm "404040"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenwritten_dark.sh
+++ b/generic/zenwritten_dark.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenwritten_dark
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "19/19/19"
+put_template 1  "de/6e/7c"
+put_template 2  "81/9b/69"
+put_template 3  "b7/7e/64"
+put_template 4  "60/99/c0"
+put_template 5  "b2/79/a7"
+put_template 6  "66/a5/ad"
+put_template 7  "bb/bb/bb"
+put_template 8  "3d/38/39"
+put_template 9  "e8/83/8f"
+put_template 10 "8b/ae/68"
+put_template 11 "d6/8c/67"
+put_template 12 "61/ab/da"
+put_template 13 "cf/86/c1"
+put_template 14 "65/b8/c1"
+put_template 15 "8e/8e/8e"
+
+color_foreground="bb/bb/bb"
+color_background="19/19/19"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "bbbbbb"
+  put_template_custom Ph "191919"
+  put_template_custom Pi "3d3839"
+  put_template_custom Pj "404040"
+  put_template_custom Pk "bbbbbb"
+  put_template_custom Pl "c9c9c9"
+  put_template_custom Pm "191919"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/generic/zenwritten_light.sh
+++ b/generic/zenwritten_light.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# zenwritten_light
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "ee/ee/ee"
+put_template 1  "a8/33/4c"
+put_template 2  "4f/6c/31"
+put_template 3  "94/49/27"
+put_template 4  "28/64/86"
+put_template 5  "88/50/7d"
+put_template 6  "3b/89/92"
+put_template 7  "35/35/35"
+put_template 8  "c6/c3/c3"
+put_template 9  "94/25/3e"
+put_template 10 "3f/5a/22"
+put_template 11 "80/3d/1c"
+put_template 12 "1d/55/73"
+put_template 13 "7b/3b/70"
+put_template 14 "2b/74/7c"
+put_template 15 "5c/5c/5c"
+
+color_foreground="35/35/35"
+color_background="ee/ee/ee"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+  put_template_custom Pg "353535"
+  put_template_custom Ph "eeeeee"
+  put_template_custom Pi "c6c3c3"
+  put_template_custom Pj "d7d7d7"
+  put_template_custom Pk "353535"
+  put_template_custom Pl "353535"
+  put_template_custom Pm "eeeeee"
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -94,6 +94,10 @@ class Color:
         return f"{self.r:d},{self.g:d},{self.b:d}"
 
     @cached_property
+    def hexshell(self) -> str:
+        return f"{self.r:02x}/{self.g:02x}/{self.b:02x}"
+
+    @cached_property
     def hexchat(self) -> str:
         return f"{self.r:02x}{self.r:02x} {self.g:02x}{self.g:02x} {self.b:02x}{self.b:02x}"
 
@@ -119,6 +123,7 @@ class Color:
             "b": self.b,
             "hex": self.hex,
             "rgb": self.rgb,
+            "hexshell": self.hexshell,
         }
 
     @property

--- a/tools/templates/generic.sh
+++ b/tools/templates/generic.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# {{ scheme_name }}
+
+# source for these helper functions:
+# https://github.com/chriskempson/base16-shell/blob/master/templates/default.mustache
+if [ -n "$TMUX" ]; then
+  # Tell tmux to pass the escape sequences through
+  # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+  put_template() { printf '\033Ptmux;\033\033]4;%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_var() { printf '\033Ptmux;\033\033]%d;rgb:%s\033\033\\\033\\' $@; }
+  put_template_custom() { printf '\033Ptmux;\033\033]%s%s\033\033\\\033\\' $@; }
+elif [ "${TERM%%[-.]*}" = "screen" ]; then
+  # GNU screen (screen, screen-256color, screen-256color-bce)
+  put_template() { printf '\033P\033]4;%d;rgb:%s\007\033\\' $@; }
+  put_template_var() { printf '\033P\033]%d;rgb:%s\007\033\\' $@; }
+  put_template_custom() { printf '\033P\033]%s%s\007\033\\' $@; }
+elif [ "${TERM%%-*}" = "linux" ]; then
+  put_template() { [ $1 -lt 16 ] && printf "\e]P%x%s" $1 $(echo $2 | sed 's/\///g'); }
+  put_template_var() { true; }
+  put_template_custom() { true; }
+else
+  put_template() { printf '\033]4;%d;rgb:%s\033\\' $@; }
+  put_template_var() { printf '\033]%d;rgb:%s\033\\' $@; }
+  put_template_custom() { printf '\033]%s%s\033\\' $@; }
+fi
+
+# 16 color space
+put_template 0  "{{Ansi_0_Color.hexshell}}"
+put_template 1  "{{Ansi_1_Color.hexshell}}"
+put_template 2  "{{Ansi_2_Color.hexshell}}"
+put_template 3  "{{Ansi_3_Color.hexshell}}"
+put_template 4  "{{Ansi_4_Color.hexshell}}"
+put_template 5  "{{Ansi_5_Color.hexshell}}"
+put_template 6  "{{Ansi_6_Color.hexshell}}"
+put_template 7  "{{Ansi_7_Color.hexshell}}"
+put_template 8  "{{Ansi_8_Color.hexshell}}"
+put_template 9  "{{Ansi_9_Color.hexshell}}"
+put_template 10 "{{Ansi_10_Color.hexshell}}"
+put_template 11 "{{Ansi_11_Color.hexshell}}"
+put_template 12 "{{Ansi_12_Color.hexshell}}"
+put_template 13 "{{Ansi_13_Color.hexshell}}"
+put_template 14 "{{Ansi_14_Color.hexshell}}"
+put_template 15 "{{Ansi_15_Color.hexshell}}"
+
+color_foreground="{{Foreground_Color.hexshell}}"
+color_background="{{Background_Color.hexshell}}"
+
+if [ -n "$ITERM_SESSION_ID" ]; then
+  # iTerm2 proprietary escape codes
+{% set iterm_codes = {
+    'g': Foreground_Color    ,
+    'h': Background_Color    ,
+    'i': Bold_Color          ,
+    'j': Selection_Color     ,
+    'k': Selected_Text_Color ,
+    'l': Cursor_Color        ,
+    'm': Cursor_Text_Color   ,
+} %}
+{% for k, v in iterm_codes.items() %}
+  put_template_custom P{{ k }} "{{ v.hex }}"
+{% endfor %}
+else
+  put_template_var 10 $color_foreground
+  put_template_var 11 $color_background
+  if [ "${TERM%%-*}" = "rxvt" ]; then
+    put_template_var 708 $color_background # internal border (rxvt)
+  fi
+  put_template_custom 12 ";7" # cursor (reverse video)
+fi
+
+# clean up
+unset -f put_template
+unset -f put_template_var
+unset -f put_template_custom
+
+unset color_foreground
+unset color_background


### PR DESCRIPTION
## Description

I noticed that iTerm-Color-Schemes is missing support for some terminal emulators like the Linux console and GNOME Terminal. I thought it could be useful to add a "generic" option (inspired by https://github.com/chriskempson/base16-shell) which uses the OSC 4 ANSI escape codes to implement the theme using a shell script. This could work at a basic level with any terminal emulator that supports OSC 4.

The template file is heavily based on [this template from base16-shell](https://github.com/chriskempson/base16-shell/blob/588691ba71b47e75793ed9edfcfaa058326a6f41/templates/default.mustache).

I'm not sure if "generic" is the best name for this theme format -- I also considered "script", "base16" (since it's inspired by `base16`'s script), and "osc-4" (since it uses the OSC 4 escape sequence to set the colours, [documented here under "Change Color Number"](https://www.xfree86.org/4.8.0/ctlseqs.html))

This could also potentially be used to enable previews of the themes in more terminal emulators than just iTerm. Here's an example of what that could look like: [preview.sh](https://gist.github.com/jvns/0b66337a9843ed4ccff0b97aee30e7f0)

### Checklist

- [x] Updated `README.md` with new format
- [x] Ran `tools/gen.py` to generate themes in all formats

### Testing

I ran one of the scripts in iTerm, Terminal.app, and ghostty. Here's a screenshot of it in action in `Terminal.app`:

<img width="887" alt="image" src="https://github.com/user-attachments/assets/48df76b8-b0be-4ede-8b0b-11097429b611" />
