### PR TITLE
fix(catppuccin): sync catppuccin themes with the canonical repo

### DIFF
--- a/alacritty/catppuccin-frappe.toml
+++ b/alacritty/catppuccin-frappe.toml
@@ -12,7 +12,7 @@ yellow = '#d9ba73'
 
 [colors.cursor]
 cursor = '#f2d5cf'
-text = '#c6d0f5'
+text = '#303446'
 
 [colors.normal]
 black = '#51576d'

--- a/alacritty/catppuccin-latte.toml
+++ b/alacritty/catppuccin-latte.toml
@@ -12,7 +12,7 @@ yellow = '#eea02d'
 
 [colors.cursor]
 cursor = '#dc8a78'
-text = '#4c4f69'
+text = '#eff1f5'
 
 [colors.normal]
 black = '#5c5f77'

--- a/alacritty/catppuccin-macchiato.toml
+++ b/alacritty/catppuccin-macchiato.toml
@@ -12,7 +12,7 @@ yellow = '#e1c682'
 
 [colors.cursor]
 cursor = '#f4dbd6'
-text = '#cad3f5'
+text = '#24273a'
 
 [colors.normal]
 black = '#494d64'

--- a/alacritty/catppuccin-mocha.toml
+++ b/alacritty/catppuccin-mocha.toml
@@ -12,7 +12,7 @@ yellow = '#ebd391'
 
 [colors.cursor]
 cursor = '#f5e0dc'
-text = '#cdd6f4'
+text = '#1e1e2e'
 
 [colors.normal]
 black = '#45475a'

--- a/foot/catppuccin-frappe.ini
+++ b/foot/catppuccin-frappe.ini
@@ -1,6 +1,6 @@
 
 [cursor]
-color=c6d0f5 f2d5cf
+color=303446 f2d5cf
 
 [colors]
 foreground=c6d0f5

--- a/foot/catppuccin-latte.ini
+++ b/foot/catppuccin-latte.ini
@@ -1,6 +1,6 @@
 
 [cursor]
-color=4c4f69 dc8a78
+color=eff1f5 dc8a78
 
 [colors]
 foreground=4c4f69

--- a/foot/catppuccin-macchiato.ini
+++ b/foot/catppuccin-macchiato.ini
@@ -1,6 +1,6 @@
 
 [cursor]
-color=cad3f5 f4dbd6
+color=24273a f4dbd6
 
 [colors]
 foreground=cad3f5

--- a/foot/catppuccin-mocha.ini
+++ b/foot/catppuccin-mocha.ini
@@ -1,6 +1,6 @@
 
 [cursor]
-color=cdd6f4 f5e0dc
+color=1e1e2e f5e0dc
 
 [colors]
 foreground=cdd6f4

--- a/generic/catppuccin-frappe.sh
+++ b/generic/catppuccin-frappe.sh
@@ -53,7 +53,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pj "626880"
   put_template_custom Pk "c6d0f5"
   put_template_custom Pl "f2d5cf"
-  put_template_custom Pm "c6d0f5"
+  put_template_custom Pm "303446"
 else
   put_template_var 10 $color_foreground
   put_template_var 11 $color_background

--- a/generic/catppuccin-latte.sh
+++ b/generic/catppuccin-latte.sh
@@ -53,7 +53,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pj "acb0be"
   put_template_custom Pk "4c4f69"
   put_template_custom Pl "dc8a78"
-  put_template_custom Pm "4c4f69"
+  put_template_custom Pm "eff1f5"
 else
   put_template_var 10 $color_foreground
   put_template_var 11 $color_background

--- a/generic/catppuccin-macchiato.sh
+++ b/generic/catppuccin-macchiato.sh
@@ -53,7 +53,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pj "5b6078"
   put_template_custom Pk "cad3f5"
   put_template_custom Pl "f4dbd6"
-  put_template_custom Pm "cad3f5"
+  put_template_custom Pm "24273a"
 else
   put_template_var 10 $color_foreground
   put_template_var 11 $color_background

--- a/generic/catppuccin-mocha.sh
+++ b/generic/catppuccin-mocha.sh
@@ -53,7 +53,7 @@ if [ -n "$ITERM_SESSION_ID" ]; then
   put_template_custom Pj "585b70"
   put_template_custom Pk "cdd6f4"
   put_template_custom Pl "f5e0dc"
-  put_template_custom Pm "cdd6f4"
+  put_template_custom Pm "1e1e2e"
 else
   put_template_var 10 $color_foreground
   put_template_var 11 $color_background

--- a/ghostty/catppuccin-frappe
+++ b/ghostty/catppuccin-frappe
@@ -17,6 +17,6 @@ palette = 15=#b5bfe2
 background = #303446
 foreground = #c6d0f5
 cursor-color = #f2d5cf
-cursor-text = #c6d0f5
+cursor-text = #303446
 selection-background = #626880
 selection-foreground = #c6d0f5

--- a/ghostty/catppuccin-latte
+++ b/ghostty/catppuccin-latte
@@ -17,6 +17,6 @@ palette = 15=#bcc0cc
 background = #eff1f5
 foreground = #4c4f69
 cursor-color = #dc8a78
-cursor-text = #4c4f69
+cursor-text = #eff1f5
 selection-background = #acb0be
 selection-foreground = #4c4f69

--- a/ghostty/catppuccin-macchiato
+++ b/ghostty/catppuccin-macchiato
@@ -17,6 +17,6 @@ palette = 15=#b8c0e0
 background = #24273a
 foreground = #cad3f5
 cursor-color = #f4dbd6
-cursor-text = #cad3f5
+cursor-text = #24273a
 selection-background = #5b6078
 selection-foreground = #cad3f5

--- a/ghostty/catppuccin-mocha
+++ b/ghostty/catppuccin-mocha
@@ -17,6 +17,6 @@ palette = 15=#bac2de
 background = #1e1e2e
 foreground = #cdd6f4
 cursor-color = #f5e0dc
-cursor-text = #cdd6f4
+cursor-text = #1e1e2e
 selection-background = #585b70
 selection-foreground = #cdd6f4

--- a/kitty/catppuccin-frappe.conf
+++ b/kitty/catppuccin-frappe.conf
@@ -17,6 +17,6 @@ color15 #b5bfe2
 background #303446
 selection_foreground #303446
 cursor #f2d5cf
