### PR TITLE
Add Keys Ocean Sunset and Keys Ocean Sunset HC themes

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,6 +13,8 @@ The Abernathy theme was created by [barish](https://instagram.com/barish)
 
 The Adventure theme was created by [hongzimao](https://github.com/hongzimao/iTerm2-Color-Schemes)
 
+The Keys Ocean Sunset and Keys Ocean Sunset HC themes were created by Grok Build Composer 2.5 Fast as an AI theme generation test — original dark themes inspired by Florida Keys ocean sunsets. Palette colors draw on perceptually sampled Keys sunset photography ([jscarto gist](https://gist.github.com/jscarto/218474b4962a022644c3b05af193a4b3)), Moody Sunset ocean-to-amber gradients, and Florida sunset coral/peach tones.
+
 The Sumi Phosphor and Sumi Linen themes were created by Grok Build Composer 2.5 Fast as a complementary dark/light pair — sumi ink on espresso black with a phosphor-teal signal accent, and sumi typography on unbleached linen.
 
 The themes AdventureTime, AlienBlood, BirdsOfParadise, Ciapre, CrayonPonyFish, DimmedMonokai, Earthsong, Elemental, FishTank, FrontEndDelight, FunForrest, Grape, Highway, IC_Green_PPL, IC_Orange_PPL, Lavandula, Medallion, MonaLisa, Ollie, Royal, SeaShells, Shaman, SleepyHollow, SoftServer, Sundried, ToyChest, Treehouse, and Urple were created by [zdj](https://github.com/zdj/themes/tree/master/iterm2)

--- a/yaml/Keys Ocean Sunset HC.yml
+++ b/yaml/Keys Ocean Sunset HC.yml
@@ -1,0 +1,32 @@
+# High-contrast companion using the same Florida Keys sunset references,
+# tuned toward WCAG enhanced contrast (7:1) on foreground and ANSI colors.
+name: "Keys Ocean Sunset HC"
+author: "Grok Build Composer 2.5 Fast"
+variant: "dark"
+
+# AI theme generation test — HC companion to Keys Ocean Sunset.
+
+color_01: "#7A92A8"
+color_02: "#FF6361"
+color_03: "#4AD68A"
+color_04: "#FFA600"
+color_05: "#6AA8F0"
+color_06: "#DE72B0"
+color_07: "#5EDEE8"
+color_08: "#C8D8EC"
+color_09: "#8AA0B8"
+color_10: "#FF8578"
+color_11: "#72F0A8"
+color_12: "#FFD380"
+color_13: "#88C4FF"
+color_14: "#F0A8D8"
+color_15: "#88F0F8"
+color_16: "#FFF5BE"
+
+background: "#060910"
+foreground: "#F0F4FA"
+cursor: "#FF8531"
+cursor_text: "#060910"
+selection: "#2C4875"
+selection_text: "#FFFFFF"
+bold: "#FFFFFF"

--- a/yaml/Keys Ocean Sunset.yml
+++ b/yaml/Keys Ocean Sunset.yml
@@ -1,0 +1,32 @@
+# Palette grounded in Florida Keys sunset references:
+# jscarto Florida Keys gist (Stu Ostro photo), Moody Sunset (#003f5c–#ffa600),
+# and color-hex "sunset at florida" (#fc9077, #ffcb9a, #fff5be, #fdbfde, #a5b5d5).
+name: "Keys Ocean Sunset"
+author: "Grok Build Composer 2.5 Fast"
+variant: "dark"
+
+# AI theme generation test — Florida Keys ocean sunset dark theme.
+
+color_01: "#101927"
+color_02: "#E85A52"
+color_03: "#4A9A72"
+color_04: "#E89A2E"
+color_05: "#5288B8"
+color_06: "#BC5090"
+color_07: "#5EC8C8"
+color_08: "#A5B5D5"
+color_09: "#344658"
+color_10: "#FC9077"
+color_11: "#62C48E"
+color_12: "#FFCB9A"
+color_13: "#5A8FD4"
+color_14: "#FDBFDE"
+color_15: "#7ED4E0"
+color_16: "#FFF5BE"
+
+background: "#0A1018"
+foreground: "#B8C8DC"
+cursor: "#FC9077"
+cursor_text: "#0A1018"
+selection: "#1A2430"
+selection_text: "#FFF5BE"


### PR DESCRIPTION
## Summary

Adds two original dark themes inspired by Florida Keys ocean sunsets:

- **Keys Ocean Sunset** — deep twilight water, coral sky accents, turquoise shallows
- **Keys Ocean Sunset HC** — high-contrast companion tuned toward WCAG enhanced contrast on ANSI colors

Palette colors draw on perceptually sampled Keys sunset photography ([jscarto gist](https://gist.github.com/jscarto/218474b4962a022644c3b05af193a4b3)), Moody Sunset ocean-to-amber gradients, and Florida sunset coral/peach tones.

## Attribution

Created by **Grok Build Composer 2.5 Fast** as an AI theme generation test.

## Files changed

Source YAML only — no generated format outputs included. CI should regenerate themes and screenshots on merge per repository workflow.

- `yaml/Keys Ocean Sunset.yml`
- `yaml/Keys Ocean Sunset HC.yml`
- `CREDITS.md`