### PR TITLE
Add Charcoal grayscale theme for Ghostty

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -532,3 +532,4 @@ The JetCalm Light theme was created by [mtueih](https://github.com/mtueih) based
 The Atlas Ragnarok theme was created by [Atlas Kaisar](https://github.com/AyoubTadlaoui) — tech-blue thunder above, crimson fire below, pure black through the middle. Built on the syntactic structure of [Vesper](https://github.com/raunofreiberg/vesper) with the warm-accent family remapped to a Tailwind blue gradient. Ships across many editors at [atlas-ragnarok](https://github.com/AyoubTadlaoui/atlas-ragnarok)
 
 The London Columbia Road, London Soho Night, London Bonfire Night, and London Embankment Dusk themes were created by [Scott Matthews](https://github.com/scottmatthews7) as a four-theme seasonal set, each anchored to a specific place and time in London: Columbia Road flower market in spring, a Soho side street in summer, Hampstead Heath on Bonfire Night in autumn, and the Embankment at dusk in winter.
+Charcoal theme by Vyom Jain (vyom.malo6904@gmail.com)

--- a/ghostty/Charcoal
+++ b/ghostty/Charcoal
@@ -1,0 +1,29 @@
+# Charcoal — grayscale blackish theme
+# Matches bat Charcoal theme palette
+
+background = #0d0d0d
+foreground = #c4c4c4
+cursor-color = #d0d0d0
+cursor-text = #0d0d0d
+selection-background = #2e2e2e
+selection-foreground = #e0e0e0
+
+# --- ANSI palette (all grayscale) ---
+# Normals (0-7)
+palette = 0=#111111
+palette = 1=#888888
+palette = 2=#a8a8a8
+palette = 3=#b0b0b0
+palette = 4=#9a9a9a
+palette = 5=#8a8a8a
+palette = 6=#a0a0a0
+palette = 7=#c0c0c0
+# Brights (8-15)
+palette = 8=#3a3a3a
+palette = 9=#a0a0a0
+palette = 10=#c4c4c4
+palette = 11=#c8c8c8
+palette = 12=#d0d0d0
+palette = 13=#b8b8b8
+palette = 14=#cccccc
+palette = 15=#ececec


### PR DESCRIPTION
## Charcoal

A deep-black grayscale theme with no hues — everything in shades of gray.

**Background:** `#0d0d0d` | **Foreground:** `#c4c4c4`

All 16 ANSI palette colors are mapped to grayscale shades for meaningful contrast without color.

Also available for bat and OpenCode: https://github.com/VyomJain6904/charcoal-theme