-cursor_text_color #c6d0f5
+cursor_text_color #303446
 foreground #c6d0f5
 selection_background #c6d0f5

--- a/kitty/catppuccin-latte.conf
+++ b/kitty/catppuccin-latte.conf
@@ -17,6 +17,6 @@ color15 #bcc0cc
 background #eff1f5
 selection_foreground #eff1f5
 cursor #dc8a78
-cursor_text_color #4c4f69
+cursor_text_color #eff1f5
 foreground #4c4f69
 selection_background #4c4f69

--- a/kitty/catppuccin-macchiato.conf
+++ b/kitty/catppuccin-macchiato.conf
@@ -17,6 +17,6 @@ color15 #b8c0e0
 background #24273a
 selection_foreground #24273a
 cursor #f4dbd6
-cursor_text_color #cad3f5
+cursor_text_color #24273a
 foreground #cad3f5
 selection_background #cad3f5

--- a/kitty/catppuccin-mocha.conf
+++ b/kitty/catppuccin-mocha.conf
@@ -17,6 +17,6 @@ color15 #bac2de
 background #1e1e2e
 selection_foreground #1e1e2e
 cursor #f5e0dc
-cursor_text_color #cdd6f4
+cursor_text_color #1e1e2e
 foreground #cdd6f4
 selection_background #cdd6f4

--- a/putty/catppuccin-frappe.reg
+++ b/putty/catppuccin-frappe.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour0"="198,208,245"
 "Colour1"="198,208,245"
 "Colour5"="242,213,207"
-"Colour4"="198,208,245"
+"Colour4"="48,52,70"
 "Colour6"="81,87,109"
 "Colour8"="231,130,132"
 "Colour11"="142,199,114"

--- a/putty/catppuccin-latte.reg
+++ b/putty/catppuccin-latte.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour0"="76,79,105"
 "Colour1"="76,79,105"
 "Colour5"="220,138,120"
-"Colour4"="76,79,105"
+"Colour4"="239,241,245"
 "Colour6"="92,95,119"
 "Colour8"="210,15,57"
 "Colour11"="73,175,61"

--- a/putty/catppuccin-macchiato.reg
+++ b/putty/catppuccin-macchiato.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour0"="202,211,245"
 "Colour1"="202,211,245"
 "Colour5"="244,219,214"
-"Colour4"="202,211,245"
+"Colour4"="36,39,58"
 "Colour6"="73,77,100"
 "Colour8"="237,135,150"
 "Colour11"="140,207,127"

--- a/putty/catppuccin-mocha.reg
+++ b/putty/catppuccin-mocha.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour0"="205,214,244"
 "Colour1"="205,214,244"
 "Colour5"="245,224,220"
-"Colour4"="205,214,244"
+"Colour4"="30,30,46"
 "Colour6"="69,71,90"
 "Colour8"="243,139,168"
 "Colour11"="137,216,139"

--- a/remmina/catppuccin-frappe.colors
+++ b/remmina/catppuccin-frappe.colors
@@ -1,7 +1,7 @@
 [ssh_colors]
 background = #303446
 cursor = #f2d5cf
-cursor_foreground = #c6d0f5
+cursor_foreground = #303446
 foreground = #c6d0f5
 highlight = #626880
 highlight_foreground = #c6d0f5

--- a/remmina/catppuccin-latte.colors
+++ b/remmina/catppuccin-latte.colors
@@ -1,7 +1,7 @@
 [ssh_colors]
 background = #eff1f5
 cursor = #dc8a78
-cursor_foreground = #4c4f69
+cursor_foreground = #eff1f5
 foreground = #4c4f69
 highlight = #acb0be
 highlight_foreground = #4c4f69

--- a/remmina/catppuccin-macchiato.colors
+++ b/remmina/catppuccin-macchiato.colors
@@ -1,7 +1,7 @@
 [ssh_colors]
 background = #24273a
 cursor = #f4dbd6
-cursor_foreground = #cad3f5
+cursor_foreground = #24273a
 foreground = #cad3f5
 highlight = #5b6078
 highlight_foreground = #cad3f5

--- a/remmina/catppuccin-mocha.colors
+++ b/remmina/catppuccin-mocha.colors
@@ -1,7 +1,7 @@
 [ssh_colors]
 background = #1e1e2e
 cursor = #f5e0dc
-cursor_foreground = #cdd6f4
+cursor_foreground = #1e1e2e
 foreground = #cdd6f4
 highlight = #585b70
 highlight_foreground = #cdd6f4

