### PR TITLE
Add display-only preview_theme.py for terminal color previews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,9 @@ python tools/wcag_check.py --schemes-dir schemes   # all schemes
 # YAML themes: generate .itermcolors first, then check
 cd tools && python gen.py -s "Your Theme Name"
 python tools/wcag_check.py -s "Your Theme Name"
+
+# Visual preview (display-only truecolor; does not change terminal palette)
+python tools/preview_theme.py -s "Your Theme Name"
 ```
 
 ## Adding a new theme

--- a/README.md
+++ b/README.md
@@ -2622,36 +2622,39 @@ Then add `bash ~/bin/set-colors.sh` to your shell's config file (`~/.bashrc`, `~
 
 ### Previewing color schemes
 
-[preview.rb](tools/preview.rb) is a simple script that allows you to preview
-the color schemes without having to import them. It parses .itermcolors files
-and applies the colors to the current session using [iTerm's proprietary
-escape codes](https://iterm2.com/documentation-escape-codes.html). As noted in
-the linked page, it doesn't run on tmux or screen.
+[preview_theme.py](tools/preview_theme.py) renders a full visual preview in the
+terminal using inline truecolor escape codes. It does **not** modify your
+terminal palette — safe to run in any truecolor-capable terminal (iTerm2, Kitty,
+WezTerm, Ghostty, Cursor, etc.).
 
 ```sh
-# Apply AdventureTime scheme to the current session
-tools/preview.rb schemes/AdventureTime.itermcolors
+# Preview by scheme name
+python3 tools/preview_theme.py -s "Your Theme Name"
 
-# Apply the schemes in turn.
-# - Press (almost) any key to advance; hit CTRL-C or ESC to stop
-# - Press the delete key to go back
-tools/preview.rb schemes/*
+# Preview from source files
+python3 tools/preview_theme.py schemes/Molokai.itermcolors
+python3 tools/preview_theme.py yaml/Clear Dark.yml
+
+# Browse multiple themes: ← → navigate, q quit
+python3 tools/preview_theme.py -s "Molokai" "Dracula"
 ```
 
-#### Previewing color schemes in other terminal emulators
+The preview shows the ANSI palette, surface colors (foreground, background,
+selection, cursor), and semantic samples (errors, git status, directory listing).
 
-[preview-generic.sh](tools/preview-generic.sh) is a script which can preview
-the themes in any terminal emulator which has support for the OSC 4 escape
-codes. It works by running the shell scripts from the `generic/` directory.
+#### Live palette preview (mutates terminal colors)
+
+[preview-generic.sh](tools/preview-generic.sh) applies OSC 4 palette changes by
+sourcing shell scripts from `generic/`. Use this only when you want the current
+session recolored.
 
 ```sh
-# Apply AdventureTime scheme to the current session
-bash generic/AdventureTime.sh
-
-# Apply the schemes in turn
-# - Press left/right arrow keys to navigate, press `q` to stop
-./tools/preview-generic.sh generic/*
+bash generic/Molokai.sh
+./tools/preview-generic.sh generic/Molokai.sh generic/Dracula.sh
 ```
+
+[preview.rb](tools/preview.rb) is deprecated (broken on current `.itermcolors`
+files). Prefer `preview_theme.py`.
 
 ---
 

--- a/tools/preview_theme.py
+++ b/tools/preview_theme.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Entry point for python tools/preview_theme.py"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+from preview_theme.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/preview_theme/__init__.py
+++ b/tools/preview_theme/__init__.py
@@ -1,0 +1,5 @@
+"""Display-only terminal theme preview."""
+
+from preview_theme.render import render_preview
+
+__all__ = ["render_preview"]

--- a/tools/preview_theme/__main__.py
+++ b/tools/preview_theme/__main__.py
@@ -1,0 +1,4 @@
+from preview_theme.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/preview_theme/cli.py
+++ b/tools/preview_theme/cli.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Display-only terminal theme preview (no palette mutation)."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+TOOLS_PATH = pathlib.Path(__file__).resolve().parent.parent
+if str(TOOLS_PATH) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PATH))
+
+from gen import Theme  # noqa: E402
+from preview_theme.loader import resolve_themes  # noqa: E402
+from preview_theme.render import render_preview  # noqa: E402
+from preview_theme.terminal import clear_screen, is_tty, parse_key, read_key, terminal_width  # noqa: E402
+
+
+def _write_preview(theme: Theme, *, index: int, total: int, width: int, no_clear: bool) -> None:
+    if not no_clear:
+        clear_screen()
+    sys.stdout.write(render_preview(theme, width, index=index, total=total))
+    sys.stdout.flush()
+
+
+def run_interactive(themes: list[Theme], width: int, no_clear: bool) -> int:
+    current = 0
+    total = len(themes)
+
+    while True:
+        _write_preview(themes[current], index=current, total=total, width=width, no_clear=no_clear)
+        action = parse_key(read_key())
+        if action == "quit":
+            if not no_clear:
+                clear_screen()
+            print("Preview exited.")
+            return 0
+        if action == "next":
+            current = (current + 1) % total
+        elif action == "prev":
+            current = (current - 1) % total
+        elif action == "redraw":
+            continue
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Display a truecolor terminal preview of color schemes (does not modify the terminal palette).",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=pathlib.Path,
+        help="Path to .itermcolors or .yml theme files",
+    )
+    parser.add_argument(
+        "-s",
+        "--scheme",
+        nargs="+",
+        dest="scheme",
+        metavar="NAME",
+        help="Theme name(s) to preview (stem of schemes/ or yaml/ file)",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=0,
+        help="Preview width in columns (default: terminal width)",
+    )
+    parser.add_argument(
+        "--no-clear",
+        action="store_true",
+        help="Do not clear the screen before drawing",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        themes = resolve_themes(args.scheme, list(args.paths))
+    except (FileNotFoundError, ValueError) as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    width = args.width or terminal_width()
+
+    if is_tty() and len(themes) > 1:
+        return run_interactive(themes, width, args.no_clear)
+
+    for index, theme in enumerate(themes):
+        _write_preview(
+            theme,
+            index=index,
+            total=len(themes),
+            width=width,
+            no_clear=args.no_clear or index > 0,
+        )
+
+    if len(themes) == 1 and is_tty() and not args.no_clear:
+        print("Press q to quit.", file=sys.stderr)
+        while True:
+            action = parse_key(read_key())
+            if action in {"quit", "redraw"}:
+                if action == "quit" and not args.no_clear:
+                    clear_screen()
+                break
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/preview_theme/cli.py
+++ b/tools/preview_theme/cli.py
@@ -69,11 +69,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Preview width in columns (default: terminal width)",
     )
     parser.add_argument(
-        "--no-clear",
+        "--clear",
         action="store_true",
-        help="Do not clear the screen before drawing",
+        help="Clear the screen before drawing (default: append to scrollback)",
     )
     args = parser.parse_args(argv)
