### PR TITLE
Ghostty: fix cursor text not being visible

### DIFF
--- a/ghostty/Atom One Dark
+++ b/ghostty/Atom One Dark
@@ -17,6 +17,6 @@ palette = 15=#abb2bf
 background = #21252b
 foreground = #abb2bf
 cursor-color = #abb2bf
-cursor-text = #abb2bf
+cursor-text = #21252b
 selection-background = #323844
 selection-foreground = #abb2bf

--- a/schemes/Atom One Dark.itermcolors
+++ b/schemes/Atom One Dark.itermcolors
@@ -280,13 +280,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.74901962280273438</real>
+		<real>0.16862745583057404</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.69803923368453979</real>
+		<real>0.14509804546833038</real>
 		<key>Red Component</key>
-		<real>0.67058825492858887</real>
+		<real>0.12941177189350128</real>
 	</dict>
 	<key>Foreground Color</key>
 	<dict>


### PR DESCRIPTION
## Description

Currently color of cursor text is same with cursor background. This PR fixes that. Background color used for cursor text.