--- a/royalts/catppuccin-frappe.termcolors
+++ b/royalts/catppuccin-frappe.termcolors
@@ -24,7 +24,7 @@
     },
     {
       "name": "CursorForeground",
-      "color": "#c6d0f5",
+      "color": "#303446",
       "terminalMapping": "cursorForeground"
     },
     {

--- a/royalts/catppuccin-latte.termcolors
+++ b/royalts/catppuccin-latte.termcolors
@@ -24,7 +24,7 @@
     },
     {
       "name": "CursorForeground",
-      "color": "#4c4f69",
+      "color": "#eff1f5",
       "terminalMapping": "cursorForeground"
     },
     {

--- a/royalts/catppuccin-macchiato.termcolors
+++ b/royalts/catppuccin-macchiato.termcolors
@@ -24,7 +24,7 @@
     },
     {
       "name": "CursorForeground",
-      "color": "#cad3f5",
+      "color": "#24273a",
       "terminalMapping": "cursorForeground"
     },
     {

--- a/royalts/catppuccin-mocha.termcolors
+++ b/royalts/catppuccin-mocha.termcolors
@@ -24,7 +24,7 @@
     },
     {
       "name": "CursorForeground",
-      "color": "#cdd6f4",
+      "color": "#1e1e2e",
       "terminalMapping": "cursorForeground"
     },
     {

--- a/schemes/catppuccin-frappe.itermcolors
+++ b/schemes/catppuccin-frappe.itermcolors
@@ -2,330 +2,330 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Ansi 0 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3176470588235294</real>
-    <key>Green Component</key>
-    <real>0.3411764705882353</real>
-    <key>Blue Component</key>
-    <real>0.42745098039215684</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 1 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9058823529411765</real>
-    <key>Green Component</key>
-    <real>0.5098039215686274</real>
-    <key>Blue Component</key>
-    <real>0.5176470588235295</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 2 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6509803921568628</real>
-    <key>Green Component</key>
-    <real>0.8196078431372549</real>
-    <key>Blue Component</key>
-    <real>0.5372549019607843</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 3 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8980392156862745</real>
-    <key>Green Component</key>
-    <real>0.7843137254901961</real>
-    <key>Blue Component</key>
-    <real>0.5647058823529412</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 4 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5490196078431373</real>
-    <key>Green Component</key>
-    <real>0.6666666666666666</real>
-    <key>Blue Component</key>
-    <real>0.9333333333333333</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 5 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9568627450980393</real>
-    <key>Green Component</key>
-    <real>0.7215686274509804</real>
-    <key>Blue Component</key>
-    <real>0.8941176470588236</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 6 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5058823529411764</real>
-    <key>Green Component</key>
-    <real>0.7843137254901961</real>
-    <key>Blue Component</key>
-    <real>0.7450980392156863</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 7 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6470588235294118</real>
-    <key>Green Component</key>
-    <real>0.6784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.807843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 8 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3843137254901961</real>
-    <key>Green Component</key>
-    <real>0.40784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.5019607843137255</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 9 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9019607843137255</real>
-    <key>Green Component</key>
-    <real>0.44313725490196076</real>
-    <key>Blue Component</key>
-    <real>0.4470588235294118</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 10 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5568627450980392</real>
-    <key>Green Component</key>
-    <real>0.7803921568627451</real>
-    <key>Blue Component</key>
-    <real>0.4470588235294118</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 11 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8509803921568627</real>
-    <key>Green Component</key>
-    <real>0.7294117647058823</real>
-    <key>Blue Component</key>
-    <real>0.45098039215686275</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 12 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.4823529411764706</real>
-    <key>Green Component</key>
-    <real>0.6196078431372549</real>
-    <key>Blue Component</key>
-    <real>0.9411764705882353</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 13 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9490196078431372</real>
-    <key>Green Component</key>
-    <real>0.6431372549019608</real>
-    <key>Blue Component</key>
-    <real>0.8588235294117647</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 14 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.35294117647058826</real>
-    <key>Green Component</key>
-    <real>0.7490196078431373</real>
-    <key>Blue Component</key>
-    <real>0.7098039215686275</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 15 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7098039215686275</real>
-    <key>Green Component</key>
-    <real>0.7490196078431373</real>
-    <key>Blue Component</key>
-    <real>0.8862745098039215</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Background Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.18823529411764706</real>
-    <key>Green Component</key>
-    <real>0.20392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.27450980392156865</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Foreground Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8156862745098039</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Link Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6</real>
-    <key>Green Component</key>
-    <real>0.8196078431372549</real>
-    <key>Blue Component</key>
-    <real>0.8588235294117647</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Bold Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8156862745098039</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9490196078431372</real>
-    <key>Green Component</key>
-    <real>0.8352941176470589</real>
-    <key>Blue Component</key>
-    <real>0.8117647058823529</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8156862745098039</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Guide Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8156862745098039</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>0.07</real>
-  </dict>
-  <key>Selection Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3843137254901961</real>
-    <key>Green Component</key>
-    <real>0.40784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.5019607843137255</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Selected Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8156862745098039</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.42745098039215684</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3411764705882353</real>
+		<key>Red Component</key>
+		<real>0.3176470588235294</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5176470588235295</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5098039215686274</real>
+		<key>Red Component</key>
+		<real>0.9058823529411765</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4470588235294118</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7803921568627451</real>
+		<key>Red Component</key>
+		<real>0.5568627450980392</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.45098039215686275</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7294117647058823</real>
+		<key>Red Component</key>
+		<real>0.8509803921568627</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9411764705882353</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6196078431372549</real>
+		<key>Red Component</key>
+		<real>0.4823529411764706</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8588235294117647</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6431372549019608</real>
+		<key>Red Component</key>
+		<real>0.9490196078431372</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7098039215686275</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7490196078431373</real>
+		<key>Red Component</key>
+		<real>0.35294117647058826</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8862745098039215</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7490196078431373</real>
+		<key>Red Component</key>
+		<real>0.7098039215686275</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5372549019607843</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.6509803921568628</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5647058823529412</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7843137254901961</real>
+		<key>Red Component</key>
+		<real>0.8980392156862745</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9333333333333333</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6666666666666666</real>
+		<key>Red Component</key>
+		<real>0.5490196078431373</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8941176470588236</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7215686274509804</real>
+		<key>Red Component</key>
+		<real>0.9568627450980393</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7450980392156863</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7843137254901961</real>
+		<key>Red Component</key>
+		<real>0.5058823529411764</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.807843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6784313725490196</real>
+		<key>Red Component</key>
+		<real>0.6470588235294118</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5019607843137255</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.40784313725490196</real>
+		<key>Red Component</key>
+		<real>0.3843137254901961</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4470588235294118</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.44313725490196076</real>
+		<key>Red Component</key>
+		<real>0.9019607843137255</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.27450980392156865</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.20392156862745098</real>
+		<key>Red Component</key>
+		<real>0.18823529411764706</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8156862745098039</real>
+		<key>Red Component</key>
+		<real>0.7764705882352941</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8352941176470589</real>
+		<key>Red Component</key>
+		<real>0.9490196078431372</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.07</real>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8156862745098039</real>
+		<key>Red Component</key>
+		<real>0.7764705882352941</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.27450980392156865</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.20392156862745098</real>
+		<key>Red Component</key>
+		<real>0.18823529411764706</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8156862745098039</real>
+		<key>Red Component</key>
+		<real>0.7764705882352941</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8588235294117647</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8196078431372549</real>
+		<key>Red Component</key>
+		<real>0.6</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8156862745098039</real>
+		<key>Red Component</key>
+		<real>0.7764705882352941</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5019607843137255</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.40784313725490196</real>
+		<key>Red Component</key>
+		<real>0.3843137254901961</real>
+	</dict>
 </dict>
 </plist>

--- a/schemes/catppuccin-latte.itermcolors
+++ b/schemes/catppuccin-latte.itermcolors
@@ -2,330 +2,330 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Ansi 0 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3607843137254902</real>
-    <key>Green Component</key>
-    <real>0.37254901960784315</real>
-    <key>Blue Component</key>
-    <real>0.4666666666666667</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 1 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8235294117647058</real>
-    <key>Green Component</key>
-    <real>0.058823529411764705</real>
-    <key>Blue Component</key>
-    <real>0.2235294117647059</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 2 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.25098039215686274</real>
-    <key>Green Component</key>
-    <real>0.6274509803921569</real>
-    <key>Blue Component</key>
-    <real>0.16862745098039217</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 3 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8745098039215686</real>
-    <key>Green Component</key>
-    <real>0.5568627450980392</real>
-    <key>Blue Component</key>
-    <real>0.11372549019607843</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 4 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.11764705882352941</real>
-    <key>Green Component</key>
-    <real>0.4</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 5 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9176470588235294</real>
-    <key>Green Component</key>
-    <real>0.4627450980392157</real>
-    <key>Blue Component</key>
-    <real>0.796078431372549</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 6 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.09019607843137255</real>
-    <key>Green Component</key>
-    <real>0.5725490196078431</real>
-    <key>Blue Component</key>
-    <real>0.6</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 7 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6745098039215687</real>
-    <key>Green Component</key>
-    <real>0.6901960784313725</real>
-    <key>Blue Component</key>
-    <real>0.7450980392156863</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 8 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.4235294117647059</real>
-    <key>Green Component</key>
-    <real>0.43529411764705883</real>
-    <key>Blue Component</key>
-    <real>0.5215686274509804</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 9 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8705882352941177</real>
-    <key>Green Component</key>
-    <real>0.1607843137254902</real>
-    <key>Blue Component</key>
-    <real>0.24313725490196078</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 10 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.28627450980392155</real>
-    <key>Green Component</key>
-    <real>0.6862745098039216</real>
-    <key>Blue Component</key>
-    <real>0.23921568627450981</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 11 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9333333333333333</real>
-    <key>Green Component</key>
-    <real>0.6274509803921569</real>
-    <key>Blue Component</key>
-    <real>0.17647058823529413</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 12 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.27058823529411763</real>
-    <key>Green Component</key>
-    <real>0.43137254901960786</real>
-    <key>Blue Component</key>
-    <real>1</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 13 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.996078431372549</real>
-    <key>Green Component</key>
-    <real>0.5215686274509804</real>
-    <key>Blue Component</key>
-    <real>0.8470588235294118</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 14 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.17647058823529413</real>
-    <key>Green Component</key>
-    <real>0.6235294117647059</real>
-    <key>Blue Component</key>
-    <real>0.6588235294117647</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 15 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7372549019607844</real>
-    <key>Green Component</key>
-    <real>0.7529411764705882</real>
-    <key>Blue Component</key>
-    <real>0.8</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Background Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9372549019607843</real>
-    <key>Green Component</key>
-    <real>0.9450980392156862</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Foreground Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.2980392156862745</real>
-    <key>Green Component</key>
-    <real>0.30980392156862746</real>
-    <key>Blue Component</key>
-    <real>0.4117647058823529</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Link Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.01568627450980392</real>
-    <key>Green Component</key>
-    <real>0.6470588235294118</real>
-    <key>Blue Component</key>
-    <real>0.8980392156862745</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Bold Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.2980392156862745</real>
-    <key>Green Component</key>
-    <real>0.30980392156862746</real>
-    <key>Blue Component</key>
-    <real>0.4117647058823529</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8627450980392157</real>
-    <key>Green Component</key>
-    <real>0.5411764705882353</real>
-    <key>Blue Component</key>
-    <real>0.47058823529411764</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.2980392156862745</real>
-    <key>Green Component</key>
-    <real>0.30980392156862746</real>
-    <key>Blue Component</key>
-    <real>0.4117647058823529</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Guide Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.2980392156862745</real>
-    <key>Green Component</key>
-    <real>0.30980392156862746</real>
-    <key>Blue Component</key>
-    <real>0.4117647058823529</real>
-    <key>Alpha Component</key>
-    <real>0.07</real>
-  </dict>
-  <key>Selection Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6745098039215687</real>
-    <key>Green Component</key>
-    <real>0.6901960784313725</real>
-    <key>Blue Component</key>
-    <real>0.7450980392156863</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Selected Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.2980392156862745</real>
-    <key>Green Component</key>
-    <real>0.30980392156862746</real>
-    <key>Blue Component</key>
-    <real>0.4117647058823529</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4666666666666667</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.37254901960784315</real>
+		<key>Red Component</key>
+		<real>0.3607843137254902</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.2235294117647059</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.058823529411764705</real>
+		<key>Red Component</key>
+		<real>0.8235294117647058</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.23921568627450981</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6862745098039216</real>
+		<key>Red Component</key>
+		<real>0.28627450980392155</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.17647058823529413</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6274509803921569</real>
+		<key>Red Component</key>
+		<real>0.9333333333333333</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<integer>1</integer>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.43137254901960786</real>
+		<key>Red Component</key>
+		<real>0.27058823529411763</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8470588235294118</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5215686274509804</real>
+		<key>Red Component</key>
+		<real>0.996078431372549</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6588235294117647</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6235294117647059</real>
+		<key>Red Component</key>
+		<real>0.17647058823529413</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7529411764705882</real>
+		<key>Red Component</key>
+		<real>0.7372549019607844</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.16862745098039217</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6274509803921569</real>
+		<key>Red Component</key>
+		<real>0.25098039215686274</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.11372549019607843</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5568627450980392</real>
+		<key>Red Component</key>
+		<real>0.8745098039215686</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.4</real>
+		<key>Red Component</key>
+		<real>0.11764705882352941</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.796078431372549</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.4627450980392157</real>
+		<key>Red Component</key>
+		<real>0.9176470588235294</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5725490196078431</real>
+		<key>Red Component</key>
+		<real>0.09019607843137255</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7450980392156863</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6901960784313725</real>
+		<key>Red Component</key>
+		<real>0.6745098039215687</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5215686274509804</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.43529411764705883</real>
+		<key>Red Component</key>
+		<real>0.4235294117647059</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.24313725490196078</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.1607843137254902</real>
+		<key>Red Component</key>
+		<real>0.8705882352941177</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.9450980392156862</real>
+		<key>Red Component</key>
+		<real>0.9372549019607843</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.30980392156862746</real>
+		<key>Red Component</key>
+		<real>0.2980392156862745</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.47058823529411764</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5411764705882353</real>
+		<key>Red Component</key>
+		<real>0.8627450980392157</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.07</real>
+		<key>Blue Component</key>
+		<real>0.4117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.30980392156862746</real>
+		<key>Red Component</key>
+		<real>0.2980392156862745</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.9450980392156862</real>
+		<key>Red Component</key>
+		<real>0.9372549019607843</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.30980392156862746</real>
+		<key>Red Component</key>
+		<real>0.2980392156862745</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8980392156862745</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6470588235294118</real>
+		<key>Red Component</key>
+		<real>0.01568627450980392</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.30980392156862746</real>
+		<key>Red Component</key>
+		<real>0.2980392156862745</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7450980392156863</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6901960784313725</real>
+		<key>Red Component</key>
+		<real>0.6745098039215687</real>
+	</dict>
 </dict>
 </plist>

--- a/schemes/catppuccin-macchiato.itermcolors
+++ b/schemes/catppuccin-macchiato.itermcolors
@@ -2,330 +2,330 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Ansi 0 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.28627450980392155</real>
-    <key>Green Component</key>
-    <real>0.30196078431372547</real>
-    <key>Blue Component</key>
-    <real>0.39215686274509803</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 1 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9294117647058824</real>
-    <key>Green Component</key>
-    <real>0.5294117647058824</real>
-    <key>Blue Component</key>
-    <real>0.5882352941176471</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 2 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6509803921568628</real>
-    <key>Green Component</key>
-    <real>0.8549019607843137</real>
-    <key>Blue Component</key>
-    <real>0.5843137254901961</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 3 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9333333333333333</real>
-    <key>Green Component</key>
-    <real>0.8313725490196079</real>
-    <key>Blue Component</key>
-    <real>0.6235294117647059</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 4 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5411764705882353</real>
-    <key>Green Component</key>
-    <real>0.6784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 5 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9607843137254902</real>
-    <key>Green Component</key>
-    <real>0.7411764705882353</real>
-    <key>Blue Component</key>
-    <real>0.9019607843137255</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 6 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5450980392156862</real>
-    <key>Green Component</key>
-    <real>0.8352941176470589</real>
-    <key>Blue Component</key>
-    <real>0.792156862745098</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 7 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6470588235294118</real>
-    <key>Green Component</key>
-    <real>0.6784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.796078431372549</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 8 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3568627450980392</real>
-    <key>Green Component</key>
-    <real>0.3764705882352941</real>
-    <key>Blue Component</key>
-    <real>0.47058823529411764</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 9 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9254901960784314</real>
-    <key>Green Component</key>
-    <real>0.4549019607843137</real>
-    <key>Blue Component</key>
-    <real>0.5254901960784314</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 10 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5490196078431373</real>
-    <key>Green Component</key>
-    <real>0.8117647058823529</real>
-    <key>Blue Component</key>
-    <real>0.4980392156862745</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 11 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.8823529411764706</real>
-    <key>Green Component</key>
-    <real>0.7764705882352941</real>
-    <key>Blue Component</key>
-    <real>0.5098039215686274</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 12 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.47058823529411764</real>
-    <key>Green Component</key>
-    <real>0.6313725490196078</real>
-    <key>Blue Component</key>
-    <real>0.9647058823529412</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 13 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9490196078431372</real>
-    <key>Green Component</key>
-    <real>0.6627450980392157</real>
-    <key>Blue Component</key>
-    <real>0.8666666666666667</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 14 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.38823529411764707</real>
-    <key>Green Component</key>
-    <real>0.796078431372549</real>
-    <key>Blue Component</key>
-    <real>0.7529411764705882</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 15 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7215686274509804</real>
-    <key>Green Component</key>
-    <real>0.7529411764705882</real>
-    <key>Blue Component</key>
-    <real>0.8784313725490196</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Background Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.1411764705882353</real>
-    <key>Green Component</key>
-    <real>0.15294117647058825</real>
-    <key>Blue Component</key>
-    <real>0.22745098039215686</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Foreground Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.792156862745098</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Link Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5686274509803921</real>
-    <key>Green Component</key>
-    <real>0.8431372549019608</real>
-    <key>Blue Component</key>
-    <real>0.8901960784313725</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Bold Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.792156862745098</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9568627450980393</real>
-    <key>Green Component</key>
-    <real>0.8588235294117647</real>
-    <key>Blue Component</key>
-    <real>0.8392156862745098</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.792156862745098</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Guide Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.792156862745098</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>0.07</real>
-  </dict>
-  <key>Selection Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.3568627450980392</real>
-    <key>Green Component</key>
-    <real>0.3764705882352941</real>
-    <key>Blue Component</key>
-    <real>0.47058823529411764</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Selected Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.792156862745098</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.9607843137254902</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.39215686274509803</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.30196078431372547</real>
+		<key>Red Component</key>
+		<real>0.28627450980392155</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5882352941176471</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5294117647058824</real>
+		<key>Red Component</key>
+		<real>0.9294117647058824</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4980392156862745</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8117647058823529</real>
+		<key>Red Component</key>
+		<real>0.5490196078431373</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5098039215686274</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7764705882352941</real>
+		<key>Red Component</key>
+		<real>0.8823529411764706</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9647058823529412</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6313725490196078</real>
+		<key>Red Component</key>
+		<real>0.47058823529411764</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8666666666666667</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6627450980392157</real>
+		<key>Red Component</key>
+		<real>0.9490196078431372</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7529411764705882</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.796078431372549</real>
+		<key>Red Component</key>
+		<real>0.38823529411764707</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8784313725490196</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7529411764705882</real>
+		<key>Red Component</key>
+		<real>0.7215686274509804</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5843137254901961</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8549019607843137</real>
+		<key>Red Component</key>
+		<real>0.6509803921568628</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6235294117647059</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8313725490196079</real>
+		<key>Red Component</key>
+		<real>0.9333333333333333</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9568627450980393</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6784313725490196</real>
+		<key>Red Component</key>
+		<real>0.5411764705882353</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9019607843137255</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7411764705882353</real>
+		<key>Red Component</key>
+		<real>0.9607843137254902</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.792156862745098</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8352941176470589</real>
+		<key>Red Component</key>
+		<real>0.5450980392156862</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.796078431372549</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6784313725490196</real>
+		<key>Red Component</key>
+		<real>0.6470588235294118</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.47058823529411764</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3764705882352941</real>
+		<key>Red Component</key>
+		<real>0.3568627450980392</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5254901960784314</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.4549019607843137</real>
+		<key>Red Component</key>
+		<real>0.9254901960784314</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.22745098039215686</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.15294117647058825</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.792156862745098</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8392156862745098</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8588235294117647</real>
+		<key>Red Component</key>
+		<real>0.9568627450980393</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.07</real>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.792156862745098</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.22745098039215686</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.15294117647058825</real>
+		<key>Red Component</key>
+		<real>0.1411764705882353</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.792156862745098</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8901960784313725</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8431372549019608</real>
+		<key>Red Component</key>
+		<real>0.5686274509803921</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9607843137254902</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.792156862745098</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.47058823529411764</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3764705882352941</real>
+		<key>Red Component</key>
+		<real>0.3568627450980392</real>
+	</dict>
 </dict>
 </plist>

--- a/schemes/catppuccin-mocha.itermcolors
+++ b/schemes/catppuccin-mocha.itermcolors
@@ -2,330 +2,330 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>Ansi 0 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.27058823529411763</real>
-    <key>Green Component</key>
-    <real>0.2784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.35294117647058826</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 1 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9529411764705882</real>
-    <key>Green Component</key>
-    <real>0.5450980392156862</real>
-    <key>Blue Component</key>
-    <real>0.6588235294117647</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 2 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6509803921568628</real>
-    <key>Green Component</key>
-    <real>0.8901960784313725</real>
-    <key>Blue Component</key>
-    <real>0.6313725490196078</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 3 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9764705882352941</real>
-    <key>Green Component</key>
-    <real>0.8862745098039215</real>
-    <key>Blue Component</key>
-    <real>0.6862745098039216</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 4 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5372549019607843</real>
-    <key>Green Component</key>
-    <real>0.7058823529411765</real>
-    <key>Blue Component</key>
-    <real>0.9803921568627451</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 5 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9607843137254902</real>
-    <key>Green Component</key>
-    <real>0.7607843137254902</real>
-    <key>Blue Component</key>
-    <real>0.9058823529411765</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 6 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8862745098039215</real>
-    <key>Blue Component</key>
-    <real>0.8352941176470589</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 7 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.6509803921568628</real>
-    <key>Green Component</key>
-    <real>0.6784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.7843137254901961</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 8 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.34509803921568627</real>
-    <key>Green Component</key>
-    <real>0.3568627450980392</real>
-    <key>Blue Component</key>
-    <real>0.4392156862745098</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 9 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9529411764705882</real>
-    <key>Green Component</key>
-    <real>0.4666666666666667</real>
-    <key>Blue Component</key>
-    <real>0.6</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 10 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5372549019607843</real>
-    <key>Green Component</key>
-    <real>0.8470588235294118</real>
-    <key>Blue Component</key>
-    <real>0.5450980392156862</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 11 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9215686274509803</real>
-    <key>Green Component</key>
-    <real>0.8274509803921568</real>
-    <key>Blue Component</key>
-    <real>0.5686274509803921</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 12 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.4549019607843137</real>
-    <key>Green Component</key>
-    <real>0.6588235294117647</real>
-    <key>Blue Component</key>
-    <real>0.9882352941176471</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 13 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9490196078431372</real>
-    <key>Green Component</key>
-    <real>0.6823529411764706</real>
-    <key>Blue Component</key>
-    <real>0.8705882352941177</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 14 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.4196078431372549</real>
-    <key>Green Component</key>
-    <real>0.8431372549019608</real>
-    <key>Blue Component</key>
-    <real>0.792156862745098</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Ansi 15 Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.7294117647058823</real>
-    <key>Green Component</key>
-    <real>0.7607843137254902</real>
-    <key>Blue Component</key>
-    <real>0.8705882352941177</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Background Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.11764705882352941</real>
-    <key>Green Component</key>
-    <real>0.11764705882352941</real>
-    <key>Blue Component</key>
-    <real>0.1803921568627451</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Foreground Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Link Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.5372549019607843</real>
-    <key>Green Component</key>
-    <real>0.8627450980392157</real>
-    <key>Blue Component</key>
-    <real>0.9215686274509803</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Bold Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.9607843137254902</real>
-    <key>Green Component</key>
-    <real>0.8784313725490196</real>
-    <key>Blue Component</key>
-    <real>0.8627450980392157</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Cursor Guide Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>0.07</real>
-  </dict>
-  <key>Selection Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.34509803921568627</real>
-    <key>Green Component</key>
-    <real>0.3568627450980392</real>
-    <key>Blue Component</key>
-    <real>0.4392156862745098</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
-  <key>Selected Text Color</key>
-  <dict>
-    <key>Color Space</key>
-    <string>sRGB</string>
-    <key>Red Component</key>
-    <real>0.803921568627451</real>
-    <key>Green Component</key>
-    <real>0.8392156862745098</real>
-    <key>Blue Component</key>
-    <real>0.9568627450980393</real>
-    <key>Alpha Component</key>
-    <real>1</real>
-  </dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.35294117647058826</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.2784313725490196</real>
+		<key>Red Component</key>
+		<real>0.27058823529411763</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6588235294117647</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5450980392156862</real>
+		<key>Red Component</key>
+		<real>0.9529411764705882</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5450980392156862</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8470588235294118</real>
+		<key>Red Component</key>
+		<real>0.5372549019607843</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.5686274509803921</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274509803921568</real>
+		<key>Red Component</key>
+		<real>0.9215686274509803</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9882352941176471</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6588235294117647</real>
+		<key>Red Component</key>
+		<real>0.4549019607843137</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8705882352941177</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6823529411764706</real>
+		<key>Red Component</key>
+		<real>0.9490196078431372</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.792156862745098</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8431372549019608</real>
+		<key>Red Component</key>
+		<real>0.4196078431372549</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8705882352941177</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7607843137254902</real>
+		<key>Red Component</key>
+		<real>0.7294117647058823</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6313725490196078</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8901960784313725</real>
+		<key>Red Component</key>
+		<real>0.6509803921568628</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6862745098039216</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8862745098039215</real>
+		<key>Red Component</key>
+		<real>0.9764705882352941</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9803921568627451</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7058823529411765</real>
+		<key>Red Component</key>
+		<real>0.5372549019607843</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9058823529411765</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7607843137254902</real>
+		<key>Red Component</key>
+		<real>0.9607843137254902</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8352941176470589</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8862745098039215</real>
+		<key>Red Component</key>
+		<real>0.5803921568627451</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.7843137254901961</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6784313725490196</real>
+		<key>Red Component</key>
+		<real>0.6509803921568628</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4392156862745098</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3568627450980392</real>
+		<key>Red Component</key>
+		<real>0.34509803921568627</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.6</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.4666666666666667</real>
+		<key>Red Component</key>
+		<real>0.9529411764705882</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.11764705882352941</real>
+		<key>Red Component</key>
+		<real>0.11764705882352941</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9568627450980393</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8392156862745098</real>
+		<key>Red Component</key>
+		<real>0.803921568627451</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.8627450980392157</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8784313725490196</real>
+		<key>Red Component</key>
+		<real>0.9607843137254902</real>
+	</dict>
+	<key>Cursor Guide Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>0.07</real>
+		<key>Blue Component</key>
+		<real>0.9568627450980393</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8392156862745098</real>
+		<key>Red Component</key>
+		<real>0.803921568627451</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.1803921568627451</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.11764705882352941</real>
+		<key>Red Component</key>
+		<real>0.11764705882352941</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9568627450980393</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8392156862745098</real>
+		<key>Red Component</key>
+		<real>0.803921568627451</real>
+	</dict>
+	<key>Link Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9215686274509803</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8627450980392157</real>
+		<key>Red Component</key>
+		<real>0.5372549019607843</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.9568627450980393</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8392156862745098</real>
+		<key>Red Component</key>
+		<real>0.803921568627451</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<integer>1</integer>
+		<key>Blue Component</key>
+		<real>0.4392156862745098</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3568627450980392</real>
+		<key>Red Component</key>
+		<real>0.34509803921568627</real>
+	</dict>
 </dict>
 </plist>

--- a/termframe/Dracula.toml
+++ b/termframe/Dracula.toml
@@ -1,24 +1,24 @@
-tags = ["dark"]
+tags = ["light"]
 
 [theme.colors]
-background = "#1e1f29"
-foreground = "#e6e6e6"
-bright-foreground = "#e6e6e6"
+background = "#282a36"
+foreground = "#f8f8f2"
+bright-foreground = "#f8f8f2"
 
 [theme.colors.palette]
-0 = "#000000"
+0 = "#21222c"
 1 = "#ff5555"
 2 = "#50fa7b"
 3 = "#f1fa8c"
 4 = "#bd93f9"
 5 = "#ff79c6"
 6 = "#8be9fd"
-7 = "#bbbbbb"
-8 = "#555555"
-9 = "#ff5555"
-10 = "#50fa7b"
-11 = "#f1fa8c"
-12 = "#bd93f9"
-13 = "#ff79c6"
-14 = "#8be9fd"
+7 = "#f8f8f2"
+8 = "#6272a4"
+9 = "#ff6e6e"
+10 = "#69ff94"
+11 = "#ffffa5"
+12 = "#d6acff"
+13 = "#ff92df"
+14 = "#a4ffff"
 15 = "#ffffff"

--- a/termframe/gruvbox-material.toml
+++ b/termframe/gruvbox-material.toml
@@ -3,7 +3,7 @@ tags = ["dark"]
 [theme.colors]
 background = "#1d2021"
 foreground = "#d4be98"
-bright-foreground = "#414694"
+bright-foreground = "#d4be98"
 
 [theme.colors.palette]
 0 = "#141617"

--- a/termite/catppuccin-frappe
+++ b/termite/catppuccin-frappe
@@ -1,7 +1,7 @@
 [colors]
 background = #303446
 cursor = #f2d5cf
-cursor_foreground = #c6d0f5
+cursor_foreground = #303446
 foreground = #c6d0f5
 color0 = #51576d
 color1 = #e78284

--- a/termite/catppuccin-latte
+++ b/termite/catppuccin-latte
@@ -1,7 +1,7 @@
 [colors]
 background = #eff1f5
 cursor = #dc8a78
-cursor_foreground = #4c4f69
+cursor_foreground = #eff1f5
 foreground = #4c4f69
 color0 = #5c5f77
 color1 = #d20f39

--- a/termite/catppuccin-macchiato
+++ b/termite/catppuccin-macchiato
@@ -1,7 +1,7 @@
 [colors]
 background = #24273a
 cursor = #f4dbd6
-cursor_foreground = #cad3f5
+cursor_foreground = #24273a
 foreground = #cad3f5
 color0 = #494d64
 color1 = #ed8796

--- a/termite/catppuccin-mocha
+++ b/termite/catppuccin-mocha
@@ -1,7 +1,7 @@
 [colors]
 background = #1e1e2e
 cursor = #f5e0dc
-cursor_foreground = #cdd6f4
+cursor_foreground = #1e1e2e
 foreground = #cdd6f4
 color0 = #45475a
 color1 = #f38ba8

--- a/vscode/catppuccin-frappe.json
+++ b/vscode/catppuccin-frappe.json
@@ -19,7 +19,7 @@
         "terminal.ansiBrightWhite": "#b5bfe2",
         "terminal.ansiBrightYellow": "#d9ba73",
         "terminal.selectionBackground": "#626880",
-        "terminalCursor.background": "#c6d0f5",
+        "terminalCursor.background": "#303446",
         "terminalCursor.foreground": "#f2d5cf"
     }
 }