+    no_clear = not args.clear
 
     try:
         themes = resolve_themes(args.scheme, list(args.paths))
@@ -84,7 +85,7 @@ def main(argv: list[str] | None = None) -> int:
     width = args.width or terminal_width()
 
     if is_tty() and len(themes) > 1:
-        return run_interactive(themes, width, args.no_clear)
+        return run_interactive(themes, width, no_clear)
 
     for index, theme in enumerate(themes):
         _write_preview(
@@ -92,15 +93,15 @@ def main(argv: list[str] | None = None) -> int:
             index=index,
             total=len(themes),
             width=width,
-            no_clear=args.no_clear or index > 0,
+            no_clear=no_clear,
         )
 
-    if len(themes) == 1 and is_tty() and not args.no_clear:
+    if len(themes) == 1 and is_tty() and not no_clear:
         print("Press q to quit.", file=sys.stderr)
         while True:
             action = parse_key(read_key())
             if action in {"quit", "redraw"}:
-                if action == "quit" and not args.no_clear:
+                if action == "quit" and not no_clear:
                     clear_screen()
                 break
 

--- a/tools/preview_theme/colors.py
+++ b/tools/preview_theme/colors.py
@@ -36,3 +36,27 @@ def styled(text: str, fg: Color, bg: Color | None = None, *, bold: bool = False)
         prefix = (BOLD if bold else "") + sgr_fg(fg)
         return f"{prefix}{text}{RESET}"
     return f"{sgr_fg_bg(fg, bg, bold=bold)}{text}{RESET}"
