### PR TITLE
Generate all workflow

### DIFF
--- a/.github/workflows/generate-all.yml
+++ b/.github/workflows/generate-all.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 14 * * 1" # Run every Monday at 14:00 UTC
+  push:
+    branches:
+      - master
+    paths:
+      - "schemes/**"
+      - "yaml/**"
 
 jobs:
   generate-themes:


### PR DESCRIPTION
This adds a workflow to generate all schemes, screenshots, and screenshots/README.md

It can be run on demand via actions, but will automatically run every monday at 14:00 UTC (9am eastern standard time), or when a change in master yaml/** or schemes/** is detected.