--- a/vscode/catppuccin-latte.json
+++ b/vscode/catppuccin-latte.json
@@ -19,7 +19,7 @@
         "terminal.ansiBrightWhite": "#bcc0cc",
         "terminal.ansiBrightYellow": "#eea02d",
         "terminal.selectionBackground": "#acb0be",
-        "terminalCursor.background": "#4c4f69",
+        "terminalCursor.background": "#eff1f5",
         "terminalCursor.foreground": "#dc8a78"
     }
 }

--- a/vscode/catppuccin-macchiato.json
+++ b/vscode/catppuccin-macchiato.json
@@ -19,7 +19,7 @@
         "terminal.ansiBrightWhite": "#b8c0e0",
         "terminal.ansiBrightYellow": "#e1c682",
         "terminal.selectionBackground": "#5b6078",
-        "terminalCursor.background": "#cad3f5",
+        "terminalCursor.background": "#24273a",
         "terminalCursor.foreground": "#f4dbd6"
     }
 }

--- a/vscode/catppuccin-mocha.json
+++ b/vscode/catppuccin-mocha.json
@@ -19,7 +19,7 @@
         "terminal.ansiBrightWhite": "#bac2de",
         "terminal.ansiBrightYellow": "#ebd391",
         "terminal.selectionBackground": "#585b70",
