### PR TITLE
Fix Atlas Ragnarok: correct Ansi 3 blue (#2582eb → #2563eb)

### DIFF
--- a/schemes/Atlas Ragnarok.itermcolors
+++ b/schemes/Atlas Ragnarok.itermcolors
@@ -73,7 +73,7 @@
 	<dict>
 		<key>Color Space</key><string>sRGB</string>
 		<key>Red Component</key><real>0.1450980392156863</real>
-		<key>Green Component</key><real>0.5098039215686274</real>
+		<key>Green Component</key><real>0.38823529411764707</real>
 		<key>Blue Component</key><real>0.9215686274509803</real>
 	</dict>
 	<key>Ansi 4 Color</key>


### PR DESCRIPTION
Hi @mbadolato — small one-value correction to **Atlas Ragnarok**, which you kindly merged in #697 (I'm the theme's author).

Slot **Ansi 3** was encoded as `#2582eb` (green component `0.5098`) but the intended/canonical value across the rest of the theme is **`#2563eb`** (green `0.3882` = 99/255). It was a single drifted value in my source file — every other color is correct.

**Change:** one line in `schemes/Atlas Ragnarok.itermcolors` — `Green Component` of `Ansi 3 Color` only. The two other `0.5098` greens in the file belong to `#3b82f6` (Ansi 5 + cursor) and are intentionally untouched.

Verified with `plutil`: Ansi 3 now decodes to `#2563eb`; Ansi 5 and cursor remain `#3b82f6`. Happy to run the regen script for the per-terminal formats if you'd prefer that included — let me know.

Thanks again!