+
+
+def fill_line(text: str, fg: Color, bg: Color, width: int, *, bold: bool = False) -> str:
+    """Render text on bg, padded with spaces to full terminal width."""
+    truncated = text[:width]
+    padding = " " * max(width - len(truncated), 0)
+    return f"{sgr_fg_bg(fg, bg, bold=bold)}{truncated}{padding}{RESET}"
+
+
+def fill_line_segments(
+    width: int,
+    bg: Color,
+    pad_fg: Color,
+    segments: list[tuple[str, Color, bool]],
+) -> str:
+    """Render colored segments on a shared bg, padded to full terminal width."""
+    out = sgr_bg(bg)
+    visible = 0
+    for text, fg, is_bold in segments:
+        out += (BOLD if is_bold else "") + sgr_fg(fg) + text
+        visible += len(text)
+    if visible < width:
+        out += sgr_fg(pad_fg) + (" " * (width - visible))
+    return out + RESET

--- a/tools/preview_theme/colors.py
+++ b/tools/preview_theme/colors.py
@@ -1,0 +1,38 @@
+"""Truecolor SGR helpers for display-only terminal preview."""
+
+from __future__ import annotations
+
+from gen import Color
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+
+
+def sgr_fg(color: Color) -> str:
+    return f"\033[38;2;{color.r};{color.g};{color.b}m"
+
+
+def sgr_bg(color: Color) -> str:
+    return f"\033[48;2;{color.r};{color.g};{color.b}m"
+
+
+def sgr_fg_bg(fg: Color, bg: Color, *, bold: bool = False) -> str:
+    prefix = BOLD if bold else ""
+    return f"{prefix}{sgr_fg(fg)}{sgr_bg(bg)}"
+
+
+def hex_display(color: Color) -> str:
+    return f"#{color.hex.upper()}"
+
+
+def label_color_for_bg(bg: Color) -> Color:
+    luminance = 0.2126 * bg.r + 0.7152 * bg.g + 0.0722 * bg.b
+    return Color(30, 30, 30) if luminance > 140 else Color(240, 240, 240)
+
+
+def styled(text: str, fg: Color, bg: Color | None = None, *, bold: bool = False) -> str:
+    if bg is None:
+        prefix = (BOLD if bold else "") + sgr_fg(fg)
+        return f"{prefix}{text}{RESET}"
+    return f"{sgr_fg_bg(fg, bg, bold=bold)}{text}{RESET}"