-        "terminalCursor.background": "#cdd6f4",
+        "terminalCursor.background": "#1e1e2e",
         "terminalCursor.foreground": "#f5e0dc"
     }
 }

--- a/wezterm/catppuccin-frappe.toml
+++ b/wezterm/catppuccin-frappe.toml
@@ -4,7 +4,7 @@ foreground = "#c6d0f5"
 background = "#303446"
 cursor_bg = "#f2d5cf"
 cursor_border = "#f2d5cf"
-cursor_fg = "#c6d0f5"
+cursor_fg = "#303446"
 selection_bg = "#626880"
 selection_fg = "#c6d0f5"
 

--- a/wezterm/catppuccin-latte.toml
+++ b/wezterm/catppuccin-latte.toml
@@ -4,7 +4,7 @@ foreground = "#4c4f69"
 background = "#eff1f5"
 cursor_bg = "#dc8a78"
 cursor_border = "#dc8a78"
-cursor_fg = "#4c4f69"
+cursor_fg = "#eff1f5"
 selection_bg = "#acb0be"
 selection_fg = "#4c4f69"
 

--- a/wezterm/catppuccin-macchiato.toml
+++ b/wezterm/catppuccin-macchiato.toml
@@ -4,7 +4,7 @@ foreground = "#cad3f5"
 background = "#24273a"
 cursor_bg = "#f4dbd6"
 cursor_border = "#f4dbd6"
