### PR TITLE
fixes preview.rb's use of renamed ruby method File.exist(s)?

### DIFF
--- a/tools/preview.rb
+++ b/tools/preview.rb
@@ -9,7 +9,7 @@
 require 'rexml/document'
 require 'io/console'
 
-files = ARGV.select { |f| File.exists? f }
+files = ARGV.select { |f| File.exist? f }
 if files.empty?
   puts "usage: #$0 <itermcolors files...>"
   exit 1


### PR DESCRIPTION
`File.exists?` has been deprecated, then removed, in [recent ruby versions](https://github.com/ruby/ruby/blob/d9efc56c16267fabcfc764fd27cf4e464a231a76/doc/NEWS/NEWS-3.2.0.md?plain=1#L589).

## Description

Fails with `missing method "exists?"` in the most recent `ruby 3.5.0preview1`, and probably earlier/currently stable versions, as well. In any case, the change to `.exist?` works for anything released since the Obama administration.

thx for your work 🦫,
karl

> [!NOTE]
> timeline for illustrative purposes only; no specific sequencing of _Obama Term 1/  Term 2_ and _iTerm / iTerm2_ is implied.  