--- a/tools/preview_theme/loader.py
+++ b/tools/preview_theme/loader.py
@@ -1,0 +1,65 @@
+"""Load themes from .itermcolors or YAML source files."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import List
+
+TOOLS_PATH = pathlib.Path(__file__).resolve().parent.parent
+if str(TOOLS_PATH) not in sys.path:
+    sys.path.insert(0, str(TOOLS_PATH))
+
+from gen import REPO_PATH, Theme, read_itermcolors_file, read_yaml_file  # noqa: E402
+
+SCHEMES_PATH = REPO_PATH / "schemes"
+YAML_PATH = REPO_PATH / "yaml"
+
+
+def load_theme_path(path: pathlib.Path) -> Theme:
+    suffix = path.suffix.lower()
+    if suffix == ".itermcolors":
+        return read_itermcolors_file(path)
+    if suffix in {".yml", ".yaml"}:
+        return read_yaml_file(path)
+    raise ValueError(f"Unsupported theme file type: {path}")
+
+
+def resolve_theme_name(name: str) -> Theme:
+    iterm_path = SCHEMES_PATH / f"{name}.itermcolors"
+    if iterm_path.exists():
+        return read_itermcolors_file(iterm_path)
+
+    yaml_path = YAML_PATH / f"{name}.yml"
+    if yaml_path.exists():
+        return read_yaml_file(yaml_path)
+
+    raise FileNotFoundError(
+        f'Theme "{name}" not found in {SCHEMES_PATH}/ or {YAML_PATH}/.'
+    )
+
+
+def resolve_themes(
+    scheme_names: List[str] | None,
+    paths: List[pathlib.Path],
+) -> List[Theme]:
+    themes: List[Theme] = []
+    seen: set[str] = set()
+
+    for path in paths:
+        theme = load_theme_path(path.expanduser().resolve())
+        if theme.name not in seen:
+            themes.append(theme)
+            seen.add(theme.name)
+
+    if scheme_names:
+        for name in scheme_names:
+            theme = resolve_theme_name(name)
+            if theme.name not in seen:
+                themes.append(theme)
+                seen.add(theme.name)
+
+    if not themes:
+        raise ValueError("No themes to preview.")
+
+    return themes

--- a/tools/preview_theme/render.py
+++ b/tools/preview_theme/render.py
@@ -1,0 +1,144 @@
+"""Render display-only theme previews using inline truecolor."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from gen import Color, Theme
+
+from preview_theme.colors import DIM, RESET, hex_display, label_color_for_bg, sgr_fg, styled
+
+
+def _color(theme: Theme, name: str, fallback: str | None = None) -> Color:
+    if name in theme.colors:
+        return theme.colors[name]
+    if fallback and fallback in theme.colors:
+        return theme.colors[fallback]
+    return Color(128, 128, 128)
+
+
+def _ansi(theme: Theme, index: int) -> Color:
+    return _color(theme, f"Ansi {index} Color")
+
+
+def _hline(width: int, char: str = "─") -> str:
+    return char * max(width, 20)
+
+
+def _swatch_cell(index: int, color: Color, cell_width: int = 10) -> str:
+    label = label_color_for_bg(color)
+    inner = f" {index} "
+    pad = max(cell_width - len(inner), 0)
+    left = pad // 2
+    right = pad - left
+    block = " " * left + inner + " " * right
+    return styled(block[:cell_width].ljust(cell_width), label, color)
+
+
+def _swatch_row(theme: Theme, indices: Iterable[int], width: int) -> List[str]:
+    colors = [_ansi(theme, i) for i in indices]
+    cell_width = 10
+    count = len(colors)
+    row_width = count * (cell_width + 1)
+    if row_width > width:
+        cell_width = max(6, (width - count) // count)
+
+    swatches = " ".join(_swatch_cell(i, c, cell_width) for i, c in zip(indices, colors))
+    hexes = " ".join(
+        f"{DIM}{sgr_fg(_color(theme, 'Foreground Color'))}{hex_display(c):<{cell_width}}{RESET}"
+        for c in colors
+    )
+    return [swatches, hexes]
+
+
+def render_preview(theme: Theme, width: int = 80, *, index: int = 0, total: int = 1) -> str:
+    fg = _color(theme, "Foreground Color")
+    bg = _color(theme, "Background Color")
+    bold = _color(theme, "Bold Color", "Foreground Color")
+    selection = _color(theme, "Selection Color")
+    selection_text = _color(theme, "Selected Text Color", "Background Color")
+    cursor = _color(theme, "Cursor Color", "Foreground Color")
+    cursor_text = _color(theme, "Cursor Text Color", "Background Color")
+
+    lines: List[str] = []
+    border = _hline(width, "═")
+
+    lines.append(styled(border, fg, bg))
+    title = f" {theme.name} "
+    if theme.variant:
+        title += f"· {theme.variant} "
+    if theme.author:
+        title += f"· {theme.author} "
+    if total > 1:
+        title += f"· [{index + 1}/{total}] "
+    lines.append(styled(title[: width - 2], fg, bg, bold=True))
+    if total > 1:
+        lines.append(styled(" ← → navigate   r redraw   q quit ", _ansi(theme, 6), bg))
+    lines.append(styled(border, fg, bg))
+
+    lines.append(styled(" ANSI (0–7)", bold, bg, bold=True))
+    lines.extend(styled(line, fg, bg) for line in _swatch_row(theme, range(8), width))
+
+    lines.append("")
+    lines.append(styled(" ANSI bright (8–15)", bold, bg, bold=True))
+    lines.extend(styled(line, fg, bg) for line in _swatch_row(theme, range(8, 16), width))
+
+    lines.append("")
+    lines.append(styled(_hline(width), fg, bg))
+    lines.append(styled(" Surfaces", bold, bg, bold=True))
+    lines.append(
+        styled(
+            f" {'The quick brown fox jumps over the lazy dog. 0123456789'} ",
+            fg,
+            bg,
+        )
+    )
+    lines.append(styled(f" {'Bold body text and emphasis sample'} ", bold, bg, bold=True))
+    lines.append(
+        styled(
+            f" {'Selected text on selection background'} ",
+            selection_text,
+            selection,
+        )
+    )
+    lines.append(
+        styled(
+            f" {'▌ cursor sample'} ",
+            cursor_text,
+            cursor,
+        )
+    )
+
+    lines.append("")
+    lines.append(styled(_hline(width), fg, bg))
+    lines.append(styled(" Semantic samples", bold, bg, bold=True))
+    lines.append(styled(" ERROR: connection refused ", _ansi(theme, 1), bg))
+    lines.append(styled(" WARNING: disk space is running low ", _ansi(theme, 3), bg))
+    lines.append(styled(" INFO: background tasks completed ", _ansi(theme, 4), bg))
+    lines.append(styled(" SUCCESS: all tests passed ", _ansi(theme, 2), bg))
+
+    lines.append("")
+    lines.append(styled(" Directory listing ", _ansi(theme, 4), bg) + styled("drwxr-xr-x  ", _ansi(theme, 4), bg) + styled("src/", _ansi(theme, 12), bg))
+    lines.append(styled("-rw-r--r--  ", _ansi(theme, 2), bg) + styled("README.md", fg, bg))
+    lines.append(styled("-rwxr-xr-x  ", _ansi(theme, 2), bg) + styled("build.sh", _ansi(theme, 10), bg))
+
+    lines.append("")
+    lines.append(styled(" Git status ", _ansi(theme, 6), bg))
+    lines.append(
+        styled("On branch ", _ansi(theme, 6), bg)
+        + styled("main", _ansi(theme, 14), bg)
+    )
+    lines.append(styled("Your branch is up to date with 'origin/main'", _ansi(theme, 2), bg))
+    lines.append(styled("modified:   ", _ansi(theme, 3), bg) + styled("tools/preview_theme.py", fg, bg))
+    lines.append(styled("deleted:    ", _ansi(theme, 1), bg) + styled("old/preview.rb", fg, bg))
+
+    lines.append(styled(border, fg, bg))
+    lines.append(
+        styled(
+            f" Display-only preview (truecolor SGR) — terminal palette unchanged ",
+            _ansi(theme, 8),
+            bg,
+        )
+    )
+
+    return "\n".join(lines) + "\n"

--- a/tools/preview_theme/render.py
+++ b/tools/preview_theme/render.py
@@ -6,7 +6,16 @@ from typing import Iterable, List
 
 from gen import Color, Theme
 
-from preview_theme.colors import DIM, RESET, hex_display, label_color_for_bg, sgr_fg, styled
+from preview_theme.colors import (
+    DIM,
+    RESET,
+    fill_line,
+    fill_line_segments,
+    hex_display,
+    label_color_for_bg,
+    sgr_bg,
+    sgr_fg,
+)
 
 
 def _color(theme: Theme, name: str, fallback: str | None = None) -> Color:
@@ -22,33 +31,42 @@ def _ansi(theme: Theme, index: int) -> Color:
 
 
 def _hline(width: int, char: str = "─") -> str:
-    return char * max(width, 20)
-
-
-def _swatch_cell(index: int, color: Color, cell_width: int = 10) -> str:
-    label = label_color_for_bg(color)
-    inner = f" {index} "
-    pad = max(cell_width - len(inner), 0)
-    left = pad // 2
-    right = pad - left
-    block = " " * left + inner + " " * right
-    return styled(block[:cell_width].ljust(cell_width), label, color)
+    return char * width
 
 
 def _swatch_row(theme: Theme, indices: Iterable[int], width: int) -> List[str]:
+    fg = _color(theme, "Foreground Color")
+    bg = _color(theme, "Background Color")
     colors = [_ansi(theme, i) for i in indices]
     cell_width = 10
     count = len(colors)
-    row_width = count * (cell_width + 1)
+    row_width = count * (cell_width + 1) - 1
     if row_width > width:
-        cell_width = max(6, (width - count) // count)
+        cell_width = max(6, (width - max(count - 1, 0)) // count)
 
-    swatches = " ".join(_swatch_cell(i, c, cell_width) for i, c in zip(indices, colors))
-    hexes = " ".join(
-        f"{DIM}{sgr_fg(_color(theme, 'Foreground Color'))}{hex_display(c):<{cell_width}}{RESET}"
-        for c in colors
-    )
-    return [swatches, hexes]
+    swatch_out = sgr_bg(bg)
+    hex_out = sgr_bg(bg)
+    visible = 0
+
+    for index, (ansi_index, color) in enumerate(zip(indices, colors)):
+        if index:
+            swatch_out += sgr_fg(fg) + " "
+            hex_out += sgr_fg(fg) + " "
+            visible += 1
+
+        label = label_color_for_bg(color)
+        inner = f" {ansi_index} "
+        cell = inner.center(cell_width)[:cell_width]
+        swatch_out += sgr_fg(label) + sgr_bg(color) + cell
+        hex_out += f"{DIM}{sgr_fg(fg)}{hex_display(color):<{cell_width}}"
+        visible += cell_width
+
+    if visible < width:
+        pad = " " * (width - visible)
+        swatch_out += sgr_fg(fg) + pad
+        hex_out += sgr_fg(fg) + pad
+
+    return [swatch_out + RESET, hex_out + RESET]
 
 
 def render_preview(theme: Theme, width: int = 80, *, index: int = 0, total: int = 1) -> str:
@@ -63,7 +81,7 @@ def render_preview(theme: Theme, width: int = 80, *, index: int = 0, total: int 
     lines: List[str] = []
     border = _hline(width, "═")
 
-    lines.append(styled(border, fg, bg))
+    lines.append(fill_line(border, fg, bg, width))
     title = f" {theme.name} "
     if theme.variant:
         title += f"· {theme.variant} "
@@ -71,73 +89,135 @@ def render_preview(theme: Theme, width: int = 80, *, index: int = 0, total: int 
         title += f"· {theme.author} "
     if total > 1:
         title += f"· [{index + 1}/{total}] "
-    lines.append(styled(title[: width - 2], fg, bg, bold=True))
+    lines.append(fill_line(title, fg, bg, width, bold=True))
     if total > 1:
-        lines.append(styled(" ← → navigate   r redraw   q quit ", _ansi(theme, 6), bg))
-    lines.append(styled(border, fg, bg))
+        lines.append(fill_line(" ← → navigate   r redraw   q quit ", _ansi(theme, 6), bg, width))
+    lines.append(fill_line(border, fg, bg, width))
 
-    lines.append(styled(" ANSI (0–7)", bold, bg, bold=True))
-    lines.extend(styled(line, fg, bg) for line in _swatch_row(theme, range(8), width))
+    lines.append(fill_line(" ANSI (0–7)", bold, bg, width, bold=True))
+    lines.extend(_swatch_row(theme, range(8), width))
 
-    lines.append("")
-    lines.append(styled(" ANSI bright (8–15)", bold, bg, bold=True))
-    lines.extend(styled(line, fg, bg) for line in _swatch_row(theme, range(8, 16), width))
+    lines.append(fill_line("", fg, bg, width))
+    lines.append(fill_line(" ANSI bright (8–15)", bold, bg, width, bold=True))
+    lines.extend(_swatch_row(theme, range(8, 16), width))
 
-    lines.append("")
-    lines.append(styled(_hline(width), fg, bg))
-    lines.append(styled(" Surfaces", bold, bg, bold=True))
+    lines.append(fill_line("", fg, bg, width))
+    lines.append(fill_line(_hline(width), fg, bg, width))
+    lines.append(fill_line(" Surfaces", bold, bg, width, bold=True))
     lines.append(
-        styled(
-            f" {'The quick brown fox jumps over the lazy dog. 0123456789'} ",
+        fill_line(
+            " The quick brown fox jumps over the lazy dog. 0123456789 ",
             fg,
             bg,
+            width,
         )
     )
-    lines.append(styled(f" {'Bold body text and emphasis sample'} ", bold, bg, bold=True))
+    lines.append(fill_line(" Bold body text and emphasis sample ", bold, bg, width, bold=True))
     lines.append(
-        styled(
-            f" {'Selected text on selection background'} ",
+        fill_line(
+            " Selected text on selection background ",
             selection_text,
             selection,
+            width,
+        )
+    )
+    lines.append(fill_line(" ▌ cursor sample ", cursor_text, cursor, width))
+
+    lines.append(fill_line("", fg, bg, width))
+    lines.append(fill_line(_hline(width), fg, bg, width))
+    lines.append(fill_line(" Semantic samples", bold, bg, width, bold=True))
+    lines.append(fill_line(" ERROR: connection refused ", _ansi(theme, 1), bg, width))
+    lines.append(fill_line(" WARNING: disk space is running low ", _ansi(theme, 3), bg, width))
+    lines.append(fill_line(" INFO: background tasks completed ", _ansi(theme, 4), bg, width))
+    lines.append(fill_line(" SUCCESS: all tests passed ", _ansi(theme, 2), bg, width))
+
+    lines.append(fill_line("", fg, bg, width))
+    lines.append(
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                (" Directory listing ", _ansi(theme, 4), False),
+                ("drwxr-xr-x  ", _ansi(theme, 4), False),
+                ("src/", _ansi(theme, 12), False),
+            ],
         )
     )
     lines.append(
-        styled(
-            f" {'▌ cursor sample'} ",
-            cursor_text,
-            cursor,
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                ("-rw-r--r--  ", _ansi(theme, 2), False),
+                ("README.md", fg, False),
+            ],
+        )
+    )
+    lines.append(
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                ("-rwxr-xr-x  ", _ansi(theme, 2), False),
+                ("build.sh", _ansi(theme, 10), False),
+            ],
         )
     )
 
-    lines.append("")
-    lines.append(styled(_hline(width), fg, bg))
-    lines.append(styled(" Semantic samples", bold, bg, bold=True))
-    lines.append(styled(" ERROR: connection refused ", _ansi(theme, 1), bg))
-    lines.append(styled(" WARNING: disk space is running low ", _ansi(theme, 3), bg))
-    lines.append(styled(" INFO: background tasks completed ", _ansi(theme, 4), bg))
-    lines.append(styled(" SUCCESS: all tests passed ", _ansi(theme, 2), bg))
-
-    lines.append("")
-    lines.append(styled(" Directory listing ", _ansi(theme, 4), bg) + styled("drwxr-xr-x  ", _ansi(theme, 4), bg) + styled("src/", _ansi(theme, 12), bg))
-    lines.append(styled("-rw-r--r--  ", _ansi(theme, 2), bg) + styled("README.md", fg, bg))
-    lines.append(styled("-rwxr-xr-x  ", _ansi(theme, 2), bg) + styled("build.sh", _ansi(theme, 10), bg))
-
-    lines.append("")
-    lines.append(styled(" Git status ", _ansi(theme, 6), bg))
+    lines.append(fill_line("", fg, bg, width))
+    lines.append(fill_line(" Git status ", _ansi(theme, 6), bg, width))
     lines.append(
-        styled("On branch ", _ansi(theme, 6), bg)
-        + styled("main", _ansi(theme, 14), bg)
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                ("On branch ", _ansi(theme, 6), False),
+                ("main", _ansi(theme, 14), False),
+            ],
+        )
     )