-cursor_fg = "#cad3f5"
+cursor_fg = "#24273a"
 selection_bg = "#5b6078"
 selection_fg = "#cad3f5"
 

--- a/wezterm/catppuccin-mocha.toml
+++ b/wezterm/catppuccin-mocha.toml
@@ -4,7 +4,7 @@ foreground = "#cdd6f4"
 background = "#1e1e2e"
 cursor_bg = "#f5e0dc"
 cursor_border = "#f5e0dc"
-cursor_fg = "#cdd6f4"
+cursor_fg = "#1e1e2e"
 selection_bg = "#585b70"
 selection_fg = "#cdd6f4"
 

--- a/xrdb/catppuccin-frappe.xrdb
+++ b/xrdb/catppuccin-frappe.xrdb
@@ -18,7 +18,7 @@
 #define Bold_Color #c6d0f5
 #define Cursor_Color #f2d5cf
 #define Cursor_Guide_Color #c6d0f5
-#define Cursor_Text_Color #c6d0f5
+#define Cursor_Text_Color #303446
 #define Foreground_Color #c6d0f5
 #define Link_Color #99d1db
 #define Selected_Text_Color #c6d0f5

--- a/xrdb/catppuccin-latte.xrdb
+++ b/xrdb/catppuccin-latte.xrdb
@@ -18,7 +18,7 @@
 #define Bold_Color #4c4f69
 #define Cursor_Color #dc8a78
 #define Cursor_Guide_Color #4c4f69
