### PR TITLE
fix(tools): add missing YAML name map for the `badge` key

### DIFF
--- a/tools/gen.py
+++ b/tools/gen.py
@@ -212,6 +212,7 @@ yaml_to_iterm_color_name_map = {
     "selection_text": "Selected Text Color",
     "tab": "Tab Color",
     "underline": "Underline Color",
+    "badge": "Badge Color",
 }
 
 fallback_color_map = {


### PR DESCRIPTION
[According to the docs](https://github.com/mbadolato/iTerm2-Color-Schemes/blob/6c7a24bb2e4506f55f7898bf42175be0aa128dd2/yaml/README.md?plain=1#L7-L11), the YAML format is supposed to support the extra `badge` key, but the corresponding YAML-to-iTerm name map was missing. This resulted in an error and the `badge` color not actually being converted to other formats.