### PR TITLE
Add Atlas Ragnarok color scheme

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -528,3 +528,5 @@ Onenord and Onenord Light theme was created by [Ryan Mehri](https://github.com/r
 The Claude theme was created by [techfitmaster](https://github.com/techfitmaster/ghostty-claude-theme), inspired by the [Claude](https://claude.ai) AI interface color palette
 
 The JetCalm Light theme was created by [mtueih](https://github.com/mtueih) based on [Son A. Pham](https://github.com/sonph)'s [One Half Light](https://github.com/sonph/onehalf) theme, inspired by the [JetBrains](https://www.jetbrains.com) IDE interface color palette
+
+The Atlas Ragnarok theme was created by [Atlas Kaisar](https://github.com/AyoubTadlaoui) — tech-blue thunder above, crimson fire below, pure black through the middle. Built on the syntactic structure of [Vesper](https://github.com/raunofreiberg/vesper) with the warm-accent family remapped to a Tailwind blue gradient. Ships across many editors at [atlas-ragnarok](https://github.com/AyoubTadlaoui/atlas-ragnarok)

--- a/schemes/Atlas Ragnarok.itermcolors
+++ b/schemes/Atlas Ragnarok.itermcolors
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- atlas-ragnarok — iTerm2 .itermcolors palette port.
+     Double-click in Finder to import into iTerm2's color presets,
+     then select it under Preferences → Profiles → Colors → Color Presets.
+     The Ghostty vignette shader has no iTerm2 equivalent. -->
+<plist version="1.0">
+<dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.0</real>
+		<key>Green Component</key><real>0.0</real>
+		<key>Blue Component</key><real>0.0</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>1.0</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.23137254901960785</real>
+		<key>Green Component</key><real>0.5098039215686274</real>
+		<key>Blue Component</key><real>0.9647058823529412</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>1.0</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.11764705882352941</real>
+		<key>Green Component</key><real>0.22745098039215686</real>
+		<key>Blue Component</key><real>0.37254901960784315</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>1.0</real>
+	</dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.0</real>
+		<key>Green Component</key><real>0.0</real>
+		<key>Blue Component</key><real>0.0</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>0.5019607843137255</real>
+		<key>Blue Component</key><real>0.5019607843137255</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.6</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>0.8941176470588235</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.1450980392156863</real>
+		<key>Green Component</key><real>0.5098039215686274</real>
+		<key>Blue Component</key><real>0.9215686274509803</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.6274509803921569</real>
+		<key>Green Component</key><real>0.6274509803921569</real>
+		<key>Blue Component</key><real>0.6274509803921569</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.23137254901960785</real>
+		<key>Green Component</key><real>0.5098039215686274</real>
+		<key>Blue Component</key><real>0.9647058823529412</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.6</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>0.8941176470588235</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>1.0</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.3137254901960784</real>
+		<key>Green Component</key><real>0.3137254901960784</real>
+		<key>Blue Component</key><real>0.3137254901960784</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>0.6</real>
+		<key>Blue Component</key><real>0.6</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.7019607843137254</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>0.8941176470588235</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.3764705882352941</real>
+		<key>Green Component</key><real>0.6470588235294118</real>
+		<key>Blue Component</key><real>0.9803921568627451</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.6901960784313725</real>
+		<key>Green Component</key><real>0.6901960784313725</real>
+		<key>Blue Component</key><real>0.6901960784313725</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.5764705882352941</real>
+		<key>Green Component</key><real>0.7725490196078432</real>
+		<key>Blue Component</key><real>0.9921568627450981</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>0.6</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>0.8941176470588235</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key><string>sRGB</string>
+		<key>Red Component</key><real>1.0</real>
+		<key>Green Component</key><real>1.0</real>
+		<key>Blue Component</key><real>1.0</real>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Description

Adding **Atlas Ragnarok** — a dark theme inspired by the Norse apocalypse:
tech-blue thunder above, crimson fire below, pure black through the middle.
Built on the syntactic structure of [Vesper](https://github.com/raunofreiberg/vesper),
with the warm-accent family remapped to a Tailwind blue gradient and a
pure-black `#000000` background.

| Role | Hex |
|------|-----|
| Background | `#000000` |
| Foreground | `#ffffff` |
| Thunder-blue primary | `#3b82f6` |
| Thunder-blue deep | `#2563eb` |
| Peppermint (strings, added) | `#99ffe4` |
| Crimson (errors, deleted) | `#ff8080` |
| Selection | `#1e3a5f` |

## New Theme

- ✅ Submitted in `.itermcolors` format → `schemes/Atlas Ragnarok.itermcolors`
- ✅ CREDITS.md entry added (alphabetical at end with the other recent additions)
- License: MIT
- Source repo: https://github.com/AyoubTadlaoui/atlas-ragnarok
- Already shipping on [Open VSX](https://open-vsx.org/extension/AyoubTadlaoui/atlas-ragnarok) and via PR to [zed-industries/extensions#6129](https://github.com/zed-industries/extensions/pull/6129)

## A heads-up on the per-terminal files

This PR contains only the source `.itermcolors` + CREDITS entry — the
per-terminal generator (`tools/gen.py` and friends) couldn't run in my
sandboxed environment because pip was unable to install the requirements
file. Since [`generate-all.yml`](.github/workflows/generate-all.yml)
auto-regenerates everything on push to `master` after merge, this should
still land cleanly. If you'd prefer I add the generated files manually
before merging, just say the word and I'll come back with them.

Thanks for maintaining this — one PR here reaches dozens of terminals.