-#define Cursor_Text_Color #4c4f69
+#define Cursor_Text_Color #eff1f5
 #define Foreground_Color #4c4f69
 #define Link_Color #04a5e5
 #define Selected_Text_Color #4c4f69

--- a/xrdb/catppuccin-macchiato.xrdb
+++ b/xrdb/catppuccin-macchiato.xrdb
@@ -18,7 +18,7 @@
 #define Bold_Color #cad3f5
 #define Cursor_Color #f4dbd6
 #define Cursor_Guide_Color #cad3f5
-#define Cursor_Text_Color #cad3f5
+#define Cursor_Text_Color #24273a
 #define Foreground_Color #cad3f5
 #define Link_Color #91d7e3
 #define Selected_Text_Color #cad3f5

--- a/xrdb/catppuccin-mocha.xrdb
+++ b/xrdb/catppuccin-mocha.xrdb
@@ -18,7 +18,7 @@
 #define Bold_Color #cdd6f4
 #define Cursor_Color #f5e0dc
 #define Cursor_Guide_Color #cdd6f4
-#define Cursor_Text_Color #cdd6f4
+#define Cursor_Text_Color #1e1e2e
 #define Foreground_Color #cdd6f4
 #define Link_Color #89dceb
 #define Selected_Text_Color #cdd6f4


### PR DESCRIPTION
## Description

The catppuccin color scheme should be sourced directly from https://github.com/catppuccin/iterm. This will ensure color palette changes, as well as particular color choices (e.g., cursor text color) are kept in sync with the latest style guide at
https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md.

The current cursor text color does not match the canonical color scheme and makes the cursor text unintelligible. This commit fixes the issue.

Before:
![catppuccin-iterm-before](https://github.com/user-attachments/assets/5f910c91-4a10-4f30-8ab6-30a72f31d3f3)

After:
![catppuccin-iterm-after](https://github.com/user-attachments/assets/95674651-077b-4503-9066-0b711ab07db0)

### Theme Submission Checklist

- [x] Included theme in iTerm2 format
- [x] Included 600x300 screenshot, 13pt Monaco font, no transparency
- [x] Updated `README.md` with new theme and screenshot
- [x] Updated `CREDITS.md` with new theme
- [x] Ran `tools/gen.py` to generate themes in all formats
- [x] Updated `screenshots/README.md` with new theme