-    lines.append(styled("Your branch is up to date with 'origin/main'", _ansi(theme, 2), bg))
-    lines.append(styled("modified:   ", _ansi(theme, 3), bg) + styled("tools/preview_theme.py", fg, bg))
-    lines.append(styled("deleted:    ", _ansi(theme, 1), bg) + styled("old/preview.rb", fg, bg))
-
-    lines.append(styled(border, fg, bg))
     lines.append(
-        styled(
-            f" Display-only preview (truecolor SGR) — terminal palette unchanged ",
+        fill_line(
+            "Your branch is up to date with 'origin/main'",
+            _ansi(theme, 2),
+            bg,
+            width,
+        )
+    )
+    lines.append(
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                ("modified:   ", _ansi(theme, 3), False),
+                ("tools/preview_theme.py", fg, False),
+            ],
+        )
+    )
+    lines.append(
+        fill_line_segments(
+            width,
+            bg,
+            fg,
+            [
+                ("deleted:    ", _ansi(theme, 1), False),
+                ("old/preview.rb", fg, False),
+            ],
+        )
+    )
+
+    lines.append(fill_line(border, fg, bg, width))
+    lines.append(
+        fill_line(
+            " Display-only preview (truecolor SGR) — terminal palette unchanged ",
             _ansi(theme, 8),
             bg,
+            width,
         )
     )
 

--- a/tools/preview_theme/terminal.py
+++ b/tools/preview_theme/terminal.py
@@ -1,0 +1,56 @@
+"""Terminal utilities for interactive preview."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import termios
+import tty
+from typing import Optional
+
+
+def is_tty() -> bool:
+    return sys.stdout.isatty() and sys.stdin.isatty()
+
+
+def terminal_width(default: int = 80) -> int:
+    try:
+        return shutil.get_terminal_size((default, 24)).columns
+    except OSError:
+        return default
+
+
+def clear_screen() -> None:
+    sys.stdout.write("\033[2J\033[H")
+    sys.stdout.flush()
+
+
+def read_key() -> str:
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+        if ch == "\x03":
+            return "ctrl-c"
+        if ch == "\x1b":
+            ch += sys.stdin.read(2)
+        elif ch == "\x7f":
+            return "backspace"
+        return ch
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+
+def parse_key(key: str) -> Optional[str]:
+    if key in {"q", "Q", "\x1b"}:
+        return "quit"
+    if key == "r":
+        return "redraw"
+    if key in {"\x1b[C", "\x1b[6~"}:
+        return "next"
+    if key in {"\x1b[D", "\x1b[5~"}:
+        return "prev"
+    if key == "ctrl-c":
+        return "quit"
+    return None

--- a/tools/test_preview_theme.py
+++ b/tools/test_preview_theme.py
@@ -20,22 +20,28 @@ def run_preview(*args: str) -> subprocess.CompletedProcess[str]:
 
 class PreviewThemeTests(unittest.TestCase):
     def test_scheme_renders_hex_values(self) -> None:
-        result = run_preview("-s", "Molokai", "--no-clear")
+        result = run_preview("-s", "Molokai")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Molokai", result.stdout)
         self.assertIn("#", result.stdout)
         self.assertIn("Semantic samples", result.stdout)
         self.assertIn("Display-only preview", result.stdout)
+        self.assertNotIn("\033[2J", result.stdout)
+
+    def test_clear_flag_clears_screen(self) -> None:
+        result = run_preview("-s", "Molokai", "--clear")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("\033[2J", result.stdout)
 
     def test_no_osc_palette_sequences(self) -> None:
-        result = run_preview("-s", "Molokai", "--no-clear")
+        result = run_preview("-s", "Molokai")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertNotIn("\033]4;", result.stdout)
         self.assertNotIn("\033]10;", result.stdout)
         self.assertNotIn("\033]11;", result.stdout)
 
     def test_yaml_source(self) -> None:
-        result = run_preview("yaml/Clear Dark.yml", "--no-clear")
+        result = run_preview("yaml/Clear Dark.yml")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Clear Dark", result.stdout)
 
@@ -45,7 +51,7 @@ class PreviewThemeTests(unittest.TestCase):
         self.assertIn("not found", result.stderr)
 
     def test_static_mode_uses_truecolor(self) -> None:
-        result = run_preview("-s", "Molokai", "--no-clear")
+        result = run_preview("-s", "Molokai")
         self.assertIn("38;2;", result.stdout)
         self.assertIn("48;2;", result.stdout)
 

--- a/tools/test_preview_theme.py
+++ b/tools/test_preview_theme.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PREVIEW = REPO_ROOT / "tools" / "preview_theme.py"
+
+
+def run_preview(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(PREVIEW), *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+class PreviewThemeTests(unittest.TestCase):
+    def test_scheme_renders_hex_values(self) -> None:
+        result = run_preview("-s", "Molokai", "--no-clear")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Molokai", result.stdout)
+        self.assertIn("#", result.stdout)
+        self.assertIn("Semantic samples", result.stdout)
+        self.assertIn("Display-only preview", result.stdout)
+
+    def test_no_osc_palette_sequences(self) -> None:
+        result = run_preview("-s", "Molokai", "--no-clear")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertNotIn("\033]4;", result.stdout)
+        self.assertNotIn("\033]10;", result.stdout)
+        self.assertNotIn("\033]11;", result.stdout)
+
+    def test_yaml_source(self) -> None:
+        result = run_preview("yaml/Clear Dark.yml", "--no-clear")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Clear Dark", result.stdout)
+
+    def test_missing_scheme_exits_nonzero(self) -> None:
+        result = run_preview("-s", "No Such Theme 99999")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not found", result.stderr)
+
+    def test_static_mode_uses_truecolor(self) -> None:
+        result = run_preview("-s", "Molokai", "--no-clear")
+        self.assertIn("38;2;", result.stdout)
+        self.assertIn("48;2;", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new `preview_theme.py` tool that renders a full visual preview of color schemes in the terminal using inline truecolor escape codes. The preview does not modify the terminal palette.

## Features

- Load themes by name (`-s`), `.itermcolors`, or `.yaml` path
- Display ANSI palette swatches with hex labels
- Show surface colors (foreground, bold, selection, cursor)
- Semantic samples (errors, directory listing, git status)
- Full-width background padding across the terminal
- Interactive multi-theme navigation (← →, q quit)
- Appends to scrollback by default (`--clear` to redraw full screen)

## Changes

- `tools/preview_theme.py` and `tools/preview_theme/` package
- `tools/test_preview_theme.py`
- README preview section updated (`preview.rb` marked deprecated)
- `AGENTS.md` common commands updated

## Usage

```bash
python tools/preview_theme.py -s "Molokai"
python tools/preview_theme.py -s "Clear Dark" "Clear Light"
python tools/preview_theme.py yaml/Clear Dark.yml
```

## Testing

```bash
python tools/test_preview_theme.py -v
```