### PR TITLE
fix: Adjust Dimidium

### DIFF
--- a/schemes/Dimidium.itermcolors
+++ b/schemes/Dimidium.itermcolors
@@ -88,11 +88,11 @@ https://github.com/dofuuz/dimidium
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.85070836</real>
+		<real>0.89408735</real>
 		<key>Green Component</key>
-		<real>0.84684394</real>
+		<real>0.89028091</real>
 		<key>Red Component</key>
-		<real>0.82602163</real>
+		<real>0.86977354</real>
 	</dict>
 	<key>Ansi 2 Color</key>
 	<dict>
@@ -211,11 +211,11 @@ https://github.com/dofuuz/dimidium
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>0.85070836</real>
+		<real>0.89408735</real>
 		<key>Green Component</key>
-		<real>0.84684394</real>
+		<real>0.89028091</real>
 		<key>Red Component</key>
-		<real>0.82602163</real>
+		<real>0.86977354</real>
 	</dict>
 	<key>Cursor Color</key>
 	<dict>


### PR DESCRIPTION
Adjust Dimidium
- Make Bright white brighter

https://github.com/dofuuz/dimidium/commit/5fbd1126d7acbfc1b7db5ee9ad13c126ce31f2fc


## Description

I made little change to Dimidium color scheme.
- Adjusted "Bright white" slightly brighter, hoping it can be distinguished better from "White".
211, 216, 217 → 222, 227, 228

This will be the final tune for Dimidum color scheme.
