### PR TITLE
Add Patina color scheme (six variants)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -380,6 +380,8 @@ The PaleNight theme was created by [Mattia Astorino](https://github.com/equinuso
 
 The Pandora theme was created by [milosmatic](https://github.com/milosmatic/Pandora-iterm)
 
+The Patina Dark, Dark Soft, Moss, Light, Lichen, and Stellar themes were created by [lmarkmann](https://github.com/lmarkmann)
+
 The PaulMillr theme was created by [paulmillr](https://github.com/paulmillr/dotfiles/tree/master/terminal) and ported to iTerm by me
 
 The Pencil Dark and Pencil Light themes were created by [mattly](https://github.com/mattly/iterm-colors-pencil)

--- a/schemes/Patina Dark Soft.itermcolors
+++ b/schemes/Patina Dark Soft.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1803921569</real>
+		<key>Blue Component</key>
+		<real>0.1803921569</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7960784314</real>
+		<key>Green Component</key>
+		<real>0.4627450980</real>
+		<key>Blue Component</key>
+		<real>0.4627450980</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3294117647</real>
+		<key>Green Component</key>
+		<real>0.6117647059</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9019607843</real>
+		<key>Green Component</key>
+		<real>0.8000000000</real>
+		<key>Blue Component</key>
+		<real>0.4666666667</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4274509804</real>
+		<key>Green Component</key>
+		<real>0.7019607843</real>
+		<key>Blue Component</key>
+		<real>0.7607843137</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7882352941</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3647058824</real>
+		<key>Green Component</key>
+		<real>0.6627450980</real>
+		<key>Blue Component</key>
+		<real>0.6549019608</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3450980392</real>
+		<key>Green Component</key>
+		<real>0.3450980392</real>
+		<key>Blue Component</key>
+		<real>0.3450980392</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7960784314</real>
+		<key>Green Component</key>
+		<real>0.4627450980</real>
+		<key>Blue Component</key>
+		<real>0.4627450980</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3294117647</real>
+		<key>Green Component</key>
+		<real>0.6117647059</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9019607843</real>
+		<key>Green Component</key>
+		<real>0.8000000000</real>
+		<key>Blue Component</key>
+		<real>0.4666666667</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4274509804</real>
+		<key>Green Component</key>
+		<real>0.7019607843</real>
+		<key>Blue Component</key>
+		<real>0.7607843137</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7882352941</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3647058824</real>
+		<key>Green Component</key>
+		<real>0.6627450980</real>
+		<key>Blue Component</key>
+		<real>0.6549019608</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1019607843</real>
+		<key>Green Component</key>
+		<real>0.1019607843</real>
+		<key>Blue Component</key>
+		<real>0.1019607843</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1019607843</real>
+		<key>Green Component</key>
+		<real>0.1019607843</real>
+		<key>Blue Component</key>
+		<real>0.1019607843</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2274509804</real>
+		<key>Green Component</key>
+		<real>0.2196078431</real>
+		<key>Blue Component</key>
+		<real>0.2078431373</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+</dict>
+</plist>

--- a/schemes/Patina Dark.itermcolors
+++ b/schemes/Patina Dark.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1803921569</real>
+		<key>Blue Component</key>
+		<real>0.1803921569</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7960784314</real>
+		<key>Green Component</key>
+		<real>0.4627450980</real>
+		<key>Blue Component</key>
+		<real>0.4627450980</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3019607843</real>
+		<key>Green Component</key>
+		<real>0.5764705882</real>
+		<key>Blue Component</key>
+		<real>0.4588235294</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9019607843</real>
+		<key>Green Component</key>
+		<real>0.8000000000</real>
+		<key>Blue Component</key>
+		<real>0.4666666667</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4274509804</real>
+		<key>Green Component</key>
+		<real>0.7019607843</real>
+		<key>Blue Component</key>
+		<real>0.7607843137</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7882352941</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3647058824</real>
+		<key>Green Component</key>
+		<real>0.6627450980</real>
+		<key>Blue Component</key>
+		<real>0.6549019608</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3450980392</real>
+		<key>Green Component</key>
+		<real>0.3450980392</real>
+		<key>Blue Component</key>
+		<real>0.3450980392</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7960784314</real>
+		<key>Green Component</key>
+		<real>0.4627450980</real>
+		<key>Blue Component</key>
+		<real>0.4627450980</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3019607843</real>
+		<key>Green Component</key>
+		<real>0.5764705882</real>
+		<key>Blue Component</key>
+		<real>0.4588235294</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9019607843</real>
+		<key>Green Component</key>
+		<real>0.8000000000</real>
+		<key>Blue Component</key>
+		<real>0.4666666667</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4274509804</real>
+		<key>Green Component</key>
+		<real>0.7019607843</real>
+		<key>Blue Component</key>
+		<real>0.7607843137</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7882352941</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3647058824</real>
+		<key>Green Component</key>
+		<real>0.6627450980</real>
+		<key>Blue Component</key>
+		<real>0.6549019608</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.0705882353</real>
+		<key>Green Component</key>
+		<real>0.0705882353</real>
+		<key>Blue Component</key>
+		<real>0.0705882353</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.0705882353</real>
+		<key>Green Component</key>
+		<real>0.0705882353</real>
+		<key>Blue Component</key>
+		<real>0.0705882353</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2588235294</real>
+		<key>Green Component</key>
+		<real>0.2509803922</real>
+		<key>Blue Component</key>
+		<real>0.2392156863</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+</dict>
+</plist>

--- a/schemes/Patina Lichen.itermcolors
+++ b/schemes/Patina Lichen.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5450980392</real>
+		<key>Green Component</key>
+		<real>0.2745098039</real>
+		<key>Blue Component</key>
+		<real>0.2745098039</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2000000000</real>
+		<key>Green Component</key>
+		<real>0.3921568627</real>
+		<key>Blue Component</key>
+		<real>0.3019607843</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4980392157</real>
+		<key>Green Component</key>
+		<real>0.3137254902</real>
+		<key>Blue Component</key>
+		<real>0.1921568627</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2078431373</real>
+		<key>Green Component</key>
+		<real>0.3803921569</real>
+		<key>Blue Component</key>
+		<real>0.4274509804</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5215686275</real>
+		<key>Green Component</key>
+		<real>0.2941176471</real>
+		<key>Blue Component</key>
+		<real>0.2470588235</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1647058824</real>
+		<key>Green Component</key>
+		<real>0.3882352941</real>
+		<key>Blue Component</key>
+		<real>0.3803921569</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3529411765</real>
+		<key>Green Component</key>
+		<real>0.3215686275</real>
+		<key>Blue Component</key>
+		<real>0.2823529412</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3568627451</real>
+		<key>Green Component</key>
+		<real>0.3568627451</real>
+		<key>Blue Component</key>
+		<real>0.3294117647</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5450980392</real>
+		<key>Green Component</key>
+		<real>0.2745098039</real>
+		<key>Blue Component</key>
+		<real>0.2745098039</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2588235294</real>
+		<key>Green Component</key>
+		<real>0.3882352941</real>
+		<key>Blue Component</key>
+		<real>0.2196078431</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4980392157</real>
+		<key>Green Component</key>
+		<real>0.3137254902</real>
+		<key>Blue Component</key>
+		<real>0.1921568627</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2078431373</real>
+		<key>Green Component</key>
+		<real>0.3803921569</real>
+		<key>Blue Component</key>
+		<real>0.4274509804</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5215686275</real>
+		<key>Green Component</key>
+		<real>0.2941176471</real>
+		<key>Blue Component</key>
+		<real>0.2470588235</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1647058824</real>
+		<key>Green Component</key>
+		<real>0.3882352941</real>
+		<key>Blue Component</key>
+		<real>0.3803921569</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8039215686</real>
+		<key>Green Component</key>
+		<real>0.8196078431</real>
+		<key>Blue Component</key>
+		<real>0.7764705882</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8039215686</real>
+		<key>Green Component</key>
+		<real>0.8196078431</real>
+		<key>Blue Component</key>
+		<real>0.7764705882</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.6666666667</real>
+		<key>Green Component</key>
+		<real>0.6901960784</real>
+		<key>Blue Component</key>
+		<real>0.6392156863</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+</dict>
+</plist>

--- a/schemes/Patina Light.itermcolors
+++ b/schemes/Patina Light.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.6078431373</real>
+		<key>Green Component</key>
+		<real>0.2313725490</real>
+		<key>Blue Component</key>
+		<real>0.2313725490</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2039215686</real>
+		<key>Green Component</key>
+		<real>0.3921568627</real>
+		<key>Blue Component</key>
+		<real>0.2980392157</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4313725490</real>
+		<key>Green Component</key>
+		<real>0.3450980392</real>
+		<key>Blue Component</key>
+		<real>0.0901960784</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1843137255</real>
+		<key>Green Component</key>
+		<real>0.3843137255</real>
+		<key>Blue Component</key>
+		<real>0.4352941176</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4784313725</real>
+		<key>Green Component</key>
+		<real>0.3098039216</real>
+		<key>Blue Component</key>
+		<real>0.2784313725</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.3843137255</real>
+		<key>Blue Component</key>
+		<real>0.3764705882</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3529411765</real>
+		<key>Green Component</key>
+		<real>0.3215686275</real>
+		<key>Blue Component</key>
+		<real>0.2823529412</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3843137255</real>
+		<key>Green Component</key>
+		<real>0.3529411765</real>
+		<key>Blue Component</key>
+		<real>0.3176470588</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5137254902</real>
+		<key>Green Component</key>
+		<real>0.2000000000</real>
+		<key>Blue Component</key>
+		<real>0.2000000000</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1764705882</real>
+		<key>Green Component</key>
+		<real>0.3450980392</real>
+		<key>Blue Component</key>
+		<real>0.2235294118</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3882352941</real>
+		<key>Green Component</key>
+		<real>0.3058823529</real>
+		<key>Blue Component</key>
+		<real>0.0784313725</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1725490196</real>
+		<key>Green Component</key>
+		<real>0.3372549020</real>
+		<key>Blue Component</key>
+		<real>0.3764705882</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4274509804</real>
+		<key>Green Component</key>
+		<real>0.2745098039</real>
+		<key>Blue Component</key>
+		<real>0.2431372549</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1568627451</real>
+		<key>Green Component</key>
+		<real>0.3372549020</real>
+		<key>Blue Component</key>
+		<real>0.3294117647</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8666666667</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7686274510</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8666666667</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7686274510</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7490196078</real>
+		<key>Green Component</key>
+		<real>0.7215686275</real>
+		<key>Blue Component</key>
+		<real>0.6392156863</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+</dict>
+</plist>

--- a/schemes/Patina Moss.itermcolors
+++ b/schemes/Patina Moss.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2000000000</real>
+		<key>Green Component</key>
+		<real>0.2117647059</real>
+		<key>Blue Component</key>
+		<real>0.1803921569</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7529411765</real>
+		<key>Green Component</key>
+		<real>0.4705882353</real>
+		<key>Blue Component</key>
+		<real>0.4705882353</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3568627451</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.5254901961</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8313725490</real>
+		<key>Green Component</key>
+		<real>0.7490196078</real>
+		<key>Blue Component</key>
+		<real>0.4313725490</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3960784314</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.7098039216</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7529411765</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3882352941</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.6509803922</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3450980392</real>
+		<key>Green Component</key>
+		<real>0.3568627451</real>
+		<key>Blue Component</key>
+		<real>0.3176470588</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7529411765</real>
+		<key>Green Component</key>
+		<real>0.4705882353</real>
+		<key>Blue Component</key>
+		<real>0.4705882353</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3568627451</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.5254901961</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8313725490</real>
+		<key>Green Component</key>
+		<real>0.7490196078</real>
+		<key>Blue Component</key>
+		<real>0.4313725490</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3960784314</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.7098039216</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7529411765</real>
+		<key>Green Component</key>
+		<real>0.5411764706</real>
+		<key>Blue Component</key>
+		<real>0.4901960784</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3882352941</real>
+		<key>Green Component</key>
+		<real>0.6588235294</real>
+		<key>Blue Component</key>
+		<real>0.6509803922</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1254901961</real>
+		<key>Green Component</key>
+		<real>0.1372549020</real>
+		<key>Blue Component</key>
+		<real>0.1215686275</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1254901961</real>
+		<key>Green Component</key>
+		<real>0.1372549020</real>
+		<key>Blue Component</key>
+		<real>0.1215686275</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2196078431</real>
+		<key>Green Component</key>
+		<real>0.2313725490</real>
+		<key>Blue Component</key>
+		<real>0.1921568627</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8431372549</real>
+		<key>Blue Component</key>
+		<real>0.7921568627</real>
+	</dict>
+</dict>
+</plist>

--- a/schemes/Patina Stellar.itermcolors
+++ b/schemes/Patina Stellar.itermcolors
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.6588235294</real>
+		<key>Green Component</key>
+		<real>0.2509803922</real>
+		<key>Blue Component</key>
+		<real>0.2509803922</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2274509804</real>
+		<key>Green Component</key>
+		<real>0.4392156863</real>
+		<key>Blue Component</key>
+		<real>0.3333333333</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4313725490</real>
+		<key>Green Component</key>
+		<real>0.3450980392</real>
+		<key>Blue Component</key>
+		<real>0.0901960784</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1843137255</real>
+		<key>Green Component</key>
+		<real>0.3843137255</real>
+		<key>Blue Component</key>
+		<real>0.4352941176</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5411764706</real>
+		<key>Green Component</key>
+		<real>0.3529411765</real>
+		<key>Blue Component</key>
+		<real>0.3137254902</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2196078431</real>
+		<key>Green Component</key>
+		<real>0.4666666667</real>
+		<key>Blue Component</key>
+		<real>0.4588235294</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.3529411765</real>
+		<key>Green Component</key>
+		<real>0.3215686275</real>
+		<key>Blue Component</key>
+		<real>0.2823529412</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.4156862745</real>
+		<key>Green Component</key>
+		<real>0.3843137255</real>
+		<key>Blue Component</key>
+		<real>0.3450980392</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.7490196078</real>
+		<key>Green Component</key>
+		<real>0.2352941176</real>
+		<key>Blue Component</key>
+		<real>0.2352941176</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2431372549</real>
+		<key>Green Component</key>
+		<real>0.4784313725</real>
+		<key>Blue Component</key>
+		<real>0.3686274510</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.5098039216</real>
+		<key>Green Component</key>
+		<real>0.4039215686</real>
+		<key>Blue Component</key>
+		<real>0.2627450980</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2470588235</real>
+		<key>Green Component</key>
+		<real>0.4509803922</real>
+		<key>Blue Component</key>
+		<real>0.5058823529</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.6156862745</real>
+		<key>Green Component</key>
+		<real>0.3490196078</real>
+		<key>Blue Component</key>
+		<real>0.2941176471</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2000000000</real>
+		<key>Green Component</key>
+		<real>0.4627450980</real>
+		<key>Blue Component</key>
+		<real>0.4588235294</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.2235294118</real>
+		<key>Green Component</key>
+		<real>0.2274509804</real>
+		<key>Blue Component</key>
+		<real>0.2039215686</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9607843137</real>
+		<key>Green Component</key>
+		<real>0.9490196078</real>
+		<key>Blue Component</key>
+		<real>0.9294117647</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.9607843137</real>
+		<key>Green Component</key>
+		<real>0.9490196078</real>
+		<key>Blue Component</key>
+		<real>0.9294117647</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.8588235294</real>
+		<key>Green Component</key>
+		<real>0.8352941176</real>
+		<key>Blue Component</key>
+		<real>0.7725490196</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Red Component</key>
+		<real>0.1803921569</real>
+		<key>Green Component</key>
+		<real>0.1647058824</real>
+		<key>Blue Component</key>
+		<real>0.1411764706</real>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Description

Adds Patina, a warm, muted theme with earthy tones (teal oxidation and amber warmth on quiet backgrounds), in six variants.

## Six variants included

| Scheme | Background | Mode |
|--------|------------|------|
| Patina Dark | `#121212` | Dark, full contrast |
| Patina Dark Soft | `#1a1a1a` | Dark, reduced contrast |
| Patina Moss | `#20231f` | Dark, moss-tinted ground |
| Patina Light | `#ddd7c4` | Light, warm parchment |
| Patina Lichen | `#cdd1c6` | Light, cool grey-green stone |
| Patina Stellar | `#f5f2ed` | Light, bright |

## New Theme

Submitted as `.itermcolors` source files in `schemes/`. Per-terminal ports and screenshots are left for the auto-generate workflow. CREDITS updated.

Already published for VS Code (Marketplace and Open VSX) and Zed: https://github.com/lmarkmann/patina-theme