### PR TITLE
Generate screenshots readme

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,3 @@
 ## Description
 
 Explain the nature of your pull request here
-
-### Theme Submission Checklist
-
-<!-- If your pull request is to submit a new theme, or to update an existing one, please ensure all the steps in the checklist have been completed. If it is not a theme submission, you can delete the section below. -->
-
-- [ ] Included theme in iTerm2 format
-- [ ] Included 600x300 screenshot, 13pt Monaco font, no transparency
-- [ ] Updated `README.md` with new theme and screenshot
-- [ ] Updated `CREDITS.md` with new theme
-- [ ] Ran `tools/gen.py` to generate themes in all formats
-- [ ] Updated `screenshots/README.md` with new theme

--- a/README.md
+++ b/README.md
@@ -219,1659 +219,1678 @@ Do you want to convert existing iTerm themes to themes for your favorite termina
 
 ## Screenshots
 
+The screenshots are categorized.
+
+- [Dark Themes](#darkthemes)
+- [Light Themes](#lightthemes)
+
+### Dark Themes<a name="darkthemes"><a/>
+
 ### 0x96f
 
-![Screenshot](screenshots/0x96f.png)
+![Screenshot](/screenshots/0x96f.png)
 
 ### 12-bit Rainbow
 
-![Screenshot](screenshots/12-bit_rainbow.png)
-
-### 3024 Day
-
-![Screenshot](screenshots/3024_day.png)
+![Screenshot](/screenshots/12-bit_rainbow.png)
 
 ### 3024 Night
 
-![Screenshot](screenshots/3024_night.png)
+![Screenshot](/screenshots/3024_night.png)
 
 ### Aardvark Blue
 
-![Screenshot](screenshots/aardvark_blue.png)
+![Screenshot](/screenshots/aardvark_blue.png)
 
 ### Abernathy
 
-![Screenshot](screenshots/abernathy.png)
+![Screenshot](/screenshots/abernathy.png)
 
 ### Adventure
 
-![Screenshot](screenshots/adventure.png)
+![Screenshot](/screenshots/adventure.png)
 
 ### AdventureTime
 
-![Screenshot](screenshots/adventure_time.png)
+![Screenshot](/screenshots/adventure_time.png)
 
 ### Adwaita Dark
 
-![Screenshot](screenshots/adwaita_dark.png)
-
-### Adwaita
-
-![Screenshot](screenshots/adwaita.png)
+![Screenshot](/screenshots/adwaita_dark.png)
 
 ### Afterglow
 
-![Screenshot](screenshots/afterglow.png)
-
-### Alabaster
-
-![Screenshot](screenshots/alabaster.png)
+![Screenshot](/screenshots/afterglow.png)
 
 ### AlienBlood
 
-![Screenshot](screenshots/alien_blood.png)
+![Screenshot](/screenshots/alien_blood.png)
 
 ### Andromeda
 
-![Screenshot](screenshots/andromeda.png)
+![Screenshot](/screenshots/andromeda.png)
 
 ### Apple Classic
 
-![Screenshot](screenshots/apple-classic.png)
+![Screenshot](/screenshots/apple-classic.png)
 
 ### Apple System Colors
 
-![Screenshot](screenshots/apple-system-colors.png)
+![Screenshot](/screenshots/apple-system-colors.png)
 
-### Apple System Colors Light
+### arcoiris
 
-![Screenshot](screenshots/apple_system_colors_light.png)
-
-### Arcoiris
-
-![Screenshot](screenshots/arcoiris.png)
+![Screenshot](/screenshots/arcoiris.png)
 
 ### Ardoise
 
-![Screenshot](screenshots/ardoise.png)
+![Screenshot](/screenshots/ardoise.png)
 
 ### Argonaut
 
-![Screenshot](screenshots/argonaut.png)
+![Screenshot](/screenshots/argonaut.png)
 
 ### Arthur
 
-![Screenshot](screenshots/arthur.png)
+![Screenshot](/screenshots/arthur.png)
 
 ### AtelierSulphurpool
 
-![Screenshot](screenshots/atelier-sulphurpool_dark.png)
+![Screenshot](/screenshots/atelier-sulphurpool_dark.png)
 
 ### Atom
 
-![Screenshot](screenshots/atom.png)
+![Screenshot](/screenshots/atom.png)
 
-### Atom One Dark
+### AtomOneDark
 
-![Screenshot](screenshots/atom_one_dark.png)
-
-### Atom One Light
-
-![Screenshot](screenshots/atom_one_light.png)
-
-### ayu
-
-![Screenshot](screenshots/ayu.png)
-
-### ayu Light
-
-![Screenshot](screenshots/ayu_light.png)
-
-### ayu Mirage
-
-![Screenshot](screenshots/ayu_mirage.png)
+![Screenshot](/screenshots/atom_one_dark.png)
 
 ### Aura
 
-![Screenshot](screenshots/aura.png)
+![Screenshot](/screenshots/aura.png)
 
 ### Aurora
 
-![Screenshot](screenshots/aurora.png)
+![Screenshot](/screenshots/aurora.png)
+
+### Ayu Mirage
+
+![Screenshot](/screenshots/ayu_mirage.png)
+
+### ayu
+
+![Screenshot](/screenshots/ayu.png)
 
 ### Banana Blueberry
 
-![Screenshot](screenshots/banana_blueberry.png)
+![Screenshot](/screenshots/banana_blueberry.png)
 
 ### Batman
 
-![Screenshot](screenshots/batman.png)
-
-### Belafonte Day
-
-![Screenshot](screenshots/belafonte_day.png)
+![Screenshot](/screenshots/batman.png)
 
 ### Belafonte Night
 
-![Screenshot](screenshots/belafonte_night.png)
+![Screenshot](/screenshots/belafonte_night.png)
 
 ### BirdsOfParadise
 
-![Screenshot](screenshots/birds_of_paradise.png)
+![Screenshot](/screenshots/birds_of_paradise.png)
 
 ### Black Metal (Bathory)
 
-![Screenshot](screenshots/black_metal_bathory.png)
+![Screenshot](/screenshots/black_metal_bathory.png)
 
 ### Black Metal (Burzum)
 
-![Screenshot](screenshots/black_metal_burzum.png)
+![Screenshot](/screenshots/black_metal_burzum.png)
 
 ### Black Metal (Dark Funeral)
 
-![Screenshot](screenshots/black_metal_dark_funeral.png)
+![Screenshot](/screenshots/black_metal_dark_funeral.png)
 
 ### Black Metal (Gorgoroth)
 
-![Screenshot](screenshots/black_metal_gorgoroth.png)
+![Screenshot](/screenshots/black_metal_gorgoroth.png)
 
 ### Black Metal (Immortal)
 
-![Screenshot](screenshots/black_metal_immortal.png)
+![Screenshot](/screenshots/black_metal_immortal.png)
 
 ### Black Metal (Khold)
 
-![Screenshot](screenshots/black_metal_khold.png)
+![Screenshot](/screenshots/black_metal_khold.png)
 
 ### Black Metal (Marduk)
 
-![Screenshot](screenshots/black_metal_marduk.png)
+![Screenshot](/screenshots/black_metal_marduk.png)
 
 ### Black Metal (Mayhem)
 
-![Screenshot](screenshots/black_metal_mayhem.png)
+![Screenshot](/screenshots/black_metal_mayhem.png)
 
 ### Black Metal (Nile)
 
-![Screenshot](screenshots/black_metal_nile.png)
+![Screenshot](/screenshots/black_metal_nile.png)
 
 ### Black Metal (Venom)
 
-![Screenshot](screenshots/black_metal_venom.png)
+![Screenshot](/screenshots/black_metal_venom.png)
 
 ### Black Metal
 
-![Screenshot](screenshots/black_metal.png)
+![Screenshot](/screenshots/black_metal.png)
 
 ### Blazer
 
-![Screenshot](screenshots/blazer.png)
-
-### BlueBerry Pie
-
-![Screenshot](screenshots/blueberry_pie.png)
-
-### BlueDolphin
-
-![Screenshot](screenshots/BlueDolphin.png)
+![Screenshot](/screenshots/blazer.png)
 
 ### Blue Matrix
 
-![Screenshot](screenshots/blue_matrix.png)
+![Screenshot](/screenshots/blue_matrix.png)
 
-### Bluloco Dark
+### BlueBerryPie
 
-![Screenshot](screenshots/bluloco_dark.png)
+![Screenshot](/screenshots/blueberry_pie.png)
 
-### Bluloco Light
+### BlueDolphin
 
-![Screenshot](screenshots/bluloco_light.png)
+![Screenshot](/screenshots/BlueDolphin.png)
+
+### BlulocoDark
+
+![Screenshot](/screenshots/bluloco_dark.png)
 
 ### Borland
 
-![Screenshot](screenshots/borland.png)
+![Screenshot](/screenshots/borland.png)
 
 ### Box
 
-![Screenshot](screenshots/box.png)
-
-### Breadog
-
-![Screenshot](screenshots/breadog.png)
+![Screenshot](/screenshots/box.png)
 
 ### Breeze
 
-![Screenshot](screenshots/breeze.png)
+![Screenshot](/screenshots/breeze.png)
 
 ### Bright Lights
 
-![Screenshot](screenshots/bright_lights.png)
+![Screenshot](/screenshots/bright_lights.png)
 
 ### Broadcast
 
-![Screenshot](screenshots/broadcast.png)
+![Screenshot](/screenshots/broadcast.png)
 
 ### Brogrammer
 
-![Screenshot](screenshots/brogrammer.png)
+![Screenshot](/screenshots/brogrammer.png)
 
 ### C64
 
-![Screenshot](screenshots/c64.png)
+![Screenshot](/screenshots/c64.png)
 
 ### Calamity
 
-![Screenshot](screenshots/calamity.png)
+![Screenshot](/screenshots/calamity.png)
 
-### Catppuccin Frappé
+### catppuccin-frappe
 
-![Screenshot](screenshots/catppuccin-frappe.png)
+![Screenshot](/screenshots/catppuccin-frappe.png)
 
-### Catppuccin Latte
+### catppuccin-macchiato
 
-![Screenshot](screenshots/catppuccin-latte.png)
+![Screenshot](/screenshots/catppuccin-macchiato.png)
 
-### Catppuccin Macchiato
+### catppuccin-mocha
 
-![Screenshot](screenshots/catppuccin-macchiato.png)
-
-### Catppuccin Mocha
-
-![Screenshot](screenshots/catppuccin-mocha.png)
+![Screenshot](/screenshots/catppuccin-mocha.png)
 
 ### CGA
 
-![Screenshot](screenshots/cga.png)
+![Screenshot](/screenshots/cga.png)
 
 ### Chalk
 
-![Screenshot](screenshots/chalk.png)
+![Screenshot](/screenshots/chalk.png)
 
 ### Chalkboard
 
-![Screenshot](screenshots/chalkboard.png)
+![Screenshot](/screenshots/chalkboard.png)
 
 ### ChallengerDeep
 
-![Screenshot](screenshots/challenger_deep.png)
+![Screenshot](/screenshots/challenger_deep.png)
 
 ### Chester
 
-![Screenshot](screenshots/chester.png)
+![Screenshot](/screenshots/chester.png)
 
 ### Ciapre
 
-![Screenshot](screenshots/ciapre.png)
+![Screenshot](/screenshots/ciapre.png)
 
-### Citruszest
+### citruszest
 
-![Screenshot](screenshots/citruszest.png)
-
-### CLRS
-
-![Screenshot](screenshots/clrs.png)
+![Screenshot](/screenshots/citruszest.png)
 
 ### Cobalt Neon
 
-![Screenshot](screenshots/cobalt_neon.png)
+![Screenshot](/screenshots/cobalt_neon.png)
 
 ### Cobalt2
 
-![Screenshot](screenshots/cobalt2.png)
+![Screenshot](/screenshots/cobalt2.png)
 
-### Coffee
+### CobaltNext-Dark
 
-![Screenshot](screenshots/Coffee.png)
+![Screenshot](/screenshots/cobalt_next-dark.png)
+
+### CobaltNext-Minimal
+
+![Screenshot](/screenshots/cobalt_next-minimal.png)
+
+### CobaltNext
+
+![Screenshot](/screenshots/cobalt_next.png)
 
 ### CrayonPonyFish
 
+![Screenshot](/screenshots/crayon_pony_fish.png)
+
 ### CutiePro
 
-![Screenshot](screenshots/CutiePro.png)
-
-![Screenshot](screenshots/crayon_pony_fish.png)
+![Screenshot](/screenshots/CutiePro.png)
 
 ### Cyberdyne
 
-![Screenshot](screenshots/cyberdyne.png)
+![Screenshot](/screenshots/cyberdyne.png)
 
-### Cyberpunk
+### cyberpunk
 
-![Screenshot](screenshots/cyberpunk.png)
+![Screenshot](/screenshots/cyberpunk.png)
 
-### Cyberpunk Scarlet Protocol
+### CyberpunkScarletProtocol
 
-![Screenshot](screenshots/cyberpunk_scarlet_protocol.png)
+![Screenshot](/screenshots/cyberpunk_scarlet_protocol.png)
 
 ### Dark Modern
 
-![Screenshot](screenshots/dark_modern.png)
+![Screenshot](/screenshots/dark_modern.png)
 
 ### Dark Pastel
 
-![Screenshot](screenshots/dark_pastel.png)
+![Screenshot](/screenshots/dark_pastel.png)
 
 ### Dark+
 
-![Screenshot](screenshots/dark_plus.png)
+![Screenshot](/screenshots/dark_plus.png)
+
+### darkermatrix
+
+![Screenshot](/screenshots/darkermatrix.png)
+
+### darkmatrix
+
+![Screenshot](/screenshots/darkmatrix.png)
 
 ### Darkside
 
-![Screenshot](screenshots/darkside.png)
+![Screenshot](/screenshots/darkside.png)
 
-### Dayfox
+### deep
 
-![Screenshot](screenshots/dayfox.png)
-
-### Deep
-
-![Screenshot](screenshots/deep.png)
+![Screenshot](/screenshots/deep.png)
 
 ### Desert
 
-![Screenshot](screenshots/desert.png)
+![Screenshot](/screenshots/desert.png)
 
-### Detuned
+### detuned
 
-![Screenshot](screenshots/detuned.png)
+![Screenshot](/screenshots/detuned.png)
 
 ### Dimidium
 
-![Screenshot](screenshots/dimidium.png)
+![Screenshot](/screenshots/dimidium.png)
 
 ### DimmedMonokai
 
-![Screenshot](screenshots/dimmed_monokai.png)
+![Screenshot](/screenshots/dimmed_monokai.png)
 
 ### Django
 
-![Screenshot](screenshots/django.png)
+![Screenshot](/screenshots/django.png)
 
 ### DjangoRebornAgain
 
-![Screenshot](screenshots/DjangoRebornAgain.png)
+![Screenshot](/screenshots/DjangoRebornAgain.png)
 
-### DjangoSmoothy
+### DjangoSmooth
 
-![Screenshot](screenshots/DjangoSmoothy.png)
-
-### Doom One
-
-![Screenshot](screenshots/doom_one.png)
+![Screenshot](/screenshots/DjangoSmoothy.png)
 
 ### Doom Peacock
 
-![Screenshot](screenshots/doom_peacock.png)
+![Screenshot](/screenshots/doom_peacock.png)
+
+### DoomOne
+
+![Screenshot](/screenshots/doom_one.png)
 
 ### DotGov
 
-![Screenshot](screenshots/dot_gov.png)
-
-### Dracula
-
-![Screenshot](screenshots/dracula.png)
+![Screenshot](/screenshots/dot_gov.png)
 
 ### Dracula+
 
-![Screenshot](screenshots/dracula+.png)
+![Screenshot](/screenshots/dracula+.png)
 
-### Duckbones
+### Dracula
 
-![Screenshot](screenshots/duckbones.png)
+![Screenshot](/screenshots/dracula.png)
+
+### duckbones
+
+![Screenshot](/screenshots/duckbones.png)
 
 ### Duotone Dark
 
-![Screenshot](screenshots/duotone_dark.png)
+![Screenshot](/screenshots/duotone_dark.png)
 
 ### Earthsong
 
-![Screenshot](screenshots/earthsong.png)
+![Screenshot](/screenshots/earthsong.png)
 
-### Electron Highlighter
+### electron-highlighter
 
-![Screenshot](screenshots/electron-highlighter.png)
+![Screenshot](/screenshots/electron-highlighter.png)
 
 ### Elegant
 
-![Screenshot](screenshots/elegant.png)
+![Screenshot](/screenshots/elegant.png)
 
 ### Elemental
 
-![Screenshot](screenshots/elemental.png)
+![Screenshot](/screenshots/elemental.png)
 
 ### Elementary
 
-![Screenshot](screenshots/elementary.png)
+![Screenshot](/screenshots/elementary.png)
 
-### Embers
+### Embark
 
-![Screenshot](screenshots/embers.png)
+![Screenshot](/screenshots/embark.png)
+
+### embers-dark
+
+![Screenshot](/screenshots/embers.png)
 
 ### ENCOM
 
-![Screenshot](screenshots/encom.png)
-
-### Espresso
-
-![Screenshot](screenshots/espresso.png)
+![Screenshot](/screenshots/encom.png)
 
 ### Espresso Libre
 
-![Screenshot](screenshots/espresso_libre.png)
+![Screenshot](/screenshots/espresso_libre.png)
+
+### Espresso
+
+![Screenshot](/screenshots/espresso.png)
 
 ### Everblush
 
-![Screenshot](screenshots/everblush.png)
+![Screenshot](/screenshots/everblush.png)
 
 ### Everforest Dark - Hard
 
-![Screenshot](screenshots/everforest_dark_hard.png)
-
-### Everforest Light - Med
-
-![Screenshot](screenshots/everforest_light_med.png)
-
-### Fairyfloss
-
-![Screenshot](screenshots/fairyfloss.png)
+![Screenshot](/screenshots/everforest_dark_hard.png)
 
 ### Fahrenheit
 
-![Screenshot](screenshots/fahrenheit.png)
+![Screenshot](/screenshots/fahrenheit.png)
 
-### Farmhouse Dark
+### Fairyfloss
 
-![Screenshot](screenshots/farmhouse-dark.png)
+![Screenshot](/screenshots/fairyfloss.png)
 
-### Farmhouse Light
+### farmhouse-dark
 
-![Screenshot](screenshots/farmhouse-light.png)
+![Screenshot](/screenshots/farmhouse-dark.png)
 
 ### Fideloper
 
-![Screenshot](screenshots/fideloper.png)
+![Screenshot](/screenshots/fideloper.png)
 
 ### Firefly Traditional
 
-![Screenshot](screenshots/firefly-traditional.png)
+![Screenshot](/screenshots/firefly-traditional.png)
 
 ### FirefoxDev
 
-![Screenshot](screenshots/firefox_dev.png)
+![Screenshot](/screenshots/firefox_dev.png)
 
 ### Firewatch
 
-![Screenshot](screenshots/firewatch.png)
+![Screenshot](/screenshots/firewatch.png)
 
 ### FishTank
 
-![Screenshot](screenshots/fish_tank.png)
+![Screenshot](/screenshots/fish_tank.png)
 
 ### Flat
 
-![Screenshot](screenshots/flat.png)
+![Screenshot](/screenshots/flat.png)
 
 ### Flatland
 
-![Screenshot](screenshots/flatland.png)
+![Screenshot](/screenshots/flatland.png)
 
-### Flexoki Dark
+### flexoki-dark
 
-![Screenshot](screenshots/flexoki-dark.png)
-
-### Flexoki Light
-
-![Screenshot](screenshots/flexoki-light.png)
+![Screenshot](/screenshots/flexoki-dark.png)
 
 ### Floraverse
 
-![Screenshot](screenshots/floraverse.png)
+![Screenshot](/screenshots/floraverse.png)
 
-### Forest Blue
+### ForestBlue
 
-![Screenshot](screenshots/forest_blue.png)
+![Screenshot](/screenshots/forest_blue.png)
 
 ### Framer
 
-![Screenshot](screenshots/framer.png)
+![Screenshot](/screenshots/framer.png)
 
 ### FrontEndDelight
 
-![Screenshot](screenshots/front_end_delight.png)
+![Screenshot](/screenshots/front_end_delight.png)
 
 ### FunForrest
 
-![Screenshot](screenshots/fun_forrest.png)
+![Screenshot](/screenshots/fun_forrest.png)
 
 ### Galaxy
 
-![Screenshot](screenshots/galaxy.png)
+![Screenshot](/screenshots/galaxy.png)
 
 ### Galizur
 
-![image](screenshots/galizur.png)
+![Screenshot](/screenshots/galizur.png)
 
 ### Ghostty Default StyleDark
 
-![image](screenshots/Ghostty_Default_StyleDark.png)
-
-### GitHub Dark Default
-
-![image](screenshots/github-dark-default.png)
-
-### GitHub Dark Dimmed
-
-![image](screenshots/github-dark-dimmed.png)
-
-### GitHub Dark Colorblind
-
-![image](screenshots/github-dark-colorblind.png)
-
-### GitHub Dark High Contrast
-
-![image](screenshots/github-dark-high-contrast.png)
-
-### GitHub Light Default
-
-![image](screenshots/github-light-default.png)
-
-### GitHub Light Colorblind
-
-![image](screenshots/github-light-colorblind.png)
-
-### GitHub Light High Contrast
-
-![image](screenshots/github-light-high-contrast.png)
-
-### Github
-
-![Screenshot](screenshots/github.png)
+![Screenshot](/screenshots/ghostty_default_style_dark.png)
 
 ### GitHub Dark
 
-![Screenshot](screenshots/github_dark.png)
+![Screenshot](/screenshots/github_dark.png)
 
-### GitLab Dark
+### GitHub-Dark-Colorblind
 
-![Screenshot](screenshots/git_lab-dark.png)
+![Screenshot](/screenshots/github-dark-colorblind.png)
 
-### GitLab Dark Grey
+### GitHub-Dark-Default
 
-![Screenshot](screenshots/git_lab-dark-grey.png)
+![Screenshot](/screenshots/github-dark-default.png)
 
-### GitLab Light
+### GitHub-Dark-Dimmed
 
-![Screenshot](screenshots/git_lab-light.png)
+![Screenshot](/screenshots/github-dark-dimmed.png)
+
+### GitHub-Dark-High-Contrast
+
+![Screenshot](/screenshots/github-dark-high-contrast.png)
+
+### GitLab-Dark-Grey
+
+![Screenshot](/screenshots/git_lab-dark-grey.png)
+
+### GitLab-Dark
+
+![Screenshot](/screenshots/git_lab-dark.png)
 
 ### Glacier
 
-![Screenshot](screenshots/glacier.png)
+![Screenshot](/screenshots/glacier.png)
 
 ### Grape
 
-![Screenshot](screenshots/grape.png)
+![Screenshot](/screenshots/grape.png)
 
 ### Grass
 
-![Screenshot](screenshots/grass.png)
+![Screenshot](/screenshots/grass.png)
 
 ### Grey-green
 
-![Screenshot](screenshots/grey-green.png)
+![Screenshot](/screenshots/grey-green.png)
 
-### Gruber Darker
+### gruber-darker
 
-![Screenshot](screenshots/gruber-darker.png)
+![Screenshot](/screenshots/gruber-darker.png)
 
-### Gruvbox Dark
+### gruvbox-material
 
-![Screenshot](screenshots/gruvbox_dark.png)
+![Screenshot](/screenshots/gruvbox_material.png)
 
-### Gruvbox Dark Hard
+### GruvboxDark
 
-![Screenshot](screenshots/gruvbox_dark_hard.png)
+![Screenshot](/screenshots/gruvbox_dark.png)
 
-### Gruvbox Light
+### GruvboxDarkHard
 
-![Screenshot](screenshots/gruvbox_light.png)
-
-### Gruvbox Light Hard
-
-![Screenshot](screenshots/gruvbox_light_hard.png)
-
-### gruvbox_material
-
-![Screenshot](screenshots/gruvbox_material.png)
+![Screenshot](/screenshots/gruvbox_dark_hard.png)
 
 ### Guezwhoz
 
-![Screenshot](screenshots/guezwhoz.png)
+![Screenshot](/screenshots/guezwhoz.png)
 
 ### Hacktober
 
-![Screenshot](screenshots/hacktober.png)
+![Screenshot](/screenshots/hacktober.png)
 
 ### Hardcore
 
-![Screenshot](screenshots/hardcore.png)
+![Screenshot](/screenshots/hardcore.png)
 
 ### Harper
 
-![Screenshot](screenshots/harper.png)
-
-### Havn Daggry
-
-![Screenshot](screenshots/havn_daggry.png)
+![Screenshot](/screenshots/harper.png)
 
 ### Havn Skumring
 
-![Screenshot](screenshots/havn_skumring.png)
-
-### HaX0R_R3D
-
-![Screenshot](screenshots/hax0r_r3d.png)
-
-### HaX0R_GR33N
-
-![Screenshot](screenshots/hax0r_gr33n.png)
+![Screenshot](/screenshots/havn_skumring.png)
 
 ### HaX0R_BLUE
 
-![Screenshot](screenshots/hax0r_blue.png)
+![Screenshot](/screenshots/hax0r_blue.png)
+
+### HaX0R_GR33N
+
+![Screenshot](/screenshots/hax0r_gr33n.png)
+
+### HaX0R_R3D
+
+![Screenshot](/screenshots/hax0r_r3d.png)
 
 ### heeler
 
-![Screenshot](screenshots/heeler.png)
+![Screenshot](/screenshots/heeler.png)
 
 ### Highway
 
-![Screenshot](screenshots/highway.png)
+![Screenshot](/screenshots/highway.png)
 
 ### Hipster Green
 
-![Screenshot](screenshots/hipster_green.png)
+![Screenshot](/screenshots/hipster_green.png)
 
 ### Hivacruz
 
-![Screenshot](screenshots/hivacruz.png)
+![Screenshot](/screenshots/hivacruz.png)
 
 ### Homebrew
 
-![Screenshot](screenshots/homebrew.png)
+![Screenshot](/screenshots/homebrew.png)
+
+### Hopscotch.256
+
+![Screenshot](/screenshots/hopscotch_256.png)
 
 ### Hopscotch
 
-![Screenshot](screenshots/hopscotch.png)
-
-### Hopscotch 256
-
-![Screenshot](screenshots/hopscotch_256.png)
+![Screenshot](/screenshots/hopscotch.png)
 
 ### Horizon
 
-![Screenshot](screenshots/horizon.png)
-
-### Horizon Bright
-
-![Screenshot](screenshots/horizon-bright.png)
+![Screenshot](/screenshots/horizon.png)
 
 ### Hurtado
 
-![Screenshot](screenshots/hurtado.png)
+![Screenshot](/screenshots/hurtado.png)
 
 ### Hybrid
 
-![Screenshot](screenshots/hybrid.png)
+![Screenshot](/screenshots/hybrid.png)
 
 ### IC_Green_PPL
 
-![Screenshot](screenshots/ic_green_ppl.png)
+![Screenshot](/screenshots/ic_green_ppl.png)
 
 ### IC_Orange_PPL
 
-![Screenshot](screenshots/ic_orange_ppl.png)
+![Screenshot](/screenshots/ic_orange_ppl.png)
 
-### iceberg
+### iceberg-dark
 
-![Screenshot](screenshots/iceberg.png)
+![Screenshot](/screenshots/iceberg.png)
 
-### IDEA Dark
+### idea
 
-![Screenshot](screenshots/idea.png)
+![Screenshot](/screenshots/idea.png)
 
 ### idleToes
 
-![Screenshot](screenshots/idleToes.png)
+![Screenshot](/screenshots/idleToes.png)
 
 ### IR_Black
 
-![Screenshot](screenshots/ir_black.png)
+![Screenshot](/screenshots/ir_black.png)
 
 ### IRIX Console
 
-![Screenshot](screenshots/irix_console.png)
+![Screenshot](/screenshots/irix_console.png)
 
 ### IRIX Terminal
 
-![Screenshot](screenshots/irix_terminal.png)
-
-### iTerm2 Default
-
-![Screenshot](screenshots/iterm2-default.png)
+![Screenshot](/screenshots/irix_terminal.png)
 
 ### iTerm2 Dark Background
 
-![Screenshot](screenshots/iterm2-dark-background.png)
+![Screenshot](/screenshots/iterm2-dark-background.png)
 
-### iTerm2 Light Background
+### iTerm2 Default
 
-![Screenshot](screenshots/iterm2-light-background.png)
+![Screenshot](/screenshots/iterm2-default.png)
 
-### iTerm2 Pastel (Dark Background)
+### iTerm2 Pastel Dark Background
 
-![Screenshot](screenshots/iterm2-pastel-dark-background.png)
+![Screenshot](/screenshots/iterm2-pastel-dark-background.png)
 
 ### iTerm2 Smoooooth
 
-![Screenshot](screenshots/iterm2-smoooooth.png)
+![Screenshot](/screenshots/iterm2-smoooooth.png)
 
 ### iTerm2 Solarized Dark
 
-![Screenshot](screenshots/iterm2-solarized-dark.png)
-
-### iTerm2 Solarized Light
-
-![Screenshot](screenshots/iterm2-solarized-light.png)
+![Screenshot](/screenshots/iterm2-solarized-dark.png)
 
 ### iTerm2 Tango Dark
 
-![Screenshot](screenshots/iterm2-tango-dark.png)
-
-### iTerm2 Tango Light
-
-![Screenshot](screenshots/iterm2-tango-light.png)
+![Screenshot](/screenshots/iterm2-tango-dark.png)
 
 ### Jackie Brown
 
-![Screenshot](screenshots/jackie_brown.png)
+![Screenshot](/screenshots/jackie_brown.png)
 
 ### Japanesque
 
-![Screenshot](screenshots/japanesque.png)
+![Screenshot](/screenshots/japanesque.png)
 
 ### Jellybeans
 
-![Screenshot](screenshots/jellybeans.png)
+![Screenshot](/screenshots/jellybeans.png)
 
 ### JetBrains Darcula
 
-![Screenshot](screenshots/jetbrains_darcula.png)
+![Screenshot](/screenshots/jetbrains_darcula.png)
 
-### Jubi
+### jubi
 
-![Screenshot](screenshots/jubi.png)
+![Screenshot](/screenshots/jubi.png)
 
 ### Kanagawa Dragon
 
-![Screenshot](screenshots/kanagawa-dragon.png)
+![Screenshot](/screenshots/kanagawa-dragon.png)
 
 ### Kanagawa Wave
 
-![Screenshot](screenshots/kanagawa-wave.png)
+![Screenshot](/screenshots/kanagawa-wave.png)
 
-### Kanagawabones
+### kanagawabones
 
-![Screenshot](screenshots/kanagawabones.png)
+![Screenshot](/screenshots/kanagawabones.png)
 
 ### Kibble
 
-![Screenshot](screenshots/kibble.png)
+![Screenshot](/screenshots/kibble.png)
 
 ### Kolorit
 
-![Screenshot](screenshots/kolorit.png)
+![Screenshot](/screenshots/kolorit.png)
 
 ### Konsolas
 
-![Screenshot](screenshots/konsolas.png)
+![Screenshot](/screenshots/konsolas.png)
 
-### Kurokula
+### kurokula
 
-![Screenshot](screenshots/kurokula.png)
+![Screenshot](/screenshots/kurokula.png)
 
 ### Lab Fox
 
-![Screenshot](screenshots/lab_fox.png)
+![Screenshot](/screenshots/lab_fox.png)
 
 ### Laser
 
-![Screenshot](screenshots/laser.png)
+![Screenshot](/screenshots/laser.png)
 
 ### Later This Evening
 
-![Screenshot](screenshots/later_this_evening.png)
+![Screenshot](/screenshots/later_this_evening.png)
 
 ### Lavandula
 
-![Screenshot](screenshots/lavandula.png)
-
-### Light Owl
-
-![Screenshot](screenshots/light_owl.png)
+![Screenshot](/screenshots/lavandula.png)
 
 ### LiquidCarbon
 
-![Screenshot](screenshots/liquid_carbon.png)
+![Screenshot](/screenshots/liquid_carbon.png)
 
 ### LiquidCarbonTransparent
 
-![Screenshot](screenshots/liquid_carbon_transparent.png)
+![Screenshot](/screenshots/liquid_carbon_transparent.png)
 
 ### LiquidCarbonTransparentInverse
 
-![Screenshot](screenshots/liquid_carbon_transparent_inverse.png)
+![Screenshot](/screenshots/liquid_carbon_transparent_inverse.png)
 
-### LoveLace
+### lovelace
 
-![Screenshot](screenshots/lovelace.png)
-
-### Man Page
-
-![Screenshot](screenshots/man_page.png)
+![Screenshot](/screenshots/lovelace.png)
 
 ### Mariana
 
-![Screenshot](screenshots/mariana.png)
-
-### Material
-
-![Screenshot](screenshots/material.png)
+![Screenshot](/screenshots/mariana.png)
 
 ### MaterialDark
 
-![Screenshot](screenshots/material_dark.png)
+![Screenshot](/screenshots/material_dark.png)
 
 ### MaterialDarker
 
-![Screenshot](screenshots/material_darker.png)
+![Screenshot](/screenshots/material_darker.png)
 
 ### MaterialDesignColors
 
-![Screenshot](screenshots/material_design_colors.png)
+![Screenshot](/screenshots/material_design_colors.png)
 
 ### MaterialOcean
 
-![Screenshot](screenshots/material_ocean.png)
+![Screenshot](/screenshots/material_ocean.png)
 
 ### Mathias
 
-![Screenshot](screenshots/mathias.png)
+![Screenshot](/screenshots/mathias.png)
 
-### Matrix
+### matrix
 
-![Screenshot](screenshots/matrix.png)
-
-### Dark Matrix
-
-![Screenshot](screenshots/darkmatrix.png)
-
-### Darker Matrix
-
-![Screenshot](screenshots/darkermatrix.png)
-
-### Melange Light
-
-![Screenshot](screenshots/melange_light.png)
-
-### Melange Dark
-
-![Screenshot](screenshots/melange_dark.png)
+![Screenshot](/screenshots/matrix.png)
 
 ### Medallion
 
-![Screenshot](screenshots/medallion.png)
+![Screenshot](/screenshots/medallion.png)
+
+### Melange_dark
+
+![Screenshot](/screenshots/melange_dark.png)
 
 ### Mellifluous
 
-![Screenshot](screenshots/mellifluous.png)
+![Screenshot](/screenshots/mellifluous.png)
 
-### Mellow
+### mellow
 
-![Screenshot](screenshots/mellow.png)
+![Screenshot](/screenshots/mellow.png)
 
-### Miasma
+### miasma
 
-![Screenshot](screenshots/miasma.png)
+![Screenshot](/screenshots/miasma.png)
 
-### Midnight In Mojave
+### midnight-in-mojave
 
-![Screenshot](screenshots/midnight_in_mojave.png)
+![Screenshot](/screenshots/midnight_in_mojave.png)
 
 ### Mirage
 
-![Screenshot](screenshots/mirage.png)
+![Screenshot](/screenshots/mirage.png)
 
 ### Misterioso
 
-![Screenshot](screenshots/misterioso.png)
+![Screenshot](/screenshots/misterioso.png)
 
 ### Molokai
 
-![Screenshot](screenshots/molokai.png)
+![Screenshot](/screenshots/molokai.png)
 
 ### MonaLisa
 
-![Screenshot](screenshots/mona_lisa.png)
+![Screenshot](/screenshots/mona_lisa.png)
 
 ### Monokai Classic
 
-![Screenshot](screenshots/monokai-classic.png)
-
-### Monokai Pro
-
-![Screenshot](screenshots/monokai-pro.png)
-
-### Monokai Pro Octagon
-
-![Screenshot](screenshots/monokai-pro-octagon.png)
+![Screenshot](/screenshots/monokai_classic.png)
 
 ### Monokai Pro Machine
 
-![Screenshot](screenshots/monokai-pro-machine.png)
+![Screenshot](/screenshots/monokai_pro_machine.png)
+
+### Monokai Pro Octagon
+
+![Screenshot](/screenshots/monokai_pro_octagon.png)
 
 ### Monokai Pro Ristretto
 
-![Screenshot](screenshots/monokai-pro-ristretto.png)
+![Screenshot](/screenshots/monokai_pro_ristretto.png)
 
 ### Monokai Pro Spectrum
 
-![Screenshot](screenshots/monokai-pro-spectrum.png)
+![Screenshot](/screenshots/monokai_pro_spectrum.png)
 
-### Monokai Pro Light
+### Monokai Pro
 
-![Screenshot](screenshots/monokai-pro-light.png)
-
-### Monokai Pro Light Sun
-
-![Screenshot](screenshots/monokai-pro-light-sun.png)
+![Screenshot](/screenshots/monokai_pro.png)
 
 ### Monokai Remastered
 
-![Screenshot](screenshots/monokai_remastered.png)
+![Screenshot](/screenshots/monokai_remastered.png)
 
 ### Monokai Soda
 
-![Screenshot](screenshots/monokai_soda.png)
+![Screenshot](/screenshots/monokai_soda.png)
 
 ### Monokai Vivid
 
-![Screenshot](screenshots/monokai_vivid.png)
+![Screenshot](/screenshots/monokai_vivid.png)
 
 ### moonfly
 
-![Screenshot](screenshots/moonfly.png)
+![Screenshot](/screenshots/moonfly.png)
 
 ### N0tch2k
 
-![Screenshot](screenshots/n0tch2k.png)
+![Screenshot](/screenshots/n0tch2k.png)
 
-### Neobones Dark
+### neobones_dark
 
-![Screenshot](screenshots/neobones_dark.png)
-
-### Neobones Light
-
-![Screenshot](screenshots/neobones_light.png)
+![Screenshot](/screenshots/neobones_dark.png)
 
 ### Neon
 
-![Screenshot](screenshots/neon.png)
+![Screenshot](/screenshots/neon.png)
 
 ### Neopolitan
 
-![Screenshot](screenshots/neopolitan.png)
+![Screenshot](/screenshots/neopolitan.png)
 
 ### Neutron
 
-![Screenshot](screenshots/neutron.png)
+![Screenshot](/screenshots/neutron.png)
 
-### Nightfox
+### nightfox
 
-![Screenshot](screenshots/nightfox.png)
+![Screenshot](/screenshots/nightfox.png)
 
 ### NightLion v1
 
-![Screenshot](screenshots/nightlion_v1.png)
+![Screenshot](/screenshots/nightlion_v1.png)
 
 ### NightLion v2
 
-![Screenshot](screenshots/nightlion_v2.png)
+![Screenshot](/screenshots/nightlion_v2.png)
 
-### Night Owl
+### NightOwl
 
-![Screenshot](screenshots/night_owl.png)
+![Screenshot](/screenshots/night_owl.png)
 
-### Night Owlish Light
+### niji
 
-![Screenshot](screenshots/night_owlish_light.png)
-
-### Niji
-
-![Screenshot](screenshots/niji.png)
-
-### Novel
-
-![Screenshot](screenshots/novel.png)
+![Screenshot](/screenshots/niji.png)
 
 ### Nocturnal Winter
 
-![Screenshot](screenshots/nocturnal_winter.png)
+![Screenshot](/screenshots/nocturnal_winter.png)
 
-### Nord
+### nord-wave
 
-![Screenshot](screenshots/nord.png)
+![Screenshot](/screenshots/nord-wave.png)
 
-### Nord-light
+### nord
 
-![Screenshot](screenshots/nord_light.png)
-
-### Nord-wave
-
-![Screenshot](screenshots/nord-wave.png)
+![Screenshot](/screenshots/nord.png)
 
 ### NvimDark
 
-![Screenshot](screenshots/NvimDark.png)
-
-### NvimLight
-
-![Screenshot](screenshots/NvimLight.png)
+![Screenshot](/screenshots/NvimDark.png)
 
 ### Obsidian
 
-![Screenshot](screenshots/obsidian.png)
+![Screenshot](/screenshots/obsidian.png)
 
 ### Ocean
 
-![Screenshot](screenshots/ocean.png)
+![Screenshot](/screenshots/ocean.png)
+
+### Oceanic-Next
+
+![Screenshot](/screenshots/oceanic_next.png)
 
 ### OceanicMaterial
 
-![Screenshot](screenshots/oceanic_material.png)
-
-### Oceanic Next
-
-![Screenshot](screenshots/oceanic_next.png)
+![Screenshot](/screenshots/oceanic_material.png)
 
 ### Ollie
 
-![Screenshot](screenshots/ollie.png)
+![Screenshot](/screenshots/ollie.png)
 
 ### One Double Dark
 
-![Screenshot](screenshots/one_double_dark.png)
+![Screenshot](/screenshots/one_double_dark.png)
 
-### One Double Light
+### OneHalfDark
 
-![Screenshot](screenshots/one_double_light.png)
-
-### One Half Dark
-
-![Screenshot](screenshots/onehalfdark.png)
-
-### One Half Light
-
-![Screenshot](screenshots/onehalflight.png)
+![Screenshot](/screenshots/onehalfdark.png)
 
 ### Operator Mono Dark
 
-![Screenshot](screenshots/operator_mono_dark.png)
+![Screenshot](/screenshots/operator_mono_dark.png)
 
 ### Overnight Slumber
 
-![Screenshot](screenshots/overnight_slumber.png)
+![Screenshot](/screenshots/overnight_slumber.png)
 
 ### Oxocarbon
 
-![Screenshot](screenshots/oxocarbon.png)
+![Screenshot](/screenshots/oxocarbon.png)
 
-### Palenight High Contrast
+### PaleNightHC
 
-![Screenshot](screenshots/PaleNightHC.png)
+![Screenshot](/screenshots/PaleNightHC.png)
 
 ### Pandora
 
-![Screenshot](screenshots/pandora.png)
+![Screenshot](/screenshots/pandora.png)
 
 ### Paraiso Dark
 
-![Screenshot](screenshots/paraiso_dark.png)
+![Screenshot](/screenshots/paraiso_dark.png)
 
 ### PaulMillr
 
-![Screenshot](screenshots/paul_millr.png)
+![Screenshot](/screenshots/paul_millr.png)
 
-### Pencil Dark
+### PencilDark
 
-![Screenshot](screenshots/pencil_dark.png)
-
-### Pencil Light
-
-![Screenshot](screenshots/pencil_light.png)
+![Screenshot](/screenshots/pencil_dark.png)
 
 ### Peppermint
 
-![Screenshot](screenshots/peppermint.png)
+![Screenshot](/screenshots/peppermint.png)
 
 ### Phala Green Dark
 
-![Screenshot](screenshots/phala_green_dark.png)
-
-### Piatto Light
-
-![Screenshot](screenshots/piatto_light.png)
+![Screenshot](/screenshots/phala_green_dark.png)
 
 ### Pnevma
 
-![Screenshot](screenshots/pnevma.png)
+![Screenshot](/screenshots/pnevma.png)
 
 ### Popping and Locking
 
-![Screenshot](screenshots/popping_and_locking.png)
-
-### Primary
-
-![Screenshot](screenshots/primary.png)
+![Screenshot](/screenshots/popping_and_locking.png)
 
 ### Pro
 
-![Screenshot](screenshots/pro.png)
-
-### Pro Light
-
-![Screenshot](screenshots/pro_light.png)
-
-### Purple Peter
-
-![Screenshot](screenshots/purplepeter.png)
+![Screenshot](/screenshots/pro.png)
 
 ### Purple Rain
 
-![Screenshot](screenshots/purple_rain.png)
+![Screenshot](/screenshots/purple_rain.png)
+
+### purplepeter
+
+![Screenshot](/screenshots/purplepeter.png)
 
 ### Rapture
 
-![Screenshot](screenshots/rapture.png)
+![Screenshot](/screenshots/rapture.png)
 
-### Raycast Dark
+### Raycast_Dark
 
-![Screenshot](screenshots/raycast_dark.png)
+![Screenshot](/screenshots/raycast_dark.png)
 
-### Raycast Light
+### rebecca
 
-![Screenshot](screenshots/raycast_light.png)
-
-### Rebecca
-
-![Screenshot](screenshots/rebecca.png)
+![Screenshot](/screenshots/rebecca.png)
 
 ### Red Alert
 
-![Screenshot](screenshots/red_alert.png)
+![Screenshot](/screenshots/red_alert.png)
 
 ### Red Planet
 
-![Screenshot](screenshots/red_planet.png)
+![Screenshot](/screenshots/red_planet.png)
 
 ### Red Sands
 
-![Screenshot](screenshots/red_sands.png)
+![Screenshot](/screenshots/red_sands.png)
 
 ### Relaxed
 
-![Screenshot](screenshots/relaxed.png)
+![Screenshot](/screenshots/relaxed.png)
 
 ### Retro
 
-![Screenshot](screenshots/retro.png)
+![Screenshot](/screenshots/retro.png)
 
 ### RetroLegends
 
-![image](screenshots/RetroLegends.png)
+![Screenshot](/screenshots/RetroLegends.png)
 
 ### Rippedcasts
 
-![Screenshot](screenshots/rippedcasts.png)
+![Screenshot](/screenshots/rippedcasts.png)
 
-### Rosé Pine
+### rose-pine-moon
 
-![Screenshot](screenshots/rose-pine.png)
+![Screenshot](/screenshots/rose-pine-moon.png)
 
-### Rosé Pine Dawn
+### rose-pine
 
-![Screenshot](screenshots/rose-pine-dawn.png)
-
-### Rosé Pine Moon
-
-![Screenshot](screenshots/rose-pine-moon.png)
+![Screenshot](/screenshots/rose-pine.png)
 
 ### Rouge 2
 
-![Screenshot](screenshots/rouge_2.png)
+![Screenshot](/screenshots/rouge_2.png)
 
 ### Royal
 
-![Screenshot](screenshots/royal.png)
+![Screenshot](/screenshots/royal.png)
 
 ### Ryuuko
 
-![Screenshot](screenshots/ryuuko.png)
+![Screenshot](/screenshots/ryuuko.png)
 
 ### Sakura
 
-![Screenshot](screenshots/sakura.png)
+![Screenshot](/screenshots/sakura.png)
 
 ### Scarlet Protocol
 
-![Screenshot](screenshots/scarlet_protocol.png)
+![Screenshot](/screenshots/scarlet_protocol.png)
 
 ### Seafoam Pastel
 
-![Screenshot](screenshots/seafoam_pastel.png)
+![Screenshot](/screenshots/seafoam_pastel.png)
 
 ### SeaShells
 
-![Screenshot](screenshots/sea_shells.png)
+![Screenshot](/screenshots/sea_shells.png)
 
-### Seoulbones Dark
+### selenized-dark
 
-![Screenshot](screenshots/seoulbones_dark.png)
+![Screenshot](/screenshots/selenized-dark.png)
 
-### Seoulbones Light
+### seoulbones_dark
 
-![Screenshot](screenshots/seoulbones_light.png)
-
-### Selenized Dark
-
-![Screenshot](screenshots/selenized-dark.png)
-
-### Selenized Light
-
-![Screenshot](screenshots/selenized-light.png)
+![Screenshot](/screenshots/seoulbones_dark.png)
 
 ### Seti
 
-![Screenshot](screenshots/seti.png)
+![Screenshot](/screenshots/seti.png)
+
+### shades-of-purple
+
+![Screenshot](/screenshots/ShadesOfPurple.png)
 
 ### Shaman
 
-![Screenshot](screenshots/shaman.png)
-
-### Shades-Of-Purple
-
-![Screenshot](screenshots/ShadesOfPurple.png)
+![Screenshot](/screenshots/shaman.png)
 
 ### Slate
 
-![Screenshot](screenshots/slate.png)
+![Screenshot](/screenshots/slate.png)
 
 ### SleepyHollow
 
-![Screenshot](screenshots/SleepyHollow.png)
+![Screenshot](/screenshots/SleepyHollow.png)
 
 ### Smyck
 
-![Screenshot](screenshots/smyck.png)
+![Screenshot](/screenshots/smyck.png)
 
 ### Snazzy Soft
 
-![Screenshot](screenshots/snazzy_soft.png)
+![Screenshot](/screenshots/snazzy_soft.png)
 
 ### Snazzy
 
-![Screenshot](screenshots/snazzy.png)
+![Screenshot](/screenshots/snazzy.png)
 
 ### SoftServer
 
-![Screenshot](screenshots/soft_server.png)
+![Screenshot](/screenshots/soft_server.png)
 
-### Solarized Darcula (With background image)
+### Solarized Darcula
 
-![Screenshot](screenshots/solarized_darcula_with_background.png)
-
-### Solarized Darcula (Without background image)
-
-![Screenshot](screenshots/solarized_darcula.png)
+![Screenshot](/screenshots/solarized_darcula.png)
 
 ### Solarized Dark - Patched
 
-Some applications assume the ANSI color code 8 is a gray color. Solarized treats
-this code as equal to the background. This theme is for people who prefer the
-former. See issues [#59][issue-59], [#62][issue-62], and [#63][issue-63] for
-more information.
-
-![Screenshot](screenshots/solarized_dark_patched.png)
-
-[issue-59]: https://github.com/mbadolato/iTerm2-Color-Schemes/issues/59
-[issue-62]: https://github.com/mbadolato/iTerm2-Color-Schemes/issues/62
-[issue-63]: https://github.com/mbadolato/iTerm2-Color-Schemes/pull/63
+![Screenshot](/screenshots/solarized_dark_patched.png)
 
 ### Solarized Dark Higher Contrast
 
-![Screenshot](screenshots/solarized_dark_higher_contrast.png)
+![Screenshot](/screenshots/solarized_dark_higher_contrast.png)
 
-### Solarized Osaka Night
+### solarized-osaka-night
 
-![Screenshot](screenshots/solarized-osaka-night.png)
+![Screenshot](/screenshots/solarized-osaka-night.png)
 
-### Sonokai
+### sonokai
 
-![Screenshot](screenshots/sonokai.png)
-
-### SpaceGray
-
-![Screenshot](screenshots/space_gray.png)
-
-### SpaceGray Bright
-
-![Screenshot](screenshots/spacegray_bright.png)
-
-### SpaceGray Eighties
-
-![Screenshot](screenshots/spacegray_eighties.png)
-
-### SpaceGray Eighties Dull
-
-![Screenshot](screenshots/spacegray_eighties_dull.png)
+![Screenshot](/screenshots/sonokai.png)
 
 ### Spacedust
 
-![Screenshot](screenshots/spacedust.png)
+![Screenshot](/screenshots/spacedust.png)
+
+### SpaceGray Bright
+
+![Screenshot](/screenshots/spacegray_bright.png)
+
+### SpaceGray Eighties Dull
+
+![Screenshot](/screenshots/spacegray_eighties_dull.png)
+
+### SpaceGray Eighties
+
+![Screenshot](/screenshots/spacegray_eighties.png)
+
+### SpaceGray
+
+![Screenshot](/screenshots/space_gray.png)
 
 ### Spiderman
 
-![Screenshot](screenshots/spiderman.png)
-
-### Spring
-
-![Screenshot](screenshots/spring.png)
+![Screenshot](/screenshots/spiderman.png)
 
 ### Square
 
-![Screenshot](screenshots/square.png)
+![Screenshot](/screenshots/square.png)
 
 ### Squirrelsong Dark
 
-![Screenshot](screenshots/squirrelsong_dark.png)
+![Screenshot](/screenshots/squirrelsong_dark.png)
 
-### Srcery
+### srcery
 
-![Screenshot](screenshots/srcery.png)
+![Screenshot](/screenshots/srcery.png)
 
-### Starlight
+### starlight
 
-![Screenshot](screenshots/starlight.png)
+![Screenshot](/screenshots/starlight.png)
 
 ### Sublette
 
-![Screenshot](screenshots/sublette.png)
+![Screenshot](/screenshots/sublette.png)
 
 ### Subliminal
 
-![Screenshot](screenshots/subliminal.png)
+![Screenshot](/screenshots/subliminal.png)
 
 ### Sugarplum
 
-![Screenshot](screenshots/sugarplum.png)
+![Screenshot](/screenshots/sugarplum.png)
 
 ### Sundried
 
-![Screenshot](screenshots/sundried.png)
+![Screenshot](/screenshots/sundried.png)
 
 ### Symfonic
 
-![Screenshot](screenshots/symfonic.png)
+![Screenshot](/screenshots/symfonic.png)
+
+### synthwave-everything
+
+![Screenshot](/screenshots/synthwave-everything.png)
 
 ### synthwave
 
-![Screenshot](screenshots/synthwave.png)
+![Screenshot](/screenshots/synthwave.png)
 
-### Synthwave Alpha
+### SynthwaveAlpha
 
-![Screenshot](screenshots/synthwave_alpha.png)
-
-### Synthwave Everything
-
-![Screenshot](screenshots/synthwave-everything.png)
-
-### Tango Adapted
-
-![Screenshot](screenshots/tango_adapted.png)
-
-### Tango Half Adapted
-
-![Screenshot](screenshots/tango_half_adapted.png)
+![Screenshot](/screenshots/synthwave_alpha.png)
 
 ### Tearout
 
-![Screenshot](screenshots/tearout.png)
+![Screenshot](/screenshots/tearout.png)
 
 ### Teerb
 
-![Screenshot](screenshots/teerb.png)
+![Screenshot](/screenshots/teerb.png)
 
-### Terafox
+### terafox
 
-![Screenshot](screenshots/terafox.png)
+![Screenshot](/screenshots/terafox.png)
 
-### Terminal Basic
+### Terminal Basic Dark
 
-![Screenshot](screenshots/terminal_basic.png)
+![Screenshot](/screenshots/terminal_basic_dark.png)
 
 ### Thayer Bright
 
-![Screenshot](screenshots/thayer_bright.png)
+![Screenshot](/screenshots/thayer_bright.png)
 
 ### The Hulk
 
-![Screenshot](screenshots/the_hulk.png)
+![Screenshot](/screenshots/the_hulk.png)
 
 ### Tinacious Design (Dark)
 
-![Screenshot](screenshots/tinacious_design_dark.png)
+![Screenshot](/screenshots/tinacious_design_dark.png)
 
-### Tinacious Design (Light)
+### tokyonight-storm
 
-![Screenshot](screenshots/tinacious_design_light.png)
+![Screenshot](/screenshots/tokyonight-storm.png)
 
-### TokyoNight
+### tokyonight
 
-![Screenshot](screenshots/tokyonight.png)
+![Screenshot](/screenshots/tokyonight.png)
 
-### TokyoNight Storm
+### tokyonight_moon
 
-![Screenshot](screenshots/tokyonight-storm.png)
+![Screenshot](/screenshots/tokyonight-moon.png)
 
-### TokyoNight Moon
+### tokyonight_night
 
-![Screenshot](screenshots/tokyonight-moon.png)
-
-### TokyoNight Day
-
-![Screenshot](screenshots/tokyonight-day.png)
-
-### TokyoNight Night
-
-![Screenshot](screenshots/tokyonight-night.png)
-
-### Tomorrow
-
-![Screenshot](screenshots/tomorrow.png)
-
-### Tomorrow Night
-
-![Screenshot](screenshots/tomorrow_night.png)
+![Screenshot](/screenshots/tokyonight-night.png)
 
 ### Tomorrow Night Blue
 
-![Screenshot](screenshots/tomorrow_night_blue.png)
+![Screenshot](/screenshots/tomorrow_night_blue.png)
 
 ### Tomorrow Night Bright
 
-![Screenshot](screenshots/tomorrow_night_bright.png)
-
-### Tomorrow Night Eighties
-
-![Screenshot](screenshots/tomorrow_night_eighties.png)
+![Screenshot](/screenshots/tomorrow_night_bright.png)
 
 ### Tomorrow Night Burns
 
-![Screenshot](screenshots/tomorrow_night_burns.png)
+![Screenshot](/screenshots/tomorrow_night_burns.png)
+
+### Tomorrow Night Eighties
+
+![Screenshot](/screenshots/tomorrow_night_eighties.png)
+
+### Tomorrow Night
+
+![Screenshot](/screenshots/tomorrow_night.png)
 
 ### ToyChest
 
-![Screenshot](screenshots/toy_chest.png)
+![Screenshot](/screenshots/toy_chest.png)
 
 ### Treehouse
 
-![Screenshot](screenshots/treehouse.png)
+![Screenshot](/screenshots/treehouse.png)
 
 ### Twilight
 
-![Screenshot](screenshots/twilight.png)
+![Screenshot](/screenshots/twilight.png)
 
 ### Ubuntu
 
-![Screenshot](screenshots/ubuntu.png)
-
-### UltraViolent
-
-![Screenshot](screenshots/ultra_violent.png)
+![Screenshot](/screenshots/ubuntu.png)
 
 ### UltraDark
 
-![Screenshot](screenshots/ultradark.png)
+![Screenshot](/screenshots/ultradark.png)
 
-### Under The Sea
+### UltraViolent
 
-![Screenshot](screenshots/under_the_sea.png)
+![Screenshot](/screenshots/ultra_violent.png)
 
-### Unikitty
+### UnderTheSea
 
-![Screenshot](screenshots/unikitty.png)
+![Screenshot](/screenshots/under_the_sea.png)
 
 ### Urple
 
-![Screenshot](screenshots/urple.png)
+![Screenshot](/screenshots/urple.png)
 
 ### Vague
 
-![Screenshot](screenshots/vague.png)
+![Screenshot](/screenshots/vague.png)
 
 ### Vaughn
 
-![Screenshot](screenshots/vaughn.png)
+![Screenshot](/screenshots/vaughn.png)
 
 ### Vesper
 
-![Screenshot](screenshots/vesper.png)
+![Screenshot](/screenshots/vesper.png)
 
 ### VibrantInk
 
-![Screenshot](screenshots/vibrant_ink.png)
-
-### Vimbones
-
-![Screenshot](screenshots/vimbones.png)
-
-### Violet Light
-
-![Screenshot](screenshots/violet_light.png)
+![Screenshot](/screenshots/vibrant_ink.png)
 
 ### Violet Dark
 
-![Screenshot](screenshots/violet_dark.png)
+![Screenshot](/screenshots/violet_dark.png)
 
 ### violite
 
-![Screenshot](screenshots/violite.png)
+![Screenshot](/screenshots/violite.png)
 
 ### WarmNeon
 
-![Screenshot](screenshots/warm_neon.png)
+![Screenshot](/screenshots/warm_neon.png)
 
 ### Wez
 
-![Screenshot](screenshots/wez.png)
+![Screenshot](/screenshots/wez.png)
 
 ### Whimsy
 
-![Screenshot](screenshots/whimsy.png)
+![Screenshot](/screenshots/whimsy.png)
 
 ### WildCherry
 
-![Screenshot](screenshots/wild_cherry.png)
+![Screenshot](/screenshots/wild_cherry.png)
 
-### Wilmersdorf
+### wilmersdorf
 
-![Screenshot](screenshots/wilmersdorf.png)
+![Screenshot](/screenshots/wilmersdorf.png)
 
 ### Wombat
 
-![Screenshot](screenshots/wombat.png)
+![Screenshot](/screenshots/wombat.png)
 
 ### Wryan
 
-![Screenshot](screenshots/wryan.png)
+![Screenshot](/screenshots/wryan.png)
 
-### Xcode dark
+### xcodedark
 
-![Screenshot](screenshots/xcodedark.png)
+![Screenshot](/screenshots/xcodedark.png)
 
-### Xcode dark (High Contrast)
+### xcodedarkhc
 
-![Screenshot](screenshots/xcodedarkhc.png)
+![Screenshot](/screenshots/xcodedarkhc.png)
 
-### Xcode light
+### xcodewwdc
 
-![Screenshot](screenshots/xcodelight.png)
+![Screenshot](/screenshots/xcodewwdc.png)
 
-### Xcode light (High Contrast)
+### zenbones_dark
 
-![Screenshot](screenshots/xcodelighthc.png)
-
-### Xcode WWDC
-
-![Screenshot](screenshots/xcodewwdc.png)
-
-### Zenbones
-
-![Screenshot](screenshots/zenbones.png)
-
-### Zenbones Dark
-
-![Screenshot](screenshots/zenbones_dark.png)
-
-### Zenbones Light
-
-![Screenshot](screenshots/zenbones_light.png)
+![Screenshot](/screenshots/zenbones_dark.png)
 
 ### Zenburn
 
-![Screenshot](screenshots/zenburn.png)
+![Screenshot](/screenshots/zenburn.png)
 
-### Zenburned
+### zenburned
 
-![Screenshot](screenshots/zenburned.png)
+![Screenshot](/screenshots/zenburned.png)
 
-### Zenwritten Dark
+### zenwritten_dark
 
-![Screenshot](screenshots/zenwritten_dark.png)
+![Screenshot](/screenshots/zenwritten_dark.png)
 
-### Zenwritten Light
+### Light Themes<a name="lightthemes"><a/>
 
-![Screenshot](screenshots/zenwritten_light.png)
+### 3024 Day
 
+![Screenshot](/screenshots/3024_day.png)
+
+### Adwaita
+
+![Screenshot](/screenshots/adwaita.png)
+
+### Alabaster
+
+![Screenshot](/screenshots/alabaster.png)
+
+### Apple System Colors Light
+
+![Screenshot](/screenshots/apple_system_colors_light.png)
+
+### AtomOneLight
+
+![Screenshot](/screenshots/atom_one_light.png)
+
+### ayu_light
+
+![Screenshot](/screenshots/ayu_light.png)
+
+### Belafonte Day
+
+![Screenshot](/screenshots/belafonte_day.png)
+
+### BlulocoLight
+
+![Screenshot](/screenshots/bluloco_light.png)
+
+### Breadog
+
+![Screenshot](/screenshots/breadog.png)
+
+### catppuccin-latte
+
+![Screenshot](/screenshots/catppuccin-latte.png)
+
+### CLRS
+
+![Screenshot](/screenshots/clrs.png)
+
+### coffee_theme
+
+![Screenshot](/screenshots/Coffee.png)
+
+### dayfox
+
+![Screenshot](/screenshots/dayfox.png)
+
+### Everforest Light - Med
+
+![Screenshot](/screenshots/everforest_light_med.png)
+
+### farmhouse-light
+
+![Screenshot](/screenshots/farmhouse-light.png)
+
+### flexoki-light
+
+![Screenshot](/screenshots/flexoki-light.png)
+
+### GitHub-Light-Colorblind
+
+![Screenshot](/screenshots/github-light-colorblind.png)
+
+### GitHub-Light-Default
+
+![Screenshot](/screenshots/github-light-default.png)
+
+### GitHub-Light-High-Contrast
+
+![Screenshot](/screenshots/github-light-high-contrast.png)
+
+### Github
+
+![Screenshot](/screenshots/github.png)
+
+### GitLab-Light
+
+![Screenshot](/screenshots/git_lab-light.png)
+
+### GruvboxLight
+
+![Screenshot](/screenshots/gruvbox_light.png)
+
+### GruvboxLightHard
+
+![Screenshot](/screenshots/gruvbox_light_hard.png)
+
+### Havn Daggry
+
+![Screenshot](/screenshots/havn_daggry.png)
+
+### Horizon-Bright
+
+![Screenshot](/screenshots/horizon-bright.png)
+
+### iceberg-light
+
+![Screenshot](/screenshots/iceberg-light.png)
+
+### iTerm2 Light Background
+
+![Screenshot](/screenshots/iterm2-light-background.png)
+
+### iTerm2 Solarized Light
+
+![Screenshot](/screenshots/iterm2-solarized-light.png)
+
+### iTerm2 Tango Light
+
+![Screenshot](/screenshots/iterm2-tango-light.png)
+
+### LightOwl
+
+![Screenshot](/screenshots/light_owl.png)
+
+### Man Page
+
+![Screenshot](/screenshots/man_page.png)
+
+### Material
+
+![Screenshot](/screenshots/material.png)
+
+### Melange_light
+
+![Screenshot](/screenshots/melange_light.png)
+
+### Monokai Pro Light Sun
+
+![Screenshot](/screenshots/monokai_pro_light_sun.png)
+
+### Monokai Pro Light
+
+![Screenshot](/screenshots/monokai_pro_light.png)
+
+### neobones_light
+
+![Screenshot](/screenshots/neobones_light.png)
+
+### Night Owlish Light
+
+![Screenshot](/screenshots/night_owlish_light.png)
+
+### nord-light
+
+![Screenshot](/screenshots/nord_light.png)
+
+### Novel
+
+![Screenshot](/screenshots/novel.png)
+
+### NvimLight
+
+![Screenshot](/screenshots/NvimLight.png)
+
+### One Double Light
+
+![Screenshot](/screenshots/one_double_light.png)
+
+### OneHalfLight
+
+![Screenshot](/screenshots/onehalflight.png)
+
+### PencilLight
+
+![Screenshot](/screenshots/pencil_light.png)
+
+### Piatto Light
+
+![Screenshot](/screenshots/piatto_light.png)
+
+### primary
+
+![Screenshot](/screenshots/primary.png)
+
+### Pro Light
+
+![Screenshot](/screenshots/pro_light.png)
+
+### Raycast_Light
+
+![Screenshot](/screenshots/raycast_light.png)
+
+### rose-pine-dawn
+
+![Screenshot](/screenshots/rose-pine-dawn.png)
+
+### selenized-light
+
+![Screenshot](/screenshots/selenized-light.png)
+
+### seoulbones_light
+
+![Screenshot](/screenshots/seoulbones_light.png)
+
+### Spring
+
+![Screenshot](/screenshots/spring.png)
+
+### Tango Adapted
+
+![Screenshot](/screenshots/tango_adapted.png)
+
+### Tango Half Adapted
+
+![Screenshot](/screenshots/tango_half_adapted.png)
+
+### Terminal Basic
+
+![Screenshot](/screenshots/terminal_basic.png)
+
+### Tinacious Design (Light)
+
+![Screenshot](/screenshots/tinacious_design_light.png)
+
+### tokyonight-day
+
+![Screenshot](/screenshots/tokyonight-day.png)
+
+### Tomorrow
+
+![Screenshot](/screenshots/tomorrow.png)
+
+### Unikitty
+
+![Screenshot](/screenshots/unikitty.png)
+
+### vimbones
+
+![Screenshot](/screenshots/vimbones.png)
+
+### Violet Light
+
+![Screenshot](/screenshots/violet_light.png)
+
+### xcodelight
+
+![Screenshot](/screenshots/xcodelight.png)
+
+### xcodelighthc
+
+![Screenshot](/screenshots/xcodelighthc.png)
+
+### zenbones
+
+![Screenshot](/screenshots/zenbones.png)
+
+### zenbones_light
+
+![Screenshot](/screenshots/zenbones_light.png)
+
+### zenwritten_light
+
+![Screenshot](/screenshots/zenwritten_light.png)
 <!-- SCREENSHOTS_END -->
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -114,29 +114,8 @@ Have a great theme? Send it to me via a Pull Request!
    - Click on **Color Presets**
    - Click on **Export**
    - Save the .itermcolors file
-   - Adjust the [Color Space](#color-space)
 2. Put your theme file into `/schemes/`
    - `mv <your-itermcolors-file> schemes/`
-3. Continue with the "Create derived versions" below.
-
-##### Color Space
-
-iTerm seems to store the colors in its color presets in P3 color space.
-The tools only can handle sRGB color space.
-To convert an `.itermcolors` file int sRGB color space, use the provided `p3tosRGB.py` tool:
-
-```shell
-python3 tools/p3tosRGB.py schemes/YOUR_SCHEME
-```
-
-When using Docker:
-
-```shell
-./generate-all.sh debug
-python3 tools/p3tosRGB.py schemes/YOUR_SCHEME
-```
-
-This will overwrite your scheme with a converted version.
 
 #### Have a theme in another format?
 
@@ -145,25 +124,18 @@ This will overwrite your scheme with a converted version.
    - If it helps, you can use `tools/kitty_to_yaml.py` and `tools/ghostty_to_yaml.py`.
      These tools accept configuration file streamed into stdin, and output a YAML fragment to stdout.
 2. Put the YAML file in `yaml/`, with the `.yml` extension.
-3. Continue with the "Create derived versions" below.
 
-#### Create derived versions
-
-If you have `make` installed, steps 1 to 4 can be run with `make` from the root of the repository.
+#### Test your theme
 
 1. Generate other formats for your theme using the `gen.py` script.
-   - `python3 tools/gen.py`
-2. If you only want to generate files for your theme, you can specify this with the `-s` flag.
-   - `python3 tools/gen.py -s Dracula`
-3. Generate a screenshot of your theme using the `screenshot_gen` tool.
+   - `python3 tools/gen.py -s <YourTheme>`
+2. Generate a screenshot of your theme using the `screenshot_gen` tool.
    - `pushd tools && python3 -m screenshot_gen && popd`. This will generate new screenshots where they are missing.
    - If you have `oxipng` or `zopflipng` installed, the screenshot will be optimized for you.
-4. Run `generate_screenshots_readme.py` to include your theme's screenshot in the `screenshots/README.md` file:
-   - `python3 tools/generate_screenshots_readme.py`
 
-#### Add your theme to the README
+#### Update `CREDITS.md` (optional)
 
-1. Update `README.md` to include your theme and screenshot. Also update `CREDITS.md` to credit yourself for your contribution.
+1. Update `CREDITS.md` to credit yourself for your contribution.
 
 ### How to add new template
 
@@ -1891,6 +1863,7 @@ The screenshots are categorized.
 ### zenwritten_light
 
 ![Screenshot](/screenshots/zenwritten_light.png)
+
 <!-- SCREENSHOTS_END -->
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Do you want to convert existing iTerm themes to themes for your favorite termina
 
 6. If in the process you had to add new dependencies or update the version of python, do not forget to indicate this in `requirements.txt` or `.python-version`.
 
+<!-- SCREENSHOTS_BEGIN -->
+
 ## Screenshots
 
 ### 0x96f
@@ -1870,6 +1872,8 @@ more information.
 
 ![Screenshot](screenshots/zenwritten_light.png)
 
+<!-- SCREENSHOTS_END -->
+
 ## Credits
 
 - The schemes [_Novel_](#novel), [_Espresso_](#espresso), [_Grass_](#grass), [_Homebrew_](#homebrew), [_Ocean_](#ocean), [_Pro_](#pro), [_Man Page_](#man-page), [_Red Sands_](#red-sands), and [_Terminal Basic_](#terminal-basic) are ports of the schemes of the same name included with the Mac Terminal application. All of Terminal's schemes have now been ported, with the exception of _Solid Colors_ (random backgrounds, which iTerm doesn't support) and _Aerogel_ (which is hideous).
@@ -2103,7 +2107,7 @@ tools/preview.rb schemes/*
 
 [preview-generic.sh](tools/preview-generic.sh) is a script which can preview
 the themes in any terminal emulator which has support for the OSC 4 escape
-codes. It works by running the shell scripts from the `generic/` directory. 
+codes. It works by running the shell scripts from the `generic/` directory.
 
 ```sh
 # Apply AdventureTime scheme to the current session
@@ -2113,6 +2117,7 @@ bash generic/AdventureTime.sh
 # - Press left/right arrow keys to navigate, press `q` to stop
 ./tools/preview-generic.sh generic/*
 ```
+
 ---
 
 iTerm Color Schemes | iTerm2 Color Schemes | iTerm 2 Color Schemes | iTerm Themes | iTerm2 Themes | iTerm 2 Themes

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -1,1675 +1,1675 @@
 
-# Screenshots
+## Screenshots
 
 The screenshots are categorized.
 
 - [Dark Themes](#darkthemes)
 - [Light Themes](#lightthemes)
 
-## Dark Themes<a name="darkthemes"><a/>
+### Dark Themes<a name="darkthemes"><a/>
 
-`0x96f`
+### 0x96f
 
-![image](0x96f.png)
+![Screenshot](/screenshots/0x96f.png)
 
-`12-bit Rainbow`
+### 12-bit Rainbow
 
-![image](12-bit_rainbow.png)
+![Screenshot](/screenshots/12-bit_rainbow.png)
 
-`3024 Night`
+### 3024 Night
 
-![image](3024_night.png)
+![Screenshot](/screenshots/3024_night.png)
 
-`Aardvark Blue`
+### Aardvark Blue
 
-![image](aardvark_blue.png)
+![Screenshot](/screenshots/aardvark_blue.png)
 
-`Abernathy`
+### Abernathy
 
-![image](abernathy.png)
+![Screenshot](/screenshots/abernathy.png)
 
-`Adventure`
+### Adventure
 
-![image](adventure.png)
+![Screenshot](/screenshots/adventure.png)
 
-`AdventureTime`
+### AdventureTime
 
-![image](adventure_time.png)
+![Screenshot](/screenshots/adventure_time.png)
 
-`Adwaita Dark`
+### Adwaita Dark
 
-![image](adwaita_dark.png)
+![Screenshot](/screenshots/adwaita_dark.png)
 
-`Afterglow`
+### Afterglow
 
-![image](afterglow.png)
+![Screenshot](/screenshots/afterglow.png)
 
-`AlienBlood`
+### AlienBlood
 
-![image](alien_blood.png)
+![Screenshot](/screenshots/alien_blood.png)
 
-`Andromeda`
+### Andromeda
 
-![image](andromeda.png)
+![Screenshot](/screenshots/andromeda.png)
 
-`Apple Classic`
+### Apple Classic
 
-![image](apple-classic.png)
+![Screenshot](/screenshots/apple-classic.png)
 
-`Apple System Colors`
+### Apple System Colors
 
-![image](apple-system-colors.png)
+![Screenshot](/screenshots/apple-system-colors.png)
 
-`arcoiris`
+### arcoiris
 
-![image](arcoiris.png)
+![Screenshot](/screenshots/arcoiris.png)
 
-`Ardoise`
+### Ardoise
 
-![image](ardoise.png)
+![Screenshot](/screenshots/ardoise.png)
 
-`Argonaut`
+### Argonaut
 
-![image](argonaut.png)
+![Screenshot](/screenshots/argonaut.png)
 
-`Arthur`
+### Arthur
 
-![image](arthur.png)
+![Screenshot](/screenshots/arthur.png)
 
-`AtelierSulphurpool`
+### AtelierSulphurpool
 
-![image](atelier-sulphurpool_dark.png)
+![Screenshot](/screenshots/atelier-sulphurpool_dark.png)
 
-`Atom`
+### Atom
 
-![image](atom.png)
+![Screenshot](/screenshots/atom.png)
 
-`AtomOneDark`
+### AtomOneDark
 
-![image](atom_one_dark.png)
+![Screenshot](/screenshots/atom_one_dark.png)
 
-`Aura`
+### Aura
 
-![image](aura.png)
+![Screenshot](/screenshots/aura.png)
 
-`Aurora`
+### Aurora
 
-![image](aurora.png)
+![Screenshot](/screenshots/aurora.png)
 
-`Ayu Mirage`
+### Ayu Mirage
 
-![image](ayu_mirage.png)
+![Screenshot](/screenshots/ayu_mirage.png)
 
-`ayu`
+### ayu
 
-![image](ayu.png)
+![Screenshot](/screenshots/ayu.png)
 
-`Banana Blueberry`
+### Banana Blueberry
 
-![image](banana_blueberry.png)
+![Screenshot](/screenshots/banana_blueberry.png)
 
-`Batman`
+### Batman
 
-![image](batman.png)
+![Screenshot](/screenshots/batman.png)
 
-`Belafonte Night`
+### Belafonte Night
 
-![image](belafonte_night.png)
+![Screenshot](/screenshots/belafonte_night.png)
 
-`BirdsOfParadise`
+### BirdsOfParadise
 
-![image](birds_of_paradise.png)
+![Screenshot](/screenshots/birds_of_paradise.png)
 
-`Black Metal (Bathory)`
+### Black Metal (Bathory)
 
-![image](black_metal_bathory.png)
+![Screenshot](/screenshots/black_metal_bathory.png)
 
-`Black Metal (Burzum)`
+### Black Metal (Burzum)
 
-![image](black_metal_burzum.png)
+![Screenshot](/screenshots/black_metal_burzum.png)
 
-`Black Metal (Dark Funeral)`
+### Black Metal (Dark Funeral)
 
-![image](black_metal_dark_funeral.png)
+![Screenshot](/screenshots/black_metal_dark_funeral.png)
 
-`Black Metal (Gorgoroth)`
+### Black Metal (Gorgoroth)
 
-![image](black_metal_gorgoroth.png)
+![Screenshot](/screenshots/black_metal_gorgoroth.png)
 
-`Black Metal (Immortal)`
+### Black Metal (Immortal)
 
-![image](black_metal_immortal.png)
+![Screenshot](/screenshots/black_metal_immortal.png)
 
-`Black Metal (Khold)`
+### Black Metal (Khold)
 
-![image](black_metal_khold.png)
+![Screenshot](/screenshots/black_metal_khold.png)
 
-`Black Metal (Marduk)`
+### Black Metal (Marduk)
 
-![image](black_metal_marduk.png)
+![Screenshot](/screenshots/black_metal_marduk.png)
 
-`Black Metal (Mayhem)`
+### Black Metal (Mayhem)
 
-![image](black_metal_mayhem.png)
+![Screenshot](/screenshots/black_metal_mayhem.png)
 
-`Black Metal (Nile)`
+### Black Metal (Nile)
 
-![image](black_metal_nile.png)
+![Screenshot](/screenshots/black_metal_nile.png)
 
-`Black Metal (Venom)`
+### Black Metal (Venom)
 
-![image](black_metal_venom.png)
+![Screenshot](/screenshots/black_metal_venom.png)
 
-`Black Metal`
+### Black Metal
 
-![image](black_metal.png)
+![Screenshot](/screenshots/black_metal.png)
 
-`Blazer`
+### Blazer
 
-![image](blazer.png)
+![Screenshot](/screenshots/blazer.png)
 
-`Blue Matrix`
+### Blue Matrix
 
-![image](blue_matrix.png)
+![Screenshot](/screenshots/blue_matrix.png)
 
-`BlueBerryPie`
+### BlueBerryPie
 
-![image](blueberry_pie.png)
+![Screenshot](/screenshots/blueberry_pie.png)
 
-`BlueDolphin`
+### BlueDolphin
 
-![image](BlueDolphin.png)
+![Screenshot](/screenshots/BlueDolphin.png)
 
-`BlulocoDark`
+### BlulocoDark
 
-![image](bluloco_dark.png)
+![Screenshot](/screenshots/bluloco_dark.png)
 
-`Borland`
+### Borland
 
-![image](borland.png)
+![Screenshot](/screenshots/borland.png)
 
-`Box`
+### Box
 
-![image](box.png)
+![Screenshot](/screenshots/box.png)
 
-`Breeze`
+### Breeze
 
-![image](breeze.png)
+![Screenshot](/screenshots/breeze.png)
 
-`Bright Lights`
+### Bright Lights
 
-![image](bright_lights.png)
+![Screenshot](/screenshots/bright_lights.png)
 
-`Broadcast`
+### Broadcast
 
-![image](broadcast.png)
+![Screenshot](/screenshots/broadcast.png)
 
-`Brogrammer`
+### Brogrammer
 
-![image](brogrammer.png)
+![Screenshot](/screenshots/brogrammer.png)
 
-`C64`
+### C64
 
-![image](c64.png)
+![Screenshot](/screenshots/c64.png)
 
-`Calamity`
+### Calamity
 
-![image](calamity.png)
+![Screenshot](/screenshots/calamity.png)
 
-`catppuccin-frappe`
+### catppuccin-frappe
 
-![image](catppuccin-frappe.png)
+![Screenshot](/screenshots/catppuccin-frappe.png)
 
-`catppuccin-macchiato`
+### catppuccin-macchiato
 
-![image](catppuccin-macchiato.png)
+![Screenshot](/screenshots/catppuccin-macchiato.png)
 
-`catppuccin-mocha`
+### catppuccin-mocha
 
-![image](catppuccin-mocha.png)
+![Screenshot](/screenshots/catppuccin-mocha.png)
 
-`CGA`
+### CGA
 
-![image](cga.png)
+![Screenshot](/screenshots/cga.png)
 
-`Chalk`
+### Chalk
 
-![image](chalk.png)
+![Screenshot](/screenshots/chalk.png)
 
-`Chalkboard`
+### Chalkboard
 
-![image](chalkboard.png)
+![Screenshot](/screenshots/chalkboard.png)
 
-`ChallengerDeep`
+### ChallengerDeep
 
-![image](challenger_deep.png)
+![Screenshot](/screenshots/challenger_deep.png)
 
-`Chester`
+### Chester
 
-![image](chester.png)
+![Screenshot](/screenshots/chester.png)
 
-`Ciapre`
+### Ciapre
 
-![image](ciapre.png)
+![Screenshot](/screenshots/ciapre.png)
 
-`citruszest`
+### citruszest
 
-![image](citruszest.png)
+![Screenshot](/screenshots/citruszest.png)
 
-`Cobalt Neon`
+### Cobalt Neon
 
-![image](cobalt_neon.png)
+![Screenshot](/screenshots/cobalt_neon.png)
 
-`Cobalt2`
+### Cobalt2
 
-![image](cobalt2.png)
+![Screenshot](/screenshots/cobalt2.png)
 
-`CobaltNext-Dark`
+### CobaltNext-Dark
 
-![image](cobalt_next-dark.png)
+![Screenshot](/screenshots/cobalt_next-dark.png)
 
-`CobaltNext-Minimal`
+### CobaltNext-Minimal
 
-![image](cobalt_next-minimal.png)
+![Screenshot](/screenshots/cobalt_next-minimal.png)
 
-`CobaltNext`
+### CobaltNext
 
-![image](cobalt_next.png)
+![Screenshot](/screenshots/cobalt_next.png)
 
-`CrayonPonyFish`
+### CrayonPonyFish
 
-![image](crayon_pony_fish.png)
+![Screenshot](/screenshots/crayon_pony_fish.png)
 
-`CutiePro`
+### CutiePro
 
-![image](CutiePro.png)
+![Screenshot](/screenshots/CutiePro.png)
 
-`Cyberdyne`
+### Cyberdyne
 
-![image](cyberdyne.png)
+![Screenshot](/screenshots/cyberdyne.png)
 
-`cyberpunk`
+### cyberpunk
 
-![image](cyberpunk.png)
+![Screenshot](/screenshots/cyberpunk.png)
 
-`CyberpunkScarletProtocol`
+### CyberpunkScarletProtocol
 
-![image](cyberpunk_scarlet_protocol.png)
+![Screenshot](/screenshots/cyberpunk_scarlet_protocol.png)
 
-`Dark Modern`
+### Dark Modern
 
-![image](dark_modern.png)
+![Screenshot](/screenshots/dark_modern.png)
 
-`Dark Pastel`
+### Dark Pastel
 
-![image](dark_pastel.png)
+![Screenshot](/screenshots/dark_pastel.png)
 
-`Dark+`
+### Dark+
 
-![image](dark_plus.png)
+![Screenshot](/screenshots/dark_plus.png)
 
-`darkermatrix`
+### darkermatrix
 
-![image](darkermatrix.png)
+![Screenshot](/screenshots/darkermatrix.png)
 
-`darkmatrix`
+### darkmatrix
 
-![image](darkmatrix.png)
+![Screenshot](/screenshots/darkmatrix.png)
 
-`Darkside`
+### Darkside
 
-![image](darkside.png)
+![Screenshot](/screenshots/darkside.png)
 
-`deep`
+### deep
 
-![image](deep.png)
+![Screenshot](/screenshots/deep.png)
 
-`Desert`
+### Desert
 
-![image](desert.png)
+![Screenshot](/screenshots/desert.png)
 
-`detuned`
+### detuned
 
-![image](detuned.png)
+![Screenshot](/screenshots/detuned.png)
 
-`Dimidium`
+### Dimidium
 
-![image](dimidium.png)
+![Screenshot](/screenshots/dimidium.png)
 
-`DimmedMonokai`
+### DimmedMonokai
 
-![image](dimmed_monokai.png)
+![Screenshot](/screenshots/dimmed_monokai.png)
 
-`Django`
+### Django
 
-![image](django.png)
+![Screenshot](/screenshots/django.png)
 
-`DjangoRebornAgain`
+### DjangoRebornAgain
 
-![image](DjangoRebornAgain.png)
+![Screenshot](/screenshots/DjangoRebornAgain.png)
 
-`DjangoSmooth`
+### DjangoSmooth
 
-![image](DjangoSmoothy.png)
+![Screenshot](/screenshots/DjangoSmoothy.png)
 
-`Doom Peacock`
+### Doom Peacock
 
-![image](doom_peacock.png)
+![Screenshot](/screenshots/doom_peacock.png)
 
-`DoomOne`
+### DoomOne
 
-![image](doom_one.png)
+![Screenshot](/screenshots/doom_one.png)
 
-`DotGov`
+### DotGov
 
-![image](dot_gov.png)
+![Screenshot](/screenshots/dot_gov.png)
 
-`Dracula+`
+### Dracula+
 
-![image](dracula+.png)
+![Screenshot](/screenshots/dracula+.png)
 
-`Dracula`
+### Dracula
 
-![image](dracula.png)
+![Screenshot](/screenshots/dracula.png)
 
-`duckbones`
+### duckbones
 
-![image](duckbones.png)
+![Screenshot](/screenshots/duckbones.png)
 
-`Duotone Dark`
+### Duotone Dark
 
-![image](duotone_dark.png)
+![Screenshot](/screenshots/duotone_dark.png)
 
-`Earthsong`
+### Earthsong
 
-![image](earthsong.png)
+![Screenshot](/screenshots/earthsong.png)
 
-`electron-highlighter`
+### electron-highlighter
 
-![image](electron-highlighter.png)
+![Screenshot](/screenshots/electron-highlighter.png)
 
-`Elegant`
+### Elegant
 
-![image](elegant.png)
+![Screenshot](/screenshots/elegant.png)
 
-`Elemental`
+### Elemental
 
-![image](elemental.png)
+![Screenshot](/screenshots/elemental.png)
 
-`Elementary`
+### Elementary
 
-![image](elementary.png)
+![Screenshot](/screenshots/elementary.png)
 
-`Embark`
+### Embark
 
-![image](embark.png)
+![Screenshot](/screenshots/embark.png)
 
-`embers-dark`
+### embers-dark
 
-![image](embers.png)
+![Screenshot](/screenshots/embers.png)
 
-`ENCOM`
+### ENCOM
 
-![image](encom.png)
+![Screenshot](/screenshots/encom.png)
 
-`Espresso Libre`
+### Espresso Libre
 
-![image](espresso_libre.png)
+![Screenshot](/screenshots/espresso_libre.png)
 
-`Espresso`
+### Espresso
 
-![image](espresso.png)
+![Screenshot](/screenshots/espresso.png)
 
-`Everblush`
+### Everblush
 
-![image](everblush.png)
+![Screenshot](/screenshots/everblush.png)
 
-`Everforest Dark - Hard`
+### Everforest Dark - Hard
 
-![image](everforest_dark_hard.png)
+![Screenshot](/screenshots/everforest_dark_hard.png)
 
-`Fahrenheit`
+### Fahrenheit
 
-![image](fahrenheit.png)
+![Screenshot](/screenshots/fahrenheit.png)
 
-`Fairyfloss`
+### Fairyfloss
 
-![image](fairyfloss.png)
+![Screenshot](/screenshots/fairyfloss.png)
 
-`farmhouse-dark`
+### farmhouse-dark
 
-![image](farmhouse-dark.png)
+![Screenshot](/screenshots/farmhouse-dark.png)
 
-`Fideloper`
+### Fideloper
 
-![image](fideloper.png)
+![Screenshot](/screenshots/fideloper.png)
 
-`Firefly Traditional`
+### Firefly Traditional
 
-![image](firefly-traditional.png)
+![Screenshot](/screenshots/firefly-traditional.png)
 
-`FirefoxDev`
+### FirefoxDev
 
-![image](firefox_dev.png)
+![Screenshot](/screenshots/firefox_dev.png)
 
-`Firewatch`
+### Firewatch
 
-![image](firewatch.png)
+![Screenshot](/screenshots/firewatch.png)
 
-`FishTank`
+### FishTank
 
-![image](fish_tank.png)
+![Screenshot](/screenshots/fish_tank.png)
 
-`Flat`
+### Flat
 
-![image](flat.png)
+![Screenshot](/screenshots/flat.png)
 
-`Flatland`
+### Flatland
 
-![image](flatland.png)
+![Screenshot](/screenshots/flatland.png)
 
-`flexoki-dark`
+### flexoki-dark
 
-![image](flexoki-dark.png)
+![Screenshot](/screenshots/flexoki-dark.png)
 
-`Floraverse`
+### Floraverse
 
-![image](floraverse.png)
+![Screenshot](/screenshots/floraverse.png)
 
-`ForestBlue`
+### ForestBlue
 
-![image](forest_blue.png)
+![Screenshot](/screenshots/forest_blue.png)
 
-`Framer`
+### Framer
 
-![image](framer.png)
+![Screenshot](/screenshots/framer.png)
 
-`FrontEndDelight`
+### FrontEndDelight
 
-![image](front_end_delight.png)
+![Screenshot](/screenshots/front_end_delight.png)
 
-`FunForrest`
+### FunForrest
 
-![image](fun_forrest.png)
+![Screenshot](/screenshots/fun_forrest.png)
 
-`Galaxy`
+### Galaxy
 
-![image](galaxy.png)
+![Screenshot](/screenshots/galaxy.png)
 
-`Galizur`
+### Galizur
 
-![image](galizur.png)
+![Screenshot](/screenshots/galizur.png)
 
-`Ghostty Default StyleDark`
+### Ghostty Default StyleDark
 
-![image](ghostty_default_style_dark.png)
+![Screenshot](/screenshots/ghostty_default_style_dark.png)
 
-`GitHub Dark`
+### GitHub Dark
 
-![image](github_dark.png)
+![Screenshot](/screenshots/github_dark.png)
 
-`GitHub-Dark-Colorblind`
+### GitHub-Dark-Colorblind
 
-![image](github-dark-colorblind.png)
+![Screenshot](/screenshots/github-dark-colorblind.png)
 
-`GitHub-Dark-Default`
+### GitHub-Dark-Default
 
-![image](github-dark-default.png)
+![Screenshot](/screenshots/github-dark-default.png)
 
-`GitHub-Dark-Dimmed`
+### GitHub-Dark-Dimmed
 
-![image](github-dark-dimmed.png)
+![Screenshot](/screenshots/github-dark-dimmed.png)
 
-`GitHub-Dark-High-Contrast`
+### GitHub-Dark-High-Contrast
 
-![image](github-dark-high-contrast.png)
+![Screenshot](/screenshots/github-dark-high-contrast.png)
 
-`GitLab-Dark-Grey`
+### GitLab-Dark-Grey
 
-![image](git_lab-dark-grey.png)
+![Screenshot](/screenshots/git_lab-dark-grey.png)
 
-`GitLab-Dark`
+### GitLab-Dark
 
-![image](git_lab-dark.png)
+![Screenshot](/screenshots/git_lab-dark.png)
 
-`Glacier`
+### Glacier
 
-![image](glacier.png)
+![Screenshot](/screenshots/glacier.png)
 
-`Grape`
+### Grape
 
-![image](grape.png)
+![Screenshot](/screenshots/grape.png)
 
-`Grass`
+### Grass
 
-![image](grass.png)
+![Screenshot](/screenshots/grass.png)
 
-`Grey-green`
+### Grey-green
 
-![image](grey-green.png)
+![Screenshot](/screenshots/grey-green.png)
 
-`gruber-darker`
+### gruber-darker
 
-![image](gruber-darker.png)
+![Screenshot](/screenshots/gruber-darker.png)
 
-`gruvbox-material`
+### gruvbox-material
 
-![image](gruvbox_material.png)
+![Screenshot](/screenshots/gruvbox_material.png)
 
-`GruvboxDark`
+### GruvboxDark
 
-![image](gruvbox_dark.png)
+![Screenshot](/screenshots/gruvbox_dark.png)
 
-`GruvboxDarkHard`
+### GruvboxDarkHard
 
-![image](gruvbox_dark_hard.png)
+![Screenshot](/screenshots/gruvbox_dark_hard.png)
 
-`Guezwhoz`
+### Guezwhoz
 
-![image](guezwhoz.png)
+![Screenshot](/screenshots/guezwhoz.png)
 
-`Hacktober`
+### Hacktober
 
-![image](hacktober.png)
+![Screenshot](/screenshots/hacktober.png)
 
-`Hardcore`
+### Hardcore
 
-![image](hardcore.png)
+![Screenshot](/screenshots/hardcore.png)
 
-`Harper`
+### Harper
 
-![image](harper.png)
+![Screenshot](/screenshots/harper.png)
 
-`Havn Skumring`
+### Havn Skumring
 
-![image](havn_skumring.png)
+![Screenshot](/screenshots/havn_skumring.png)
 
-`HaX0R_BLUE`
+### HaX0R_BLUE
 
-![image](hax0r_blue.png)
+![Screenshot](/screenshots/hax0r_blue.png)
 
-`HaX0R_GR33N`
+### HaX0R_GR33N
 
-![image](hax0r_gr33n.png)
+![Screenshot](/screenshots/hax0r_gr33n.png)
 
-`HaX0R_R3D`
+### HaX0R_R3D
 
-![image](hax0r_r3d.png)
+![Screenshot](/screenshots/hax0r_r3d.png)
 
-`heeler`
+### heeler
 
-![image](heeler.png)
+![Screenshot](/screenshots/heeler.png)
 
-`Highway`
+### Highway
 
-![image](highway.png)
+![Screenshot](/screenshots/highway.png)
 
-`Hipster Green`
+### Hipster Green
 
-![image](hipster_green.png)
+![Screenshot](/screenshots/hipster_green.png)
 
-`Hivacruz`
+### Hivacruz
 
-![image](hivacruz.png)
+![Screenshot](/screenshots/hivacruz.png)
 
-`Homebrew`
+### Homebrew
 
-![image](homebrew.png)
+![Screenshot](/screenshots/homebrew.png)
 
-`Hopscotch.256`
+### Hopscotch.256
 
-![image](hopscotch_256.png)
+![Screenshot](/screenshots/hopscotch_256.png)
 
-`Hopscotch`
+### Hopscotch
 
-![image](hopscotch.png)
+![Screenshot](/screenshots/hopscotch.png)
 
-`Horizon`
+### Horizon
 
-![image](horizon.png)
+![Screenshot](/screenshots/horizon.png)
 
-`Hurtado`
+### Hurtado
 
-![image](hurtado.png)
+![Screenshot](/screenshots/hurtado.png)
 
-`Hybrid`
+### Hybrid
 
-![image](hybrid.png)
+![Screenshot](/screenshots/hybrid.png)
 
-`IC_Green_PPL`
+### IC_Green_PPL
 
-![image](ic_green_ppl.png)
+![Screenshot](/screenshots/ic_green_ppl.png)
 
-`IC_Orange_PPL`
+### IC_Orange_PPL
 
-![image](ic_orange_ppl.png)
+![Screenshot](/screenshots/ic_orange_ppl.png)
 
-`iceberg-dark`
+### iceberg-dark
 
-![image](iceberg.png)
+![Screenshot](/screenshots/iceberg.png)
 
-`idea`
+### idea
 
-![image](idea.png)
+![Screenshot](/screenshots/idea.png)
 
-`idleToes`
+### idleToes
 
-![image](idleToes.png)
+![Screenshot](/screenshots/idleToes.png)
 
-`IR_Black`
+### IR_Black
 
-![image](ir_black.png)
+![Screenshot](/screenshots/ir_black.png)
 
-`IRIX Console`
+### IRIX Console
 
-![image](irix_console.png)
+![Screenshot](/screenshots/irix_console.png)
 
-`IRIX Terminal`
+### IRIX Terminal
 
-![image](irix_terminal.png)
+![Screenshot](/screenshots/irix_terminal.png)
 
-`iTerm2 Dark Background`
+### iTerm2 Dark Background
 
-![image](iterm2-dark-background.png)
+![Screenshot](/screenshots/iterm2-dark-background.png)
 
-`iTerm2 Default`
+### iTerm2 Default
 
-![image](iterm2-default.png)
+![Screenshot](/screenshots/iterm2-default.png)
 
-`iTerm2 Pastel Dark Background`
+### iTerm2 Pastel Dark Background
 
-![image](iterm2-pastel-dark-background.png)
+![Screenshot](/screenshots/iterm2-pastel-dark-background.png)
 
-`iTerm2 Smoooooth`
+### iTerm2 Smoooooth
 
-![image](iterm2-smoooooth.png)
+![Screenshot](/screenshots/iterm2-smoooooth.png)
 
-`iTerm2 Solarized Dark`
+### iTerm2 Solarized Dark
 
-![image](iterm2-solarized-dark.png)
+![Screenshot](/screenshots/iterm2-solarized-dark.png)
 
-`iTerm2 Tango Dark`
+### iTerm2 Tango Dark
 
-![image](iterm2-tango-dark.png)
+![Screenshot](/screenshots/iterm2-tango-dark.png)
 
-`Jackie Brown`
+### Jackie Brown
 
-![image](jackie_brown.png)
+![Screenshot](/screenshots/jackie_brown.png)
 
-`Japanesque`
+### Japanesque
 
-![image](japanesque.png)
+![Screenshot](/screenshots/japanesque.png)
 
-`Jellybeans`
+### Jellybeans
 
-![image](jellybeans.png)
+![Screenshot](/screenshots/jellybeans.png)
 
-`JetBrains Darcula`
+### JetBrains Darcula
 
-![image](jetbrains_darcula.png)
+![Screenshot](/screenshots/jetbrains_darcula.png)
 
-`jubi`
+### jubi
 
-![image](jubi.png)
+![Screenshot](/screenshots/jubi.png)
 
-`Kanagawa Dragon`
+### Kanagawa Dragon
 
-![image](kanagawa-dragon.png)
+![Screenshot](/screenshots/kanagawa-dragon.png)
 
-`Kanagawa Wave`
+### Kanagawa Wave
 
-![image](kanagawa-wave.png)
+![Screenshot](/screenshots/kanagawa-wave.png)
 
-`kanagawabones`
+### kanagawabones
 
-![image](kanagawabones.png)
+![Screenshot](/screenshots/kanagawabones.png)
 
-`Kibble`
+### Kibble
 
-![image](kibble.png)
+![Screenshot](/screenshots/kibble.png)
 
-`Kolorit`
+### Kolorit
 
-![image](kolorit.png)
+![Screenshot](/screenshots/kolorit.png)
 
-`Konsolas`
+### Konsolas
 
-![image](konsolas.png)
+![Screenshot](/screenshots/konsolas.png)
 
-`kurokula`
+### kurokula
 
-![image](kurokula.png)
+![Screenshot](/screenshots/kurokula.png)
 
-`Lab Fox`
+### Lab Fox
 
-![image](lab_fox.png)
+![Screenshot](/screenshots/lab_fox.png)
 
-`Laser`
+### Laser
 
-![image](laser.png)
+![Screenshot](/screenshots/laser.png)
 
-`Later This Evening`
+### Later This Evening
 
-![image](later_this_evening.png)
+![Screenshot](/screenshots/later_this_evening.png)
 
-`Lavandula`
+### Lavandula
 
-![image](lavandula.png)
+![Screenshot](/screenshots/lavandula.png)
 
-`LiquidCarbon`
+### LiquidCarbon
 
-![image](liquid_carbon.png)
+![Screenshot](/screenshots/liquid_carbon.png)
 
-`LiquidCarbonTransparent`
+### LiquidCarbonTransparent
 
-![image](liquid_carbon_transparent.png)
+![Screenshot](/screenshots/liquid_carbon_transparent.png)
 
-`LiquidCarbonTransparentInverse`
+### LiquidCarbonTransparentInverse
 
-![image](liquid_carbon_transparent_inverse.png)
+![Screenshot](/screenshots/liquid_carbon_transparent_inverse.png)
 
-`lovelace`
+### lovelace
 
-![image](lovelace.png)
+![Screenshot](/screenshots/lovelace.png)
 
-`Mariana`
+### Mariana
 
-![image](mariana.png)
+![Screenshot](/screenshots/mariana.png)
 
-`MaterialDark`
+### MaterialDark
 
-![image](material_dark.png)
+![Screenshot](/screenshots/material_dark.png)
 
-`MaterialDarker`
+### MaterialDarker
 
-![image](material_darker.png)
+![Screenshot](/screenshots/material_darker.png)
 
-`MaterialDesignColors`
+### MaterialDesignColors
 
-![image](material_design_colors.png)
+![Screenshot](/screenshots/material_design_colors.png)
 
-`MaterialOcean`
+### MaterialOcean
 
-![image](material_ocean.png)
+![Screenshot](/screenshots/material_ocean.png)
 
-`Mathias`
+### Mathias
 
-![image](mathias.png)
+![Screenshot](/screenshots/mathias.png)
 
-`matrix`
+### matrix
 
-![image](matrix.png)
+![Screenshot](/screenshots/matrix.png)
 
-`Medallion`
+### Medallion
 
-![image](medallion.png)
+![Screenshot](/screenshots/medallion.png)
 
-`Melange_dark`
+### Melange_dark
 
-![image](melange_dark.png)
+![Screenshot](/screenshots/melange_dark.png)
 
-`Mellifluous`
+### Mellifluous
 
-![image](mellifluous.png)
+![Screenshot](/screenshots/mellifluous.png)
 
-`mellow`
+### mellow
 
-![image](mellow.png)
+![Screenshot](/screenshots/mellow.png)
 
-`miasma`
+### miasma
 
-![image](miasma.png)
+![Screenshot](/screenshots/miasma.png)
 
-`midnight-in-mojave`
+### midnight-in-mojave
 
-![image](midnight_in_mojave.png)
+![Screenshot](/screenshots/midnight_in_mojave.png)
 
-`Mirage`
+### Mirage
 
-![image](mirage.png)
+![Screenshot](/screenshots/mirage.png)
 
-`Misterioso`
+### Misterioso
 
-![image](misterioso.png)
+![Screenshot](/screenshots/misterioso.png)
 
-`Molokai`
+### Molokai
 
-![image](molokai.png)
+![Screenshot](/screenshots/molokai.png)
 
-`MonaLisa`
+### MonaLisa
 
-![image](mona_lisa.png)
+![Screenshot](/screenshots/mona_lisa.png)
 
-`Monokai Classic`
+### Monokai Classic
 
-![image](monokai_classic.png)
+![Screenshot](/screenshots/monokai_classic.png)
 
-`Monokai Pro Machine`
+### Monokai Pro Machine
 
-![image](monokai_pro_machine.png)
+![Screenshot](/screenshots/monokai_pro_machine.png)
 
-`Monokai Pro Octagon`
+### Monokai Pro Octagon
 
-![image](monokai_pro_octagon.png)
+![Screenshot](/screenshots/monokai_pro_octagon.png)
 
-`Monokai Pro Ristretto`
+### Monokai Pro Ristretto
 
-![image](monokai_pro_ristretto.png)
+![Screenshot](/screenshots/monokai_pro_ristretto.png)
 
-`Monokai Pro Spectrum`
+### Monokai Pro Spectrum
 
-![image](monokai_pro_spectrum.png)
+![Screenshot](/screenshots/monokai_pro_spectrum.png)
 
-`Monokai Pro`
+### Monokai Pro
 
-![image](monokai_pro.png)
+![Screenshot](/screenshots/monokai_pro.png)
 
-`Monokai Remastered`
+### Monokai Remastered
 
-![image](monokai_remastered.png)
+![Screenshot](/screenshots/monokai_remastered.png)
 
-`Monokai Soda`
+### Monokai Soda
 
-![image](monokai_soda.png)
+![Screenshot](/screenshots/monokai_soda.png)
 
-`Monokai Vivid`
+### Monokai Vivid
 
-![image](monokai_vivid.png)
+![Screenshot](/screenshots/monokai_vivid.png)
 
-`moonfly`
+### moonfly
 
-![image](moonfly.png)
+![Screenshot](/screenshots/moonfly.png)
 
-`N0tch2k`
+### N0tch2k
 
-![image](n0tch2k.png)
+![Screenshot](/screenshots/n0tch2k.png)
 
-`neobones_dark`
+### neobones_dark
 
-![image](neobones_dark.png)
+![Screenshot](/screenshots/neobones_dark.png)
 
-`Neon`
+### Neon
 
-![image](neon.png)
+![Screenshot](/screenshots/neon.png)
 
-`Neopolitan`
+### Neopolitan
 
-![image](neopolitan.png)
+![Screenshot](/screenshots/neopolitan.png)
 
-`Neutron`
+### Neutron
 
-![image](neutron.png)
+![Screenshot](/screenshots/neutron.png)
 
-`nightfox`
+### nightfox
 
-![image](nightfox.png)
+![Screenshot](/screenshots/nightfox.png)
 
-`NightLion v1`
+### NightLion v1
 
-![image](nightlion_v1.png)
+![Screenshot](/screenshots/nightlion_v1.png)
 
-`NightLion v2`
+### NightLion v2
 
-![image](nightlion_v2.png)
+![Screenshot](/screenshots/nightlion_v2.png)
 
-`NightOwl`
+### NightOwl
 
-![image](night_owl.png)
+![Screenshot](/screenshots/night_owl.png)
 
-`niji`
+### niji
 
-![image](niji.png)
+![Screenshot](/screenshots/niji.png)
 
-`Nocturnal Winter`
+### Nocturnal Winter
 
-![image](nocturnal_winter.png)
+![Screenshot](/screenshots/nocturnal_winter.png)
 
-`nord-wave`
+### nord-wave
 
-![image](nord-wave.png)
+![Screenshot](/screenshots/nord-wave.png)
 
-`nord`
+### nord
 
-![image](nord.png)
+![Screenshot](/screenshots/nord.png)
 
-`NvimDark`
+### NvimDark
 
-![image](NvimDark.png)
+![Screenshot](/screenshots/NvimDark.png)
 
-`Obsidian`
+### Obsidian
 
-![image](obsidian.png)
+![Screenshot](/screenshots/obsidian.png)
 
-`Ocean`
+### Ocean
 
-![image](ocean.png)
+![Screenshot](/screenshots/ocean.png)
 
-`Oceanic-Next`
+### Oceanic-Next
 
-![image](oceanic_next.png)
+![Screenshot](/screenshots/oceanic_next.png)
 
-`OceanicMaterial`
+### OceanicMaterial
 
-![image](oceanic_material.png)
+![Screenshot](/screenshots/oceanic_material.png)
 
-`Ollie`
+### Ollie
 
-![image](ollie.png)
+![Screenshot](/screenshots/ollie.png)
 
-`One Double Dark`
+### One Double Dark
 
-![image](one_double_dark.png)
+![Screenshot](/screenshots/one_double_dark.png)
 
-`OneHalfDark`
+### OneHalfDark
 
-![image](onehalfdark.png)
+![Screenshot](/screenshots/onehalfdark.png)
 
-`Operator Mono Dark`
+### Operator Mono Dark
 
-![image](operator_mono_dark.png)
+![Screenshot](/screenshots/operator_mono_dark.png)
 
-`Overnight Slumber`
+### Overnight Slumber
 
-![image](overnight_slumber.png)
+![Screenshot](/screenshots/overnight_slumber.png)
 
-`Oxocarbon`
+### Oxocarbon
 
-![image](oxocarbon.png)
+![Screenshot](/screenshots/oxocarbon.png)
 
-`PaleNightHC`
+### PaleNightHC
 
-![image](PaleNightHC.png)
+![Screenshot](/screenshots/PaleNightHC.png)
 
-`Pandora`
+### Pandora
 
-![image](pandora.png)
+![Screenshot](/screenshots/pandora.png)
 
-`Paraiso Dark`
+### Paraiso Dark
 
-![image](paraiso_dark.png)
+![Screenshot](/screenshots/paraiso_dark.png)
 
-`PaulMillr`
+### PaulMillr
 
-![image](paul_millr.png)
+![Screenshot](/screenshots/paul_millr.png)
 
-`PencilDark`
+### PencilDark
 
-![image](pencil_dark.png)
+![Screenshot](/screenshots/pencil_dark.png)
 
-`Peppermint`
+### Peppermint
 
-![image](peppermint.png)
+![Screenshot](/screenshots/peppermint.png)
 
-`Phala Green Dark`
+### Phala Green Dark
 
-![image](phala_green_dark.png)
+![Screenshot](/screenshots/phala_green_dark.png)
 
-`Pnevma`
+### Pnevma
 
-![image](pnevma.png)
+![Screenshot](/screenshots/pnevma.png)
 
-`Popping and Locking`
+### Popping and Locking
 
-![image](popping_and_locking.png)
+![Screenshot](/screenshots/popping_and_locking.png)
 
-`Pro`
+### Pro
 
-![image](pro.png)
+![Screenshot](/screenshots/pro.png)
 
-`Purple Rain`
+### Purple Rain
 
-![image](purple_rain.png)
+![Screenshot](/screenshots/purple_rain.png)
 
-`purplepeter`
+### purplepeter
 
-![image](purplepeter.png)
+![Screenshot](/screenshots/purplepeter.png)
 
-`Rapture`
+### Rapture
 
-![image](rapture.png)
+![Screenshot](/screenshots/rapture.png)
 
-`Raycast_Dark`
+### Raycast_Dark
 
-![image](raycast_dark.png)
+![Screenshot](/screenshots/raycast_dark.png)
 
-`rebecca`
+### rebecca
 
-![image](rebecca.png)
+![Screenshot](/screenshots/rebecca.png)
 
-`Red Alert`
+### Red Alert
 
-![image](red_alert.png)
+![Screenshot](/screenshots/red_alert.png)
 
-`Red Planet`
+### Red Planet
 
-![image](red_planet.png)
+![Screenshot](/screenshots/red_planet.png)
 
-`Red Sands`
+### Red Sands
 
-![image](red_sands.png)
+![Screenshot](/screenshots/red_sands.png)
 
-`Relaxed`
+### Relaxed
 
-![image](relaxed.png)
+![Screenshot](/screenshots/relaxed.png)
 
-`Retro`
+### Retro
 
-![image](retro.png)
+![Screenshot](/screenshots/retro.png)
 
-`RetroLegends`
+### RetroLegends
 
-![image](RetroLegends.png)
+![Screenshot](/screenshots/RetroLegends.png)
 
-`Rippedcasts`
+### Rippedcasts
 
-![image](rippedcasts.png)
+![Screenshot](/screenshots/rippedcasts.png)
 
-`rose-pine-moon`
+### rose-pine-moon
 
-![image](rose-pine-moon.png)
+![Screenshot](/screenshots/rose-pine-moon.png)
 
-`rose-pine`
+### rose-pine
 
-![image](rose-pine.png)
+![Screenshot](/screenshots/rose-pine.png)
 
-`Rouge 2`
+### Rouge 2
 
-![image](rouge_2.png)
+![Screenshot](/screenshots/rouge_2.png)
 
-`Royal`
+### Royal
 
-![image](royal.png)
+![Screenshot](/screenshots/royal.png)
 
-`Ryuuko`
+### Ryuuko
 
-![image](ryuuko.png)
+![Screenshot](/screenshots/ryuuko.png)
 
-`Sakura`
+### Sakura
 
-![image](sakura.png)
+![Screenshot](/screenshots/sakura.png)
 
-`Scarlet Protocol`
+### Scarlet Protocol
 
-![image](scarlet_protocol.png)
+![Screenshot](/screenshots/scarlet_protocol.png)
 
-`Seafoam Pastel`
+### Seafoam Pastel
 
-![image](seafoam_pastel.png)
+![Screenshot](/screenshots/seafoam_pastel.png)
 
-`SeaShells`
+### SeaShells
 
-![image](sea_shells.png)
+![Screenshot](/screenshots/sea_shells.png)
 
-`selenized-dark`
+### selenized-dark
 
-![image](selenized-dark.png)
+![Screenshot](/screenshots/selenized-dark.png)
 
-`seoulbones_dark`
+### seoulbones_dark
 
-![image](seoulbones_dark.png)
+![Screenshot](/screenshots/seoulbones_dark.png)
 
-`Seti`
+### Seti
 
-![image](seti.png)
+![Screenshot](/screenshots/seti.png)
 
-`shades-of-purple`
+### shades-of-purple
 
-![image](ShadesOfPurple.png)
+![Screenshot](/screenshots/ShadesOfPurple.png)
 
-`Shaman`
+### Shaman
 
-![image](shaman.png)
+![Screenshot](/screenshots/shaman.png)
 
-`Slate`
+### Slate
 
-![image](slate.png)
+![Screenshot](/screenshots/slate.png)
 
-`SleepyHollow`
+### SleepyHollow
 
-![image](SleepyHollow.png)
+![Screenshot](/screenshots/SleepyHollow.png)
 
-`Smyck`
+### Smyck
 
-![image](smyck.png)
+![Screenshot](/screenshots/smyck.png)
 
-`Snazzy Soft`
+### Snazzy Soft
 
-![image](snazzy_soft.png)
+![Screenshot](/screenshots/snazzy_soft.png)
 
-`Snazzy`
+### Snazzy
 
-![image](snazzy.png)
+![Screenshot](/screenshots/snazzy.png)
 
-`SoftServer`
+### SoftServer
 
-![image](soft_server.png)
+![Screenshot](/screenshots/soft_server.png)
 
-`Solarized Darcula`
+### Solarized Darcula
 
-![image](solarized_darcula.png)
+![Screenshot](/screenshots/solarized_darcula.png)
 
-`Solarized Dark - Patched`
+### Solarized Dark - Patched
 
-![image](solarized_dark_patched.png)
+![Screenshot](/screenshots/solarized_dark_patched.png)
 
-`Solarized Dark Higher Contrast`
+### Solarized Dark Higher Contrast
 
-![image](solarized_dark_higher_contrast.png)
+![Screenshot](/screenshots/solarized_dark_higher_contrast.png)
 
-`solarized-osaka-night`
+### solarized-osaka-night
 
-![image](solarized-osaka-night.png)
+![Screenshot](/screenshots/solarized-osaka-night.png)
 
-`sonokai`
+### sonokai
 
-![image](sonokai.png)
+![Screenshot](/screenshots/sonokai.png)
 
-`Spacedust`
+### Spacedust
 
-![image](spacedust.png)
+![Screenshot](/screenshots/spacedust.png)
 
-`SpaceGray Bright`
+### SpaceGray Bright
 
-![image](spacegray_bright.png)
+![Screenshot](/screenshots/spacegray_bright.png)
 
-`SpaceGray Eighties Dull`
+### SpaceGray Eighties Dull
 
-![image](spacegray_eighties_dull.png)
+![Screenshot](/screenshots/spacegray_eighties_dull.png)
 
-`SpaceGray Eighties`
+### SpaceGray Eighties
 
-![image](spacegray_eighties.png)
+![Screenshot](/screenshots/spacegray_eighties.png)
 
-`SpaceGray`
+### SpaceGray
 
-![image](space_gray.png)
+![Screenshot](/screenshots/space_gray.png)
 
-`Spiderman`
+### Spiderman
 
-![image](spiderman.png)
+![Screenshot](/screenshots/spiderman.png)
 
-`Square`
+### Square
 
-![image](square.png)
+![Screenshot](/screenshots/square.png)
 
-`Squirrelsong Dark`
+### Squirrelsong Dark
 
-![image](squirrelsong_dark.png)
+![Screenshot](/screenshots/squirrelsong_dark.png)
 
-`srcery`
+### srcery
 
-![image](srcery.png)
+![Screenshot](/screenshots/srcery.png)
 
-`starlight`
+### starlight
 
-![image](starlight.png)
+![Screenshot](/screenshots/starlight.png)
 
-`Sublette`
+### Sublette
 
-![image](sublette.png)
+![Screenshot](/screenshots/sublette.png)
 
-`Subliminal`
+### Subliminal
 
-![image](subliminal.png)
+![Screenshot](/screenshots/subliminal.png)
 
-`Sugarplum`
+### Sugarplum
 
-![image](sugarplum.png)
+![Screenshot](/screenshots/sugarplum.png)
 
-`Sundried`
+### Sundried
 
-![image](sundried.png)
+![Screenshot](/screenshots/sundried.png)
 
-`Symfonic`
+### Symfonic
 
-![image](symfonic.png)
+![Screenshot](/screenshots/symfonic.png)
 
-`synthwave-everything`
+### synthwave-everything
 
-![image](synthwave-everything.png)
+![Screenshot](/screenshots/synthwave-everything.png)
 
-`synthwave`
+### synthwave
 
-![image](synthwave.png)
+![Screenshot](/screenshots/synthwave.png)
 
-`SynthwaveAlpha`
+### SynthwaveAlpha
 
-![image](synthwave_alpha.png)
+![Screenshot](/screenshots/synthwave_alpha.png)
 
-`Tearout`
+### Tearout
 
-![image](tearout.png)
+![Screenshot](/screenshots/tearout.png)
 
-`Teerb`
+### Teerb
 
-![image](teerb.png)
+![Screenshot](/screenshots/teerb.png)
 
-`terafox`
+### terafox
 
-![image](terafox.png)
+![Screenshot](/screenshots/terafox.png)
 
-`Terminal Basic Dark`
+### Terminal Basic Dark
 
-![image](terminal_basic_dark.png)
+![Screenshot](/screenshots/terminal_basic_dark.png)
 
-`Thayer Bright`
+### Thayer Bright
 
-![image](thayer_bright.png)
+![Screenshot](/screenshots/thayer_bright.png)
 
-`The Hulk`
+### The Hulk
 
-![image](the_hulk.png)
+![Screenshot](/screenshots/the_hulk.png)
 
-`Tinacious Design (Dark)`
+### Tinacious Design (Dark)
 
-![image](tinacious_design_dark.png)
+![Screenshot](/screenshots/tinacious_design_dark.png)
 
-`tokyonight-storm`
+### tokyonight-storm
 
-![image](tokyonight-storm.png)
+![Screenshot](/screenshots/tokyonight-storm.png)
 
-`tokyonight`
+### tokyonight
 
-![image](tokyonight.png)
+![Screenshot](/screenshots/tokyonight.png)
 
-`tokyonight_moon`
+### tokyonight_moon
 
-![image](tokyonight-moon.png)
+![Screenshot](/screenshots/tokyonight-moon.png)
 
-`tokyonight_night`
+### tokyonight_night
 
-![image](tokyonight-night.png)
+![Screenshot](/screenshots/tokyonight-night.png)
 
-`Tomorrow Night Blue`
+### Tomorrow Night Blue
 
-![image](tomorrow_night_blue.png)
+![Screenshot](/screenshots/tomorrow_night_blue.png)
 
-`Tomorrow Night Bright`
+### Tomorrow Night Bright
 
-![image](tomorrow_night_bright.png)
+![Screenshot](/screenshots/tomorrow_night_bright.png)
 
-`Tomorrow Night Burns`
+### Tomorrow Night Burns
 
-![image](tomorrow_night_burns.png)
+![Screenshot](/screenshots/tomorrow_night_burns.png)
 
-`Tomorrow Night Eighties`
+### Tomorrow Night Eighties
 
-![image](tomorrow_night_eighties.png)
+![Screenshot](/screenshots/tomorrow_night_eighties.png)
 
-`Tomorrow Night`
+### Tomorrow Night
 
-![image](tomorrow_night.png)
+![Screenshot](/screenshots/tomorrow_night.png)
 
-`ToyChest`
+### ToyChest
 
-![image](toy_chest.png)
+![Screenshot](/screenshots/toy_chest.png)
 
-`Treehouse`
+### Treehouse
 
-![image](treehouse.png)
+![Screenshot](/screenshots/treehouse.png)
 
-`Twilight`
+### Twilight
 
-![image](twilight.png)
+![Screenshot](/screenshots/twilight.png)
 
-`Ubuntu`
+### Ubuntu
 
-![image](ubuntu.png)
+![Screenshot](/screenshots/ubuntu.png)
 
-`UltraDark`
+### UltraDark
 
-![image](ultradark.png)
+![Screenshot](/screenshots/ultradark.png)
 
-`UltraViolent`
+### UltraViolent
 
-![image](ultra_violent.png)
+![Screenshot](/screenshots/ultra_violent.png)
 
-`UnderTheSea`
+### UnderTheSea
 
-![image](under_the_sea.png)
+![Screenshot](/screenshots/under_the_sea.png)
 
-`Urple`
+### Urple
 
-![image](urple.png)
+![Screenshot](/screenshots/urple.png)
 
-`Vague`
+### Vague
 
-![image](vague.png)
+![Screenshot](/screenshots/vague.png)
 
-`Vaughn`
+### Vaughn
 
-![image](vaughn.png)
+![Screenshot](/screenshots/vaughn.png)
 
-`Vesper`
+### Vesper
 
-![image](vesper.png)
+![Screenshot](/screenshots/vesper.png)
 
-`VibrantInk`
+### VibrantInk
 
-![image](vibrant_ink.png)
+![Screenshot](/screenshots/vibrant_ink.png)
 
-`Violet Dark`
+### Violet Dark
 
-![image](violet_dark.png)
+![Screenshot](/screenshots/violet_dark.png)
 
-`violite`
+### violite
 
-![image](violite.png)
+![Screenshot](/screenshots/violite.png)
 
-`WarmNeon`
+### WarmNeon
 
-![image](warm_neon.png)
+![Screenshot](/screenshots/warm_neon.png)
 
-`Wez`
+### Wez
 
-![image](wez.png)
+![Screenshot](/screenshots/wez.png)
 
-`Whimsy`
+### Whimsy
 
-![image](whimsy.png)
+![Screenshot](/screenshots/whimsy.png)
 
-`WildCherry`
+### WildCherry
 
-![image](wild_cherry.png)
+![Screenshot](/screenshots/wild_cherry.png)
 
-`wilmersdorf`
+### wilmersdorf
 
-![image](wilmersdorf.png)
+![Screenshot](/screenshots/wilmersdorf.png)
 
-`Wombat`
+### Wombat
 
-![image](wombat.png)
+![Screenshot](/screenshots/wombat.png)
 
-`Wryan`
+### Wryan
 
-![image](wryan.png)
+![Screenshot](/screenshots/wryan.png)
 
-`xcodedark`
+### xcodedark
 
-![image](xcodedark.png)
+![Screenshot](/screenshots/xcodedark.png)
 
-`xcodedarkhc`
+### xcodedarkhc
 
-![image](xcodedarkhc.png)
+![Screenshot](/screenshots/xcodedarkhc.png)
 
-`xcodewwdc`
+### xcodewwdc
 
-![image](xcodewwdc.png)
+![Screenshot](/screenshots/xcodewwdc.png)
 
-`zenbones_dark`
+### zenbones_dark
 
-![image](zenbones_dark.png)
+![Screenshot](/screenshots/zenbones_dark.png)
 
-`Zenburn`
+### Zenburn
 
-![image](zenburn.png)
+![Screenshot](/screenshots/zenburn.png)
 
-`zenburned`
+### zenburned
 
-![image](zenburned.png)
+![Screenshot](/screenshots/zenburned.png)
 
-`zenwritten_dark`
+### zenwritten_dark
 
-![image](zenwritten_dark.png)
+![Screenshot](/screenshots/zenwritten_dark.png)
 
-## Light Themes<a name="lightthemes"><a/>
+### Light Themes<a name="lightthemes"><a/>
 
-`3024 Day`
+### 3024 Day
 
-![image](3024_day.png)
+![Screenshot](/screenshots/3024_day.png)
 
-`Adwaita`
+### Adwaita
 
-![image](adwaita.png)
+![Screenshot](/screenshots/adwaita.png)
 
-`Alabaster`
+### Alabaster
 
-![image](alabaster.png)
+![Screenshot](/screenshots/alabaster.png)
 
-`Apple System Colors Light`
+### Apple System Colors Light
 
-![image](apple_system_colors_light.png)
+![Screenshot](/screenshots/apple_system_colors_light.png)
 
-`AtomOneLight`
+### AtomOneLight
 
-![image](atom_one_light.png)
+![Screenshot](/screenshots/atom_one_light.png)
 
-`ayu_light`
+### ayu_light
 
-![image](ayu_light.png)
+![Screenshot](/screenshots/ayu_light.png)
 
-`Belafonte Day`
+### Belafonte Day
 
-![image](belafonte_day.png)
+![Screenshot](/screenshots/belafonte_day.png)
 
-`BlulocoLight`
+### BlulocoLight
 
-![image](bluloco_light.png)
+![Screenshot](/screenshots/bluloco_light.png)
 
-`Breadog`
+### Breadog
 
-![image](breadog.png)
+![Screenshot](/screenshots/breadog.png)
 
-`catppuccin-latte`
+### catppuccin-latte
 
-![image](catppuccin-latte.png)
+![Screenshot](/screenshots/catppuccin-latte.png)
 
-`CLRS`
+### CLRS
 
-![image](clrs.png)
+![Screenshot](/screenshots/clrs.png)
 
-`coffee_theme`
+### coffee_theme
 
-![image](Coffee.png)
+![Screenshot](/screenshots/Coffee.png)
 
-`dayfox`
+### dayfox
 
-![image](dayfox.png)
+![Screenshot](/screenshots/dayfox.png)
 
-`Everforest Light - Med`
+### Everforest Light - Med
 
-![image](everforest_light_med.png)
+![Screenshot](/screenshots/everforest_light_med.png)
 
-`farmhouse-light`
+### farmhouse-light
 
-![image](farmhouse-light.png)
+![Screenshot](/screenshots/farmhouse-light.png)
 
-`flexoki-light`
+### flexoki-light
 
-![image](flexoki-light.png)
+![Screenshot](/screenshots/flexoki-light.png)
 
-`GitHub-Light-Colorblind`
+### GitHub-Light-Colorblind
 
-![image](github-light-colorblind.png)
+![Screenshot](/screenshots/github-light-colorblind.png)
 
-`GitHub-Light-Default`
+### GitHub-Light-Default
 
-![image](github-light-default.png)
+![Screenshot](/screenshots/github-light-default.png)
 
-`GitHub-Light-High-Contrast`
+### GitHub-Light-High-Contrast
 
-![image](github-light-high-contrast.png)
+![Screenshot](/screenshots/github-light-high-contrast.png)
 
-`Github`
+### Github
 
-![image](github.png)
+![Screenshot](/screenshots/github.png)
 
-`GitLab-Light`
+### GitLab-Light
 
-![image](git_lab-light.png)
+![Screenshot](/screenshots/git_lab-light.png)
 
-`GruvboxLight`
+### GruvboxLight
 
-![image](gruvbox_light.png)
+![Screenshot](/screenshots/gruvbox_light.png)
 
-`GruvboxLightHard`
+### GruvboxLightHard
 
-![image](gruvbox_light_hard.png)
+![Screenshot](/screenshots/gruvbox_light_hard.png)
 
-`Havn Daggry`
+### Havn Daggry
 
-![image](havn_daggry.png)
+![Screenshot](/screenshots/havn_daggry.png)
 
-`Horizon-Bright`
+### Horizon-Bright
 
-![image](horizon-bright.png)
+![Screenshot](/screenshots/horizon-bright.png)
 
-`iceberg-light`
+### iceberg-light
 
-![image](iceberg-light.png)
+![Screenshot](/screenshots/iceberg-light.png)
 
-`iTerm2 Light Background`
+### iTerm2 Light Background
 
-![image](iterm2-light-background.png)
+![Screenshot](/screenshots/iterm2-light-background.png)
 
-`iTerm2 Solarized Light`
+### iTerm2 Solarized Light
 
-![image](iterm2-solarized-light.png)
+![Screenshot](/screenshots/iterm2-solarized-light.png)
 
-`iTerm2 Tango Light`
+### iTerm2 Tango Light
 
-![image](iterm2-tango-light.png)
+![Screenshot](/screenshots/iterm2-tango-light.png)
 
-`LightOwl`
+### LightOwl
 
-![image](light_owl.png)
+![Screenshot](/screenshots/light_owl.png)
 
-`Man Page`
+### Man Page
 
-![image](man_page.png)
+![Screenshot](/screenshots/man_page.png)
 
-`Material`
+### Material
 
-![image](material.png)
+![Screenshot](/screenshots/material.png)
 
-`Melange_light`
+### Melange_light
 
-![image](melange_light.png)
+![Screenshot](/screenshots/melange_light.png)
 
-`Monokai Pro Light Sun`
+### Monokai Pro Light Sun
 
-![image](monokai_pro_light_sun.png)
+![Screenshot](/screenshots/monokai_pro_light_sun.png)
 
-`Monokai Pro Light`
+### Monokai Pro Light
 
-![image](monokai_pro_light.png)
+![Screenshot](/screenshots/monokai_pro_light.png)
 
-`neobones_light`
+### neobones_light
 
-![image](neobones_light.png)
+![Screenshot](/screenshots/neobones_light.png)
 
-`Night Owlish Light`
+### Night Owlish Light
 
-![image](night_owlish_light.png)
+![Screenshot](/screenshots/night_owlish_light.png)
 
-`nord-light`
+### nord-light
 
-![image](nord_light.png)
+![Screenshot](/screenshots/nord_light.png)
 
-`Novel`
+### Novel
 
-![image](novel.png)
+![Screenshot](/screenshots/novel.png)
 
-`NvimLight`
+### NvimLight
 
-![image](NvimLight.png)
+![Screenshot](/screenshots/NvimLight.png)
 
-`One Double Light`
+### One Double Light
 
-![image](one_double_light.png)
+![Screenshot](/screenshots/one_double_light.png)
 
-`OneHalfLight`
+### OneHalfLight
 
-![image](onehalflight.png)
+![Screenshot](/screenshots/onehalflight.png)
 
-`PencilLight`
+### PencilLight
 
-![image](pencil_light.png)
+![Screenshot](/screenshots/pencil_light.png)
 
-`Piatto Light`
+### Piatto Light
 
-![image](piatto_light.png)
+![Screenshot](/screenshots/piatto_light.png)
 
-`primary`
+### primary
 
-![image](primary.png)
+![Screenshot](/screenshots/primary.png)
 
-`Pro Light`
+### Pro Light
 
-![image](pro_light.png)
+![Screenshot](/screenshots/pro_light.png)
 
-`Raycast_Light`
+### Raycast_Light
 
-![image](raycast_light.png)
+![Screenshot](/screenshots/raycast_light.png)
 
-`rose-pine-dawn`
+### rose-pine-dawn
 
-![image](rose-pine-dawn.png)
+![Screenshot](/screenshots/rose-pine-dawn.png)
 
-`selenized-light`
+### selenized-light
 
-![image](selenized-light.png)
+![Screenshot](/screenshots/selenized-light.png)
 
-`seoulbones_light`
+### seoulbones_light
 
-![image](seoulbones_light.png)
+![Screenshot](/screenshots/seoulbones_light.png)
 
-`Spring`
+### Spring
 
-![image](spring.png)
+![Screenshot](/screenshots/spring.png)
 
-`Tango Adapted`
+### Tango Adapted
 
-![image](tango_adapted.png)
+![Screenshot](/screenshots/tango_adapted.png)
 
-`Tango Half Adapted`
+### Tango Half Adapted
 
-![image](tango_half_adapted.png)
+![Screenshot](/screenshots/tango_half_adapted.png)
 
-`Terminal Basic`
+### Terminal Basic
 
-![image](terminal_basic.png)
+![Screenshot](/screenshots/terminal_basic.png)
 
-`Tinacious Design (Light)`
+### Tinacious Design (Light)
 
-![image](tinacious_design_light.png)
+![Screenshot](/screenshots/tinacious_design_light.png)
 
-`tokyonight-day`
+### tokyonight-day
 
-![image](tokyonight-day.png)
+![Screenshot](/screenshots/tokyonight-day.png)
 
-`Tomorrow`
+### Tomorrow
 
-![image](tomorrow.png)
+![Screenshot](/screenshots/tomorrow.png)
 
-`Unikitty`
+### Unikitty
 
-![image](unikitty.png)
+![Screenshot](/screenshots/unikitty.png)
 
-`vimbones`
+### vimbones
 
-![image](vimbones.png)
+![Screenshot](/screenshots/vimbones.png)
 
-`Violet Light`
+### Violet Light
 
-![image](violet_light.png)
+![Screenshot](/screenshots/violet_light.png)
 
-`xcodelight`
+### xcodelight
 
-![image](xcodelight.png)
+![Screenshot](/screenshots/xcodelight.png)
 
-`xcodelighthc`
+### xcodelighthc
 
-![image](xcodelighthc.png)
+![Screenshot](/screenshots/xcodelighthc.png)
 
-`zenbones`
+### zenbones
 
-![image](zenbones.png)
+![Screenshot](/screenshots/zenbones.png)
 
-`zenbones_light`
+### zenbones_light
 
-![image](zenbones_light.png)
+![Screenshot](/screenshots/zenbones_light.png)
 
-`zenwritten_light`
+### zenwritten_light
 
-![image](zenwritten_light.png)
+![Screenshot](/screenshots/zenwritten_light.png)

--- a/tools/generate_screenshots_readme.py
+++ b/tools/generate_screenshots_readme.py
@@ -16,7 +16,7 @@ def calculate_brightness(r, g, b):
 def classify_itermcolors(directory="."):
     light_themes = []
     dark_themes = []
-    
+
     for file in sorted(directory.glob("*.itermcolors"), key=lambda entry: entry.name.lower()):
         screenshot_filename = get_screenshot_filename(file.with_suffix("").name)+ ".png"
         if screenshot_filename.startswith("builtin_"):
@@ -24,14 +24,14 @@ def classify_itermcolors(directory="."):
             continue
         with open(os.path.join(directory, file), "rb") as f:
             plist = plistlib.load(f)
-            
+
             bg_color = plist.get("Background Color", {})
             r = bg_color.get("Red Component", 0)
             g = bg_color.get("Green Component", 0)
             b = bg_color.get("Blue Component", 0)
-            
+
             brightness = calculate_brightness(r, g, b)
-            
+
             if brightness > 0.5:
                 light_themes.append((file.with_suffix(""), screenshot_filename))
             else:
@@ -48,23 +48,23 @@ def generate_screenshots_readme():
 
     with (screenshots_path / "README.md").open("w", encoding="utf-8") as outf:
         outf.write("""
-# Screenshots
+## Screenshots
 
 The screenshots are categorized.
 
 - [Dark Themes](#darkthemes)
 - [Light Themes](#lightthemes)
 
-## Dark Themes<a name="darkthemes"><a/>
+### Dark Themes<a name="darkthemes"><a/>
 
 """)
-        outf.write("\n\n".join(f"`{f[0].name}`\n\n![image]({f[1]})" for f in dark_themes))
+        outf.write("\n\n".join(f"### {f[0].name}\n\n![Screenshot](/screenshots/{f[1]})" for f in dark_themes))
         outf.write("""
 
-## Light Themes<a name="lightthemes"><a/>
+### Light Themes<a name="lightthemes"><a/>
 
 """)
-        outf.write("\n\n".join(f"`{f[0].name}`\n\n![image]({f[1]})" for f in light_themes))
+        outf.write("\n\n".join(f"### {f[0].name}\n\n![Screenshot](/screenshots/{f[1]})" for f in light_themes))
         outf.write("\n")
         print(outf.name, "written")
 

--- a/tools/generate_screenshots_readme.py
+++ b/tools/generate_screenshots_readme.py
@@ -46,7 +46,9 @@ def generate_screenshots_readme():
 
     dark_themes, light_themes = classify_itermcolors(schemes_path)
 
-    with (screenshots_path / "README.md").open("w", encoding="utf-8") as outf:
+    # Write screenshots/README.md
+    screenshots_readme_path = screenshots_path / "README.md"
+    with screenshots_readme_path.open("w", encoding="utf-8") as outf:
         outf.write("""
 ## Screenshots
 
@@ -66,8 +68,39 @@ The screenshots are categorized.
 """)
         outf.write("\n\n".join(f"### {f[0].name}\n\n![Screenshot](/screenshots/{f[1]})" for f in light_themes))
         outf.write("\n")
-        print(outf.name, "written")
+        print(f"{outf.name} written")
 
+    # Read the newly written screenshots/README.md
+    with screenshots_readme_path.open("r", encoding="utf-8") as f:
+        screenshots_readme_content = f.read()
+
+    # Update parent README.md
+    parent_readme_path = pathlib.Path(__file__).parent.parent / "README.md"
+    if parent_readme_path.exists():
+        with parent_readme_path.open("r", encoding="utf-8") as f:
+            parent_content = f.read()
+
+        # Find the markers
+        begin_marker = "<!-- SCREENSHOTS_BEGIN -->"
+        end_marker = "<!-- SCREENSHOTS_END -->"
+        begin_index = parent_content.find(begin_marker)
+        end_index = parent_content.find(end_marker)
+
+        if begin_index != -1 and end_index != -1 and begin_index < end_index:
+            # Replace content between markers
+            new_content = (
+                parent_content[:begin_index + len(begin_marker)]
+                + "\n"
+                + screenshots_readme_content
+                + parent_content[end_index:]
+            )
+            with parent_readme_path.open("w", encoding="utf-8") as f:
+                f.write(new_content)
+                print(f"{parent_readme_path} updated")
+        else:
+            print(f"Warning: Could not find {begin_marker} and {end_marker} in {parent_readme_path}")
+    else:
+        print(f"Warning: {parent_readme_path} does not exist")
 
 if __name__ == "__main__":
     generate_screenshots_readme()


### PR DESCRIPTION
This pull request updates [generate_screenshots_readme.py](https://github.com/mbadolato/iTerm2-Color-Schemes/compare/master...j-c-m:iTerm2-Color-Schemes:generate_screenshots_readme?expand=1#diff-294e2a2ad2479b8ae5fbed42002e5adb2501da83c02400790b0afc7962811f0f) to generate in the same format as the primary README.md.

This allows for the script to automatically merge the screenshot section into the primary README.md via workflow.

I've updated the pull request template and README.md to no longer require steps which will be automatically generated via the workflow or manually.

