### PR TITLE
fix: sync ghostty catppuccin themes with upstream

### DIFF
--- a/ghostty/catppuccin-frappe
+++ b/ghostty/catppuccin-frappe
@@ -5,7 +5,7 @@ palette = 3=#e5c890
 palette = 4=#8caaee
 palette = 5=#f4b8e4
 palette = 6=#81c8be
-palette = 7=#b5bfe2
+palette = 7=#a5adce
 palette = 8=#626880
 palette = 9=#e78284
 palette = 10=#a6d189
@@ -13,7 +13,7 @@ palette = 11=#e5c890
 palette = 12=#8caaee
 palette = 13=#f4b8e4
 palette = 14=#81c8be
-palette = 15=#a5adce
+palette = 15=#b5bfe2
 background = 303446
 foreground = c6d0f5
 cursor-color = f2d5cf

--- a/ghostty/catppuccin-macchiato
+++ b/ghostty/catppuccin-macchiato
@@ -5,7 +5,7 @@ palette = 3=#eed49f
 palette = 4=#8aadf4
 palette = 5=#f5bde6
 palette = 6=#8bd5ca
-palette = 7=#b8c0e0
+palette = 7=#a5adcb
 palette = 8=#5b6078
 palette = 9=#ed8796
 palette = 10=#a6da95
@@ -13,7 +13,7 @@ palette = 11=#eed49f
 palette = 12=#8aadf4
 palette = 13=#f5bde6
 palette = 14=#8bd5ca
-palette = 15=#a5adcb
+palette = 15=#b8c0e0
 background = 24273a
 foreground = cad3f5
 cursor-color = f4dbd6

--- a/ghostty/catppuccin-mocha
+++ b/ghostty/catppuccin-mocha
@@ -5,7 +5,7 @@ palette = 3=#f9e2af
 palette = 4=#89b4fa
 palette = 5=#f5c2e7
 palette = 6=#94e2d5
-palette = 7=#bac2de
+palette = 7=#a6adc8
 palette = 8=#585b70
 palette = 9=#f38ba8
 palette = 10=#a6e3a1
@@ -13,7 +13,7 @@ palette = 11=#f9e2af
 palette = 12=#89b4fa
 palette = 13=#f5c2e7
 palette = 14=#94e2d5
-palette = 15=#a6adc8
+palette = 15=#bac2de
 background = 1e1e2e
 foreground = cdd6f4
 cursor-color = f5e0dc


### PR DESCRIPTION
## Description

https://github.com/catppuccin/ghostty/pull/15 fixes a typo in ANSI `color7` and `color15`, and this includes that fix.

Continuation of https://github.com/mbadolato/iTerm2-Color-Schemes/pull/572.

### Theme Submission Checklist

<!-- If your pull request is to submit a new theme, or to update an existing one, please ensure all the steps in the checklist have been completed. If it is not a theme submission, you can delete the section below. -->

- [ ] Included theme in iTerm2 format
- [ ] Included 600x300 screenshot, 13pt Monaco font, no transparency
- [ ] Updated `README.md` with new theme and screenshot
- [ ] Updated `CREDITS.md` with new theme
- [ ] Ran `tools/gen.py` to generate themes in all formats
- [ ] Updated `screenshots/README.md` with new theme
