### PR TITLE
Add IBM 5153 CGA Theme

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -224,6 +224,8 @@ The Horizon and Horizon Bright themes were added by [Antonio Camargo](https://gi
 
 The Hybrid theme was found [here](https://gist.github.com/luan/6362811)
 
+The IBM 5153 CGA themes were created by [Jesse Miller](https://jmiller.com/). Based on The IBM 5153's True CGA Palette and Color Output [int10h.org/blog](https://int10h.org/blog/2022/06/ibm-5153-color-true-cga-palette/).
+
 The iceberg theme was created by [cocopon](https://github.com/cocopon/iceberg.vim) and ported to iTerm2 by [pbnj](https://github.com/pbnj)
 
 The scheme idleToes was inspired by the [idleFingers](http://www.idlefingers.co.uk/) TextMate theme and suggested for inclusion by Seth Wilson.

--- a/yaml/IBM 5153 CGA (Black).yml
+++ b/yaml/IBM 5153 CGA (Black).yml
@@ -1,0 +1,26 @@
+# https://int10h.org/blog/2022/06/ibm-5153-color-true-cga-palette/
+
+name:     'IBM 5153 CGA (Black)'
+author:   '(https://jmiller.com/)' # 'Author Name (http://website.com)'
+variant:  'Dark' # Dark or Light
+
+color_01:   '#000000' # Black (Host)
+color_02:   '#C40000' # Red (Syntax string)
+color_03:   '#00C400' # Green (Command)
+color_04:   '#C47E00' # Yellow (Command second)
+color_05:   '#0000C4' # Blue (Path)
+color_06:   '#C400C4' # Magenta (Syntax var)
+color_07:   '#00C4C4' # Cyan (Prompt)
+color_08:   '#C4C4C4' # White
+color_09:   '#4E4E4E' # Bright Black
+color_10:   '#DC4E4E' # Bright Red (Command error)
+color_11:   '#4EDC4E' # Bright Green (Exec)
+color_12:   '#F3F34E' # Bright Yellow
+color_13:   '#4E4EDC' # Bright Blue (Folder)
+color_14:   '#F34EF3' # Bright Magenta
+color_15:   '#4EF3F3' # Bright Cyan
+color_16:   '#FFFFFF' # Bright White
+
+background: '#000000' # Background
+foreground: '#C4C4C4' # Foreground (Text)
+cursor:     '#C4C4C4' # Cursor

--- a/yaml/IBM 5153 CGA.yml
+++ b/yaml/IBM 5153 CGA.yml
@@ -1,0 +1,27 @@
+# https://int10h.org/blog/2022/06/ibm-5153-color-true-cga-palette/
+# 15% brightness increase 0-7 to simulate brightness on monitor
+
+name:     'IBM 5153 CGA'
+author:   '(https://jmiller.com/)' # 'Author Name (http://website.com)'
+variant:  'Dark' # Dark or Light
+
+color_01:   '#262626' # Black (Host)
+color_02:   '#DB3333' # Red (Syntax string)
+color_03:   '#33DB33' # Green (Command)
+color_04:   '#DB9833' # Yellow (Command second)
+color_05:   '#3333DB' # Blue (Path)
+color_06:   '#DB33DB' # Magenta (Syntax var)
+color_07:   '#33DBDB' # Cyan (Prompt)
+color_08:   '#D6D6D6' # White
+color_09:   '#4E4E4E' # Bright Black
+color_10:   '#DC4E4E' # Bright Red (Command error)
+color_11:   '#4EDC4E' # Bright Green (Exec)
+color_12:   '#F3F34E' # Bright Yellow
+color_13:   '#4E4EDC' # Bright Blue (Folder)
+color_14:   '#F34EF3' # Bright Magenta
+color_15:   '#4EF3F3' # Bright Cyan
+color_16:   '#FFFFFF' # Bright White
+
+background: '#262626' # Background
+foreground: '#D6D6D6' # Foreground (Text)
+cursor:     '#D6D6D6' # Cursor


### PR DESCRIPTION
IBM 5153 CGA Theme, based on the "True" CGA Palette.

https://int10h.org/blog/2022/06/ibm-5153-color-true-cga-palette/

## Description

New theme, minimal amount of files in the PR to see how the actions work.

