### PR TITLE
Add a preview script that works in more terminal emulators

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Screenshots](#screenshots)
 - [Credits](#credits)
 - [Extra](#extra)
+  - [Previewing color schemes](#previewing-color-schemes)
   - [X11 Installation](#x11-installation)
   - [Konsole color schemes](#konsole-color-schemes)
   - [Terminator color schemes](#terminator-color-schemes)
@@ -13,7 +14,6 @@
   - [PuTTY color schemes](#putty-color-schemes)
   - [Xfce Terminal color schemes](#xfce-terminal-color-schemes)
   - [FreeBSD vt(4) color schemes](#freebsd-vt-color-schemes)
-  - [Previewing color schemes](#previewing-color-schemes)
   - [MobaXterm color schemes](#mobaxterm-color-schemes)
   - [LXTerminal color schemes](#lxterminal-color-schemes)
   - [Visual Studio Code color schemes](#visual-studio-code-color-schemes)
@@ -2083,6 +2083,20 @@ tools/preview.rb schemes/AdventureTime.itermcolors
 tools/preview.rb schemes/*
 ```
 
+#### Previewing color schemes in other terminal emulators
+
+[preview-generic.sh](tools/preview-generic.sh) is a script which can preview
+the themes in any terminal emulator which has support for the OSC 4 escape
+codes. It works by running the shell scripts from the `generic/` directory. 
+
+```sh
+# Apply AdventureTime scheme to the current session
+bash generic/AdventureTime.sh
+
+# Apply the schemes in turn
+# - Press left/right arrow keys to navigate, press `q` to stop
+./tools/preview-generic.sh generic/*
+```
 ---
 
 iTerm Color Schemes | iTerm2 Color Schemes | iTerm 2 Color Schemes | iTerm Themes | iTerm2 Themes | iTerm 2 Themes

--- a/tools/preview-generic.sh
+++ b/tools/preview-generic.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 [theme files]"
+  echo "Example: $0 generic/*Light*.sh"
+  exit 1
+fi
+
+themes=("$@")
+total=${#themes[@]}
+
+if [ $total -eq 0 ]; then
+  echo "No theme files found."
+  exit 1
+fi
+
+current=0
+
+show_theme_info() {
+  # Move cursor to beginning of line
+  echo -en "\r\033[K"
+  echo -en "\033[1;36m>> Theme $((current+1))/$total: $(basename "${themes[$current]}") | ← → to navigate | q to quit\033[0m"
+}
+
+execute_theme() {
+  show_theme_info
+  source "${themes[$current]}"
+}
+
+execute_theme
+
+while true; do
+  read -s -n 1 key
+  if [[ $key == "q" ]]; then
+    echo -e "\nTheme preview exited."
+    exit 0
+  elif [[ $key == $'\e' ]]; then
+    read -s -n 2 rest
+    if [[ $rest == "[C" ]]; then # Right arrow
+      ((current++))
+      [[ $current -ge $total ]] && current=0
+      execute_theme
+    elif [[ $rest == "[D" ]]; then # Left arrow
+      ((current--))
+      [[ $current -lt 0 ]] && current=$((total-1))
+      execute_theme
+    fi
+  fi
+done


### PR DESCRIPTION
Right now `tools/preview.rb` uses iTerm-specific escape codes to preview the theme. This adds a more generic preview script which works in any terminal emulator, using the OSC 4 escape codes. It works by just running the shell scripts in the `preview/` directory, it doesn't do any translation on its own.

Here's a screenshot of it in action:

<img width="1457" alt="image" src="https://github.com/user-attachments/assets/0bf9e8e5-5fa7-4cbb-a373-8ae793134cca" />

I left the original `preview.rb` script alone because iTerm's proprietary escape codes support theming more parts of the UI (like the cursor text), so the "generic" preview script doesn't have the exact same behaviour. 

I also moved the "Previewing color themes" TOC link up in the README because I didn't think it made sense for it to be in the middle of the instructions for all the different terminal